### PR TITLE
Fix type-check errors in pkg/rancher-components tests

### DIFF
--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -6,7 +6,7 @@ describe('component: Banner', () => {
     const label = 'some-label-test';
     const wrapper = mount(
       Banner,
-      { propsData: { label } });
+      { props: { label } });
 
     expect(wrapper.html()).toContain(label);
   });
@@ -24,7 +24,7 @@ describe('component: Banner', () => {
 
   it('should display an icon', () => {
     const icon = 'my-icon';
-    const wrapper = mount(Banner, { propsData: { icon } });
+    const wrapper = mount(Banner, { props: { icon } });
 
     const element = wrapper.find(`.${ icon }`).element;
 
@@ -40,8 +40,8 @@ describe('component: Banner', () => {
   });
 
   it('should emit close event', () => {
-    const wrapper = mount(Banner, { propsData: { closable: true } });
-    const element = wrapper.find(`[data-testid="banner-close"]`).element;
+    const wrapper = mount(Banner, { props: { closable: true } });
+    const element = wrapper.find(`[data-testid="banner-close"]`).element as HTMLElement;
 
     element.click();
 
@@ -50,7 +50,7 @@ describe('component: Banner', () => {
 
   it('should add the right color', () => {
     const color = 'red';
-    const wrapper = mount(Banner, { propsData: { color } });
+    const wrapper = mount(Banner, { props: { color } });
 
     const element = wrapper.element;
 
@@ -59,7 +59,7 @@ describe('component: Banner', () => {
 
   it('should stack the banner messages', () => {
     const stacked = true;
-    const wrapper = mount(Banner, { propsData: { stacked } });
+    const wrapper = mount(Banner, { props: { stacked } });
 
     const element = wrapper.find(`[data-testid="banner-content"]`).element;
 
@@ -74,7 +74,7 @@ describe('component: Banner', () => {
     const wrapper = mount(
       Banner,
       {
-        propsData: {
+        props: {
           label, icon, closable
         }
       });
@@ -101,29 +101,29 @@ describe('component: Banner', () => {
 
   describe('a11y: role prop (live region)', () => {
     it('should have no role attribute by default', () => {
-      const wrapper = mount(Banner, { propsData: { label: 'test' } });
+      const wrapper = mount(Banner, { props: { label: 'test' } });
       const mainContainer = wrapper.find('.banner');
 
       expect(mainContainer.attributes('role')).toBeUndefined();
     });
 
     it('should render role="alert" for persistent live-region containers announcing errors', () => {
-      const wrapper = mount(Banner, { propsData: { label: 'Something went wrong', role: 'alert' } });
+      const wrapper = mount(Banner, { props: { label: 'Something went wrong', role: 'alert' } });
       const mainContainer = wrapper.find('.banner');
 
       expect(mainContainer.attributes('role')).toBe('alert');
     });
 
     it('should render role="status" for persistent live-region containers announcing polite notifications', () => {
-      const wrapper = mount(Banner, { propsData: { label: 'Cluster is provisioning', role: 'status' } });
+      const wrapper = mount(Banner, { props: { label: 'Cluster is provisioning', role: 'status' } });
       const mainContainer = wrapper.find('.banner');
 
       expect(mainContainer.attributes('role')).toBe('status');
     });
 
     it('should accept only "alert" and "status" as valid role values', () => {
-      const alertWrapper = mount(Banner, { propsData: { label: 'test', role: 'alert' } });
-      const statusWrapper = mount(Banner, { propsData: { label: 'test', role: 'status' } });
+      const alertWrapper = mount(Banner, { props: { label: 'test', role: 'alert' } });
+      const statusWrapper = mount(Banner, { props: { label: 'test', role: 'status' } });
 
       expect(alertWrapper.find('.banner').attributes('role')).toBe('alert');
       expect(statusWrapper.find('.banner').attributes('role')).toBe('status');

--- a/pkg/rancher-components/src/components/Card/Card.test.ts
+++ b/pkg/rancher-components/src/components/Card/Card.test.ts
@@ -7,8 +7,8 @@ describe('component: Card', () => {
 
   it('should have a card title', () => {
     const wrapper = mount(Card, {
-      propsData: { title },
-      slots:     { title: '<div>Card title</div>' }
+      props: { title },
+      slots: { title: '<div>Card title</div>' }
     });
 
     const element = wrapper.find('[data-testid="card-title-slot"]');
@@ -18,10 +18,8 @@ describe('component: Card', () => {
   });
 
   it('should have a card body', () => {
-    const wrapper = mount(Card, {
-      propsData: { body },
-      slots:     { body: '<div>Card body</div>' }
-    });
+    const wrapper = mount(Card, { slots: { body: '<div>Card body</div>' } });
+
     const element = wrapper.find('[data-testid="card-body-slot"]');
 
     expect(element.exists()).toBe(true);

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount, Wrapper, mount } from '@vue/test-utils';
+import { shallowMount, VueWrapper, mount } from '@vue/test-utils';
 import { Checkbox } from './index';
 
 describe('checkbox.vue', () => {
@@ -16,7 +16,7 @@ describe('checkbox.vue', () => {
   });
 
   it('renders a true value', () => {
-    const wrapper = shallowMount(Checkbox, { propsData: { value: true } });
+    const wrapper = shallowMount(Checkbox, { props: { value: true } });
     const cbInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
 
     expect(cbInput.checked).toBe(true);
@@ -34,36 +34,42 @@ describe('checkbox.vue', () => {
   });
 
   it('emits an input event with a true value', async() => {
-    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox);
+    const wrapper: VueWrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox);
 
     wrapper.vm.clicked(event);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(true);
+    const emitted = wrapper.emitted('update:value') as [boolean][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(true);
   });
 
   it('emits an input event with a custom valueWhenTrue', async() => {
     const valueWhenTrue = 'BIG IF TRUE';
 
-    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox, { propsData: { value: false, valueWhenTrue } });
+    const wrapper: VueWrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox, { props: { value: false, valueWhenTrue } });
 
     wrapper.vm.clicked(event);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(valueWhenTrue);
+    const emitted = wrapper.emitted('update:value') as [string][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(valueWhenTrue);
   });
 
   it('updates from valueWhenTrue to falsy', async() => {
     const valueWhenTrue = 'REAL HUGE IF FALSE';
 
-    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox, { propsData: { value: valueWhenTrue, valueWhenTrue } });
+    const wrapper: VueWrapper<InstanceType<typeof Checkbox>> = shallowMount(Checkbox, { props: { value: valueWhenTrue, valueWhenTrue } });
 
     wrapper.vm.clicked(event);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')[0][0]).toBeNull();
+    const [[value]] = wrapper.emitted('update:value') as [string | null][];
+
+    expect(value).toBeNull();
   });
 
   it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
@@ -71,10 +77,10 @@ describe('checkbox.vue', () => {
     const description = 'some-description';
     const ariaDescribedById = 'some-external-id';
 
-    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
+    const wrapper: VueWrapper<InstanceType<typeof Checkbox>> = mount(
       Checkbox,
       {
-        propsData: {
+        props: {
           value: false, alternateLabel, description
         },
         attrs: { 'aria-describedby': ariaDescribedById },
@@ -97,10 +103,10 @@ describe('checkbox.vue', () => {
   it('a11y: having a label should not render "aria-label" prop and have "aria-labelledby"', async() => {
     const label = 'some-label';
 
-    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
+    const wrapper: VueWrapper<InstanceType<typeof Checkbox>> = mount(
       Checkbox,
       {
-        propsData: {
+        props: {
           value: true, label, disabled: true
         }
       }

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -19,7 +19,9 @@ describe('component: LabeledInput', () => {
     jest.useRealTimers();
 
     expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')![0][0]).toBe(value);
+    const [[emitted]] = wrapper.emitted('update:value') as [string][];
+
+    expect(emitted).toBe(value);
   });
 
   it('using type "multiline" should emit input value correctly', () => {
@@ -37,7 +39,9 @@ describe('component: LabeledInput', () => {
     jest.useRealTimers();
 
     expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')![0][0]).toBe(value);
+    const [[emitted]] = wrapper.emitted('update:value') as [string][];
+
+    expect(emitted).toBe(value);
   });
 
   describe('using type "chron"', () => {
@@ -270,7 +274,9 @@ describe('component: LabeledInput', () => {
         await clearButton.trigger('click');
 
         expect(wrapper.emitted('update:value')).toHaveLength(1);
-        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+        const [[emitted]] = wrapper.emitted('update:value') as [string][];
+
+        expect(emitted).toBe('');
       });
 
       it('should clear input value when Enter key is pressed on clear button', async() => {
@@ -284,7 +290,9 @@ describe('component: LabeledInput', () => {
         await clearButton.trigger('keydown.enter');
 
         expect(wrapper.emitted('update:value')).toHaveLength(1);
-        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+        const [[emitted]] = wrapper.emitted('update:value') as [string][];
+
+        expect(emitted).toBe('');
       });
 
       it('should clear input value when Space key is pressed on clear button', async() => {
@@ -298,7 +306,9 @@ describe('component: LabeledInput', () => {
         await clearButton.trigger('keydown.space');
 
         expect(wrapper.emitted('update:value')).toHaveLength(1);
-        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+        const [[emitted]] = wrapper.emitted('update:value') as [string][];
+
+        expect(emitted).toBe('');
       });
 
       it('should have proper ARIA label for accessibility', () => {

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -13,7 +13,7 @@ describe('toggleSwitch.vue', () => {
   it('renders a true value', () => {
     const wrapper = shallowMount(
       ToggleSwitch,
-      { propsData: { value: true } });
+      { props: { value: true } });
 
     const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
 
@@ -39,22 +39,26 @@ describe('toggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(true);
+    const emitted = wrapper.emitted('update:value') as [boolean][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(true);
   });
 
   it('emits an input event with a false value', async() => {
     const wrapper: VueWrapper<InstanceType<typeof ToggleSwitch>> = shallowMount(
       ToggleSwitch,
-      { propsData: { value: true } }
+      { props: { value: true } }
     );
 
     wrapper.vm.toggle(false);
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(false);
+    const emitted = wrapper.emitted('update:value') as [boolean][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(false);
   });
 
   it('emits an input event with a custom onValue', async() => {
@@ -62,14 +66,16 @@ describe('toggleSwitch.vue', () => {
 
     const wrapper: VueWrapper<InstanceType<typeof ToggleSwitch>> = shallowMount(
       ToggleSwitch,
-      { propsData: { onValue } });
+      { props: { onValue } });
 
     wrapper.vm.toggle(true);
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(onValue);
+    const emitted = wrapper.emitted('update:value') as [string][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(onValue);
   });
 
   it('emits an input event with a custom offValue', async() => {
@@ -78,7 +84,7 @@ describe('toggleSwitch.vue', () => {
     const wrapper: VueWrapper<InstanceType<typeof ToggleSwitch>> = shallowMount(
       ToggleSwitch,
       {
-        propsData: {
+        props: {
           value: true,
           offValue,
         }
@@ -88,8 +94,10 @@ describe('toggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('update:value')).toHaveLength(1);
-    expect(wrapper.emitted('update:value')[0][0]).toBe(offValue);
+    const emitted = wrapper.emitted('update:value') as [string][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBe(offValue);
   });
 
   it('adds focus class when input is focused', async() => {

--- a/pkg/rancher-components/src/components/Pill/RcStatusBadge/RcStatusBadge.test.ts
+++ b/pkg/rancher-components/src/components/Pill/RcStatusBadge/RcStatusBadge.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import RcStatusBadge from './index';
-import { Status } from '@components/Pill/types';
+import { Status } from '@components/utils/status';
 
 describe('component: RcStatusBadge', () => {
   const statuses: Status[] = ['info', 'success', 'warning', 'error', 'unknown', 'none'];

--- a/pkg/rancher-components/src/components/Pill/RcStatusIndicator/RcStatusIndicator.test.ts
+++ b/pkg/rancher-components/src/components/Pill/RcStatusIndicator/RcStatusIndicator.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import RcStatusIndicator, { Shape } from './index';
-import { Status } from '@components/Pill/types';
+import { Status } from '@components/utils/status';
 
 describe('component: RcStatusIndicator', () => {
   const shapes: Shape[] = ['disc', 'horizontal-bar', 'vertical-bar'];

--- a/pkg/rancher-components/src/components/Pill/RcTag/RcTag.test.ts
+++ b/pkg/rancher-components/src/components/Pill/RcTag/RcTag.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import RcTag from './index';
-import { Type } from './types';
+import { Type } from '@components/Pill/types';
 
 describe('component: RcTag', () => {
   const types: Type[] = ['active', 'inactive'];

--- a/pkg/rancher-components/src/components/RcButtonSplit/RcButtonSplit.test.ts
+++ b/pkg/rancher-components/src/components/RcButtonSplit/RcButtonSplit.test.ts
@@ -1,7 +1,10 @@
 import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 import RcButtonSplit from './RcButtonSplit.vue';
-import { ButtonVariant, ButtonSize } from '@components/RcButton/types';
+import { ButtonSize } from '@components/RcButton/types';
+
+// RcButtonSplit narrows RcButton's variants, and the narrowed type is local to the SFC.
+type RcButtonSplitVariant = NonNullable<InstanceType<typeof RcButtonSplit>['$props']['variant']>;
 
 // v-dropdown is provided by floating-vue and must be mocked in unit tests.
 // The default slot is the trigger anchor; the popper slot is the dropdown content.
@@ -38,8 +41,10 @@ describe('rcButtonSplit.vue', () => {
 
     await wrapper.find('.rc-button-split-action').trigger('click');
 
-    expect(wrapper.emitted('click')).toHaveLength(1);
-    expect(wrapper.emitted('click')![0][0]).toBeInstanceOf(MouseEvent);
+    const emitted = wrapper.emitted('click') as [MouseEvent][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toBeInstanceOf(MouseEvent);
   });
 
   it('does not emit click when the dropdown trigger is clicked', async() => {
@@ -51,21 +56,19 @@ describe('rcButtonSplit.vue', () => {
   });
 
   describe('variant prop', () => {
-    it.each([
+    const variantCases: [RcButtonSplitVariant, string][] = [
       ['primary', 'variant-primary'],
       ['secondary', 'variant-secondary'],
       ['tertiary', 'variant-tertiary'],
-    ] as [ButtonVariant, string][])('applies %s variant class to the action button', (variant, className) => {
+    ];
+
+    it.each(variantCases)('applies %s variant class to the action button', (variant, className) => {
       const wrapper = mount(RcButtonSplit, { ...globalConfig, props: { variant } });
 
       expect(wrapper.find('.rc-button-split-action').classes()).toContain(className);
     });
 
-    it.each([
-      ['primary', 'variant-primary'],
-      ['secondary', 'variant-secondary'],
-      ['tertiary', 'variant-tertiary'],
-    ] as [ButtonVariant, string][])('applies %s variant class to the dropdown trigger button', (variant, className) => {
+    it.each(variantCases)('applies %s variant class to the dropdown trigger button', (variant, className) => {
       const wrapper = mount(RcButtonSplit, { ...globalConfig, props: { variant } });
 
       expect(wrapper.find('.rc-button-split-trigger').classes()).toContain(className);
@@ -73,21 +76,19 @@ describe('rcButtonSplit.vue', () => {
   });
 
   describe('size prop', () => {
-    it.each([
+    const sizeCases: [ButtonSize, string][] = [
       ['small', 'btn-small'],
       ['medium', 'btn-medium'],
       ['large', 'btn-large'],
-    ] as [ButtonSize, string][])('applies %s size class to the action button', (size, className) => {
+    ];
+
+    it.each(sizeCases)('applies %s size class to the action button', (size, className) => {
       const wrapper = mount(RcButtonSplit, { ...globalConfig, props: { size } });
 
       expect(wrapper.find('.rc-button-split-action').classes()).toContain(className);
     });
 
-    it.each([
-      ['small', 'btn-small'],
-      ['medium', 'btn-medium'],
-      ['large', 'btn-large'],
-    ] as [ButtonSize, string][])('applies %s size class to the dropdown trigger button', (size, className) => {
+    it.each(sizeCases)('applies %s size class to the dropdown trigger button', (size, className) => {
       const wrapper = mount(RcButtonSplit, { ...globalConfig, props: { size } });
 
       expect(wrapper.find('.rc-button-split-trigger').classes()).toContain(className);
@@ -150,8 +151,10 @@ describe('rcButtonSplit.vue', () => {
 
     await wrapper.findComponent({ name: 'RcDropdown' }).vm.$emit('update:open', true);
 
-    expect(wrapper.emitted('update:open')).toHaveLength(1);
-    expect(wrapper.emitted('update:open')![0]).toStrictEqual([true]);
+    const emitted = wrapper.emitted('update:open') as [boolean][];
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toStrictEqual([true]);
   });
 
   it('applies default variant "primary" when no variant is provided', () => {
@@ -228,8 +231,10 @@ describe('rcButtonSplit.vue', () => {
 
       await wrapper.findAllComponents({ name: 'RcDropdownItem' })[0].trigger('click');
 
-      expect(wrapper.emitted('select')).toHaveLength(1);
-      expect(wrapper.emitted('select')![0]).toStrictEqual(['draft']);
+      const emitted = wrapper.emitted('select') as [string][];
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toStrictEqual(['draft']);
     });
 
     it('does not emit select when no items prop is provided', async() => {

--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import RcItemCard from './RcItemCard.vue';
 import RcItemCardAction from './RcItemCardAction.vue';
+import { DropdownOption } from '@components/RcDropdown/types';
 
 class ResizeObserverMock {
   observe = jest.fn();
@@ -11,6 +12,12 @@ class ResizeObserverMock {
 global.ResizeObserver = ResizeObserverMock;
 
 const id = 'test';
+
+// RcDropdown's DropdownOption, which RcItemCard forwards to ActionMenu, carries
+// bulk-action bookkeeping that RcItemCard never reads.
+const actionDefaults: DropdownOption = {
+  enabled: true, total: 1, allEnabled: true, anyEnabled: true, available: 1
+};
 
 const baseProps = {
   id,
@@ -90,7 +97,9 @@ describe('rcItemCard', () => {
     const wrapper = mount(RcItemCard, {
       props: {
         ...baseProps,
-        actions: [{ action: 'test', label: 'test' }]
+        actions: [{
+          ...actionDefaults, action: 'test', label: 'test'
+        }]
       }
     });
 
@@ -113,10 +122,10 @@ describe('rcItemCard', () => {
 
     await wrapper.trigger('click');
 
-    const emitted = wrapper.emitted('card-click');
+    const emitted = wrapper.emitted('card-click') as [Record<string, unknown>][];
 
     expect(emitted).toBeTruthy();
-    expect(emitted?.[0]).toStrictEqual([{ someProperty: 'some-value' }]);
+    expect(emitted[0]).toStrictEqual([{ someProperty: 'some-value' }]);
   });
 
   it('does not emit card-click when clicking on rc-item-card-action content', async() => {
@@ -212,8 +221,12 @@ describe('rcItemCard', () => {
       props: {
         ...baseProps,
         actions: [
-          { action: 'myActionA', label: 'Edit' },
-          { action: 'myActionB', label: 'Delete' }
+          {
+            ...actionDefaults, action: 'myActionA', label: 'Edit'
+          },
+          {
+            ...actionDefaults, action: 'myActionB', label: 'Delete'
+          }
         ]
       }
     });
@@ -231,9 +244,9 @@ describe('rcItemCard', () => {
     actionMenu.vm.$emit('action-invoked', payload);
     await wrapper.vm.$nextTick();
 
-    const emitted = wrapper.emitted('action-invoked');
+    const emitted = wrapper.emitted('action-invoked') as [typeof payload][];
 
     expect(emitted).toBeTruthy();
-    expect(emitted?.[0]).toStrictEqual([payload]);
+    expect(emitted[0]).toStrictEqual([payload]);
   });
 });

--- a/pkg/rancher-components/src/components/RcSection/RcSection.test.ts
+++ b/pkg/rancher-components/src/components/RcSection/RcSection.test.ts
@@ -49,12 +49,8 @@ describe('component: RcSection', () => {
         props: {
           ...defaultProps, background: 'primary', expanded: true
         },
-        slots: {
-          default: {
-            components: { RcSection },
-            template:   '<RcSection type="secondary" mode="with-header" :expandable="false" title="Child" />',
-          },
-        },
+        global: { components: { RcSection } },
+        slots:  { default: '<RcSection type="secondary" mode="with-header" :expandable="false" title="Child" />' },
       });
 
       const childSection = wrapper.findAll('.rc-section')[1];
@@ -67,12 +63,8 @@ describe('component: RcSection', () => {
         props: {
           ...defaultProps, background: 'primary', expanded: true
         },
-        slots: {
-          default: {
-            components: { RcSection },
-            template:   '<RcSection type="secondary" mode="with-header" :expandable="false" background="primary" title="Child" />',
-          },
-        },
+        global: { components: { RcSection } },
+        slots:  { default: '<RcSection type="secondary" mode="with-header" :expandable="false" background="primary" title="Child" />' },
       });
 
       const childSection = wrapper.findAll('.rc-section')[1];
@@ -181,8 +173,10 @@ describe('component: RcSection', () => {
 
       await wrapper.find('.section-header').trigger('click');
 
-      expect(wrapper.emitted('update:expanded')).toHaveLength(1);
-      expect(wrapper.emitted('update:expanded')![0]).toStrictEqual([false]);
+      const emitted = wrapper.emitted('update:expanded') as [boolean][];
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toStrictEqual([false]);
     });
 
     it('should emit update:expanded with true when clicking a collapsed header', async() => {
@@ -194,8 +188,10 @@ describe('component: RcSection', () => {
 
       await wrapper.find('.section-header').trigger('click');
 
-      expect(wrapper.emitted('update:expanded')).toHaveLength(1);
-      expect(wrapper.emitted('update:expanded')![0]).toStrictEqual([true]);
+      const emitted = wrapper.emitted('update:expanded') as [boolean][];
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toStrictEqual([true]);
     });
 
     it('should not emit update:expanded when clicking a non-expandable header', async() => {
@@ -215,8 +211,10 @@ describe('component: RcSection', () => {
 
       await wrapper.find('.toggle-button').trigger('click');
 
-      expect(wrapper.emitted('update:expanded')).toHaveLength(1);
-      expect(wrapper.emitted('update:expanded')![0]).toStrictEqual([false]);
+      const emitted = wrapper.emitted('update:expanded') as [boolean][];
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toStrictEqual([false]);
     });
   });
 

--- a/pkg/rancher-components/src/components/RcSection/RcSectionBadges.test.ts
+++ b/pkg/rancher-components/src/components/RcSection/RcSectionBadges.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import RcSectionBadges from './RcSectionBadges.vue';
+import { BadgeConfig } from './types';
 
 // Stub RcStatusBadge to avoid pulling in its full dependency tree
 const RcStatusBadgeStub = {
@@ -9,7 +10,7 @@ const RcStatusBadgeStub = {
 };
 
 describe('component: RcSectionBadges', () => {
-  function createWrapper(badges: { label: string; status: string; tooltip?: string }[]) {
+  function createWrapper(badges: BadgeConfig[]) {
     return mount(RcSectionBadges, {
       props:  { badges },
       global: {
@@ -20,7 +21,7 @@ describe('component: RcSectionBadges', () => {
   }
 
   it('should render all badges when count is within the limit', () => {
-    const badges = [
+    const badges: BadgeConfig[] = [
       { label: 'Active', status: 'success' },
       { label: 'Pending', status: 'warning' },
     ];
@@ -33,7 +34,7 @@ describe('component: RcSectionBadges', () => {
   });
 
   it('should render exactly 3 badges when 3 are provided', () => {
-    const badges = [
+    const badges: BadgeConfig[] = [
       { label: 'A', status: 'success' },
       { label: 'B', status: 'warning' },
       { label: 'C', status: 'error' },
@@ -44,7 +45,7 @@ describe('component: RcSectionBadges', () => {
   });
 
   it('should render a maximum of 3 badges when more than 3 are provided', () => {
-    const badges = [
+    const badges: BadgeConfig[] = [
       { label: 'A', status: 'success' },
       { label: 'B', status: 'warning' },
       { label: 'C', status: 'error' },
@@ -60,7 +61,7 @@ describe('component: RcSectionBadges', () => {
   });
 
   it('should pass the correct status prop to each badge', () => {
-    const badges = [
+    const badges: BadgeConfig[] = [
       { label: 'A', status: 'success' },
       { label: 'B', status: 'error' },
     ];
@@ -86,7 +87,7 @@ describe('component: RcSectionBadges', () => {
 
   describe('tooltip', () => {
     it('should pass tooltip value to v-clean-tooltip directive', () => {
-      const badges = [
+      const badges: BadgeConfig[] = [
         {
           label: 'Active', status: 'success', tooltip: 'All systems operational'
         },
@@ -100,7 +101,7 @@ describe('component: RcSectionBadges', () => {
     });
 
     it('should render badges without tooltip when tooltip is omitted', () => {
-      const badges = [
+      const badges: BadgeConfig[] = [
         { label: 'Pending', status: 'warning' },
       ];
       const wrapper = createWrapper(badges);
@@ -113,7 +114,7 @@ describe('component: RcSectionBadges', () => {
   describe('console warning', () => {
     it('should warn when more than 3 badges are provided', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      const badges = [
+      const badges: BadgeConfig[] = [
         { label: 'A', status: 'success' },
         { label: 'B', status: 'warning' },
         { label: 'C', status: 'error' },
@@ -131,7 +132,7 @@ describe('component: RcSectionBadges', () => {
 
     it('should not warn when 3 or fewer badges are provided', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      const badges = [
+      const badges: BadgeConfig[] = [
         { label: 'A', status: 'success' },
         { label: 'B', status: 'warning' },
         { label: 'C', status: 'error' },

--- a/pkg/rancher-components/src/components/StringList/StringList.test.ts
+++ b/pkg/rancher-components/src/components/StringList/StringList.test.ts
@@ -2,11 +2,14 @@
 import { mount, VueWrapper } from '@vue/test-utils';
 import { StringList } from './index';
 
+// StringList declares its error map inline, so derive the `errors` payload from the component.
+type Errors = InstanceType<typeof StringList>['errors'];
+
 describe('stringList.vue', () => {
   let wrapper: VueWrapper<InstanceType<typeof StringList>>;
 
   beforeEach(() => {
-    wrapper = mount(StringList, { propsData: { items: [] } });
+    wrapper = mount(StringList, { props: { items: [] } });
   });
 
   describe('list box', () => {
@@ -125,9 +128,9 @@ describe('stringList.vue', () => {
       await inputField.setValue('F');
       await wrapper.vm.$nextTick();
 
-      const emitted = (wrapper.emitted('type:item') || [])[0][0][0];
+      const [[typed]] = wrapper.emitted('type:item') as [string][];
 
-      expect(emitted).toBe('F');
+      expect(typed).toBe('F');
     });
   });
 
@@ -241,9 +244,9 @@ describe('stringList.vue', () => {
 
         await wrapper.vm.$nextTick();
 
-        const itemsCount = (wrapper.emitted('change') || [])[0][0].length;
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
-        expect(itemsCount).toBe(0);
+        expect(itemsResult).toHaveLength(0);
       });
 
       it('deactivates create mode', async() => {
@@ -297,9 +300,9 @@ describe('stringList.vue', () => {
       await inputField.trigger('keydown.enter');
       await wrapper.vm.$nextTick();
 
-      const emitted = (wrapper.emitted('change') || [])[0][0][0];
+      const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
-      expect(emitted).toBe(validItem.trim());
+      expect(itemsResult[0]).toBe(validItem.trim());
     });
 
     it('save item in edit mode by pressing Enter key', async() => {
@@ -318,9 +321,9 @@ describe('stringList.vue', () => {
       await inputField.trigger('keydown.enter');
       await wrapper.vm.$nextTick();
 
-      const emitted = (wrapper.emitted('change') || [])[0][0][0];
+      const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
-      expect(emitted).toBe(validItem.trim());
+      expect(itemsResult[0]).toBe(validItem.trim());
     });
 
     it('reject a new item in create mode when item name is empty', async() => {
@@ -406,7 +409,7 @@ describe('stringList.vue', () => {
 
       beforeEach(() => {
         wrapper = mount(StringList, {
-          propsData: {
+          props: {
             items,
             bulkAdditionDelimiter: delimiter,
             errorMessages:         { duplicate: 'error, item is duplicate.' },
@@ -428,7 +431,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -448,9 +451,9 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+        const [[errors]] = wrapper.emitted('errors') as [Errors][];
 
-        expect(isDuplicate).toBe(true);
+        expect(errors.duplicate).toBe(true);
       });
 
       it('should show a warning if the new values are all duplicates', async() => {
@@ -466,9 +469,9 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+        const [[errors]] = wrapper.emitted('errors') as [Errors][];
 
-        expect(isDuplicate).toBe(true);
+        expect(errors.duplicate).toBe(true);
       });
 
       it('should not consider empty strings at the beginning', async() => {
@@ -485,7 +488,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -504,7 +507,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -523,7 +526,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -534,7 +537,7 @@ describe('stringList.vue', () => {
 
       beforeEach(() => {
         wrapper = mount(StringList, {
-          propsData: {
+          props: {
             items,
             bulkAdditionDelimiter: delimiter,
             errorMessages:         { duplicate: 'error, item is duplicate.' },
@@ -555,7 +558,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -572,9 +575,9 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+        const [[errors]] = wrapper.emitted('errors') as [Errors][];
 
-        expect(isDuplicate).toBe(true);
+        expect(errors.duplicate).toBe(true);
       });
 
       it('should show a warning if the new values are all duplicates', async() => {
@@ -589,9 +592,9 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+        const [[errors]] = wrapper.emitted('errors') as [Errors][];
 
-        expect(isDuplicate).toBe(true);
+        expect(errors.duplicate).toBe(true);
       });
 
       it('should not consider empty strings at the beginning', async() => {
@@ -607,7 +610,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -625,7 +628,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -643,7 +646,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -661,7 +664,7 @@ describe('stringList.vue', () => {
         await inputField.trigger('keydown.enter');
         await wrapper.vm.$nextTick();
 
-        const itemsResult = (wrapper.emitted('change') || [])[0][0];
+        const [[itemsResult]] = wrapper.emitted('change') as [string[]][];
 
         expect(JSON.stringify(itemsResult)).toBe(JSON.stringify(result));
       });
@@ -724,9 +727,9 @@ describe('stringList.vue', () => {
 
       await inputField.setValue('test');
 
-      const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+      const [[errors]] = wrapper.emitted('errors') as [Errors][];
 
-      expect(isDuplicate).toBe(true);
+      expect(errors.duplicate).toBe(true);
     });
 
     it('emit duplicate errors, reset error', async() => {
@@ -746,9 +749,12 @@ describe('stringList.vue', () => {
       // it is not duplicate, reset duplicate error -> emit false
       await inputField.setValue('test-1');
 
-      const isDuplicate = (wrapper.emitted('errors') || [])[0][0].duplicate;
+      const emitted = wrapper.emitted('errors') as [Errors][];
 
-      expect(isDuplicate).toBe(false);
+      // This asserts the state after the reset, so read the last emission. The deep
+      // watcher emits the component's own errors object, so every entry is the same
+      // reference and index 0 would not describe the first emission anyway.
+      expect(emitted[emitted.length - 1][0].duplicate).toBe(false);
     });
   });
 });

--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 1770
+# Total errors: 1736
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ addTaint(): void; updateTaint(keyedTaint: any, idx: any): void; removeTaint(idx: number): void; availabilityZonesSupport(): any; poolCountValidator(): (val: number) => any; }'.
@@ -603,38 +603,10 @@ pkg/imported/components/__tests__/CruImported.test.ts: error TS2339: Property 'a
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2339: Property 'annotations' does not exist on type 'never'.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2349: This expression is not callable.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2349: This expression is not callable.
-pkg/rancher-components/src/components/Banner/Banner.test.ts: error TS2339: Property 'click' does not exist on type 'VueNode<Element>'.
-pkg/rancher-components/src/components/Card/Card.test.ts: error TS2353: Object literal may only specify known properties, and 'body' does not exist in type 'NonNullable<Partial<{ title: string; content: string; sticky: boolean; buttonAction: (event: MouseEvent) => void; buttonText: string; showHighlightBorder: boolean; showActions: boolean; }> & Omit<...>>'.
-pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue: error TS2322: Type 'string | number | Record<string, any>' is not assignable to type 'string'.
-pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
-pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
-pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
-pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
-pkg/rancher-components/src/components/Pill/RcStatusBadge/RcStatusBadge.test.ts: error TS2305: Module '"@components/Pill/types"' has no exported member 'Status'.
-pkg/rancher-components/src/components/Pill/RcStatusIndicator/RcStatusIndicator.test.ts: error TS2305: Module '"@components/Pill/types"' has no exported member 'Status'.
-pkg/rancher-components/src/components/Pill/RcTag/RcTag.test.ts: error TS2459: Module '"./types"' declares 'Type' locally, but it is not exported.
-pkg/rancher-components/src/components/RcButtonSplit/RcButtonSplit.test.ts: error TS2322: Type 'ButtonVariant' is not assignable to type 'RcButtonSplitVariant | undefined'.
-pkg/rancher-components/src/components/RcButtonSplit/RcButtonSplit.test.ts: error TS2322: Type 'ButtonVariant' is not assignable to type 'RcButtonSplitVariant | undefined'.
 pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
 pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue: error TS2307: Cannot find module '@shell/components/IconOrSvg' or its corresponding type declarations.
-pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts: error TS2739: Type '{ action: string; label: string; }' is missing the following properties from type 'DropdownOption': enabled, total, allEnabled, anyEnabled, available
-pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts: error TS2739: Type '{ action: string; label: string; }' is missing the following properties from type 'DropdownOption': enabled, total, allEnabled, anyEnabled, available
-pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts: error TS2739: Type '{ action: string; label: string; }' is missing the following properties from type 'DropdownOption': enabled, total, allEnabled, anyEnabled, available
 pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue: error TS2307: Cannot find module './RcItemCardAction' or its corresponding type declarations.
-pkg/rancher-components/src/components/RcSection/RcSection.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((props: {}) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((props: {}) => any))[]'.
-pkg/rancher-components/src/components/RcSection/RcSection.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((props: {}) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((props: {}) => any))[]'.
-pkg/rancher-components/src/components/RcSection/RcSectionBadges.test.ts: error TS2322: Type '{ label: string; status: string; tooltip?: string | undefined; }[]' is not assignable to type 'BadgeConfig[]'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
 pkg/rancher-prime/config/navigation.ts: error TS2353: Object literal may only specify known properties, and 'ifFeature' does not exist in type 'ConfigureVirtualTypeOptions'.
 pkg/rancher-prime/pages/Registration.test.ts: error TS2445: Property 'isDisabled' is protected and only accessible within class 'BaseWrapper<ElementType>' and its subclasses.
 pkg/rancher-prime/pages/Registration.test.ts: error TS2445: Property 'isDisabled' is protected and only accessible within class 'BaseWrapper<ElementType>' and its subclasses.
@@ -727,7 +699,6 @@ shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ stat
 shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{}' is not assignable to parameter of type 'never'.
 shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{}' is not assignable to parameter of type 'never'.
 shell/apis/shell/__tests__/slide-in.test.ts: error TS2554: Expected 1 arguments, but got 0.
-shell/apis/shell/__tests__/slide-in.test.ts: error TS2694: Namespace 'jest' has no exported member 'SpyInstance'.
 shell/apis/shell/__tests__/system.test.ts: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/apis/shell/__tests__/system.test.ts: error TS2724: '"@shell/config/version"' has no exported member named 'getKubeVersionData'. Did you mean 'getVersionData'?
 shell/apis/shell/index.ts: error TS2459: Module '"@shell/apis/intf/shell"' declares 'ProxyApi' locally, but it is not exported.
@@ -978,9 +949,6 @@ shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is no
 shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileImageSelector' or its corresponding type declarations.
 shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 shell/components/form/__tests__/FileSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
-shell/components/form/__tests__/NameNsDescription.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/NameNsDescription.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/NameNsDescription.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
@@ -1190,8 +1158,6 @@ shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts: error 
 shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts: error TS2339: Property 'EDITOR_MODES' does not exist on type '{ name: string; template: string; props: string[]; methods: { updateValue: Mock<any, any, any>; }; }'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Networking.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS18047: 'wrapper.vm.machinePools' is possibly 'null'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2322: Type '() => { credentialId: string; credential: { decodedData: { clusterId: string; }; }; machinePools: never[]; }' is not assignable to type '() => Partial<{ loadedOnce: boolean; lastIdx: number; allPSAs: never[]; credentialId: string; credential: null; initialMachinePoolsValues: {}; machinePools: null; rke2Versions: null; k3sVersions: null; ... 47 more ...; infrastructureCluster: null; }>'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2322: Type '() => { credentialId: string; userChartValues: { 'rke2-calico': {}; 'rke2-ingress-nginx': { controller: { extraArgs: { 'enable-ssl-passthrough': boolean; 'watch-ingress-without-class': boolean; }; }; }; 'rke2-ingress-nginx-invalid': { ...; }; } | { ...; }; rke2Versions: { ...; }[]; }' is not assignable to type '() => Partial<{ loadedOnce: boolean; lastIdx: number; allPSAs: never[]; credentialId: string; credential: null; initialMachinePoolsValues: {}; machinePools: null; rke2Versions: null; k3sVersions: null; ... 47 more ...; infrastructureCluster: null; }>'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2339: Property 'dataDirectories' does not exist on type '{ etcd: { disableSnapshots: boolean; }; }'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.


### PR DESCRIPTION
### Summary
Fixes #18592

### Occurred changes and/or fixed issues

Reducing the amount of type errors we have.

### Technical notes summary


**Switched `propsData:` to `props:` but we may want to revert.**

The issue requires it, but offers no evidence for it: its own error table attributes nothing to `propsData`. It is a net loss of static checking. VTU types `propsData` exactly, but types `props` as `RawProps & Props`, and `RawProps` carries an index signature, so unknown and misspelled prop names stop being caught:

```ts
mount(Comp, { props:     { labelll: 'x' } }); // compiles
mount(Comp, { propsData: { labelll: 'x' } }); // TS2561, did you mean 'label'?
```

**That is the check that produced this package's own `Card.test.ts` baseline error** (`'body' does not exist`). Renaming that line would have silenced the error while leaving the prop in place.**

The rest:

- The issue prescribes `as [[string]]`; this uses `as [string][]`. A 1-tuple also asserts the event fired exactly once, which is false where StringList's `errors` fires twice.
- One rule, two shapes: bind the emissions array when the test asserts how many times the event fired, destructure the payload when it does not.
- 13 of the 39 reads produced no baseline error, since `expect()` takes `any`. Narrowed anyway: the issue's carve-out is for presence-only assertions.
- `RcButtonSplitVariant` and StringList's `errors` payload are derived from the component, neither being exported from its SFC.

### Areas or cases that should be tested

- No runtime changes. Just run the tests.

### Areas which could experience regressions

- Just the tests.

### Screenshot/Video

Not applicable: test files only.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
