### PR TITLE
[backport v2.15.1] Automation: Scope Default project lookup by clusterName in project-secrets spec

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -1,38 +1,49 @@
 import { ProjectSecretsListPagePo, ProjectSecretsCreateEditPo } from '@/cypress/e2e/po/pages/explorer/project-secrets.po';
-import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
+import { qase } from '@/cypress/support/qase';
 
-const projectSecretsListPage = new ProjectSecretsListPagePo('local');
-const namespaceFilter = new NamespaceFilterPo();
+const clusterId = 'local';
+const projectSecretsListPage = new ProjectSecretsListPagePo(clusterId);
 const targetProject = {
   name: 'default', label: 'Default', namespace: ''
 };
-const projectScopedSecretName = 'e2e-project-scoped-secret-name';
+let projectScopedSecretName = '';
+let removeProjectScopedSecret = false;
 const username = 'test';
 const password = 'test-password';
 
-describe('Project Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
 
+    cy.createE2EResourceName('project-scoped-secret').then((name) => {
+      projectScopedSecretName = name;
+    });
+
     cy.getRancherResource('v1', 'management.cattle.io.projects').then((resp: Cypress.Response<any>) => {
-      targetProject.namespace = resp.body.data.find((item: any) => item.spec.displayName === 'Default').status.backingNamespace;
+      // Scope by clusterName in addition to displayName: multiple clusters can each have their
+      // own "Default" project, and an unscoped find() can resolve to the wrong cluster's project
+      // (mismatching the namespace the UI actually uses for the "local" cluster's secret).
+      const project = resp.body.data.find((item: any) => item.spec.displayName === targetProject.label && item.spec.clusterName === clusterId);
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(project, `project "${ targetProject.label }" in cluster "${ clusterId }"`).to.exist;
+      targetProject.namespace = project.status.backingNamespace;
     });
 
     cy.intercept('POST', '/v1/secrets?exclude=metadata.managedFields').as('createProjectScopedSecret');
   });
 
-  it('has the correct title', () => {
+  qase(24277, it('has the correct title', () => {
     projectSecretsListPage.goTo();
     projectSecretsListPage.title().should('include', 'Project Secrets');
 
     cy.title().should('eq', 'Rancher - local - Project Secrets');
-  });
+  }));
 
-  it('creates a project-scoped secret and displays it in the list', () => {
-    namespaceFilter.toggle();
-    namespaceFilter.clickOptionByLabel('All Namespaces');
-    namespaceFilter.closeDropdown();
-    const secretCreatePage = new ProjectSecretsCreateEditPo('local');
+  qase(27179, it('creates a project-scoped secret and displays it in the list', () => {
+    cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
+
+    const secretCreatePage = new ProjectSecretsCreateEditPo(clusterId);
 
     projectSecretsListPage.goTo();
 
@@ -52,12 +63,20 @@ describe('Project Secrets', { testIsolation: 'off', tags: ['@explorer2', '@admin
     cy.wait('@createProjectScopedSecret', { requestTimeout: 10000 }).then((req) => {
       const payload = req.request?.body;
 
+      expect(req.response?.statusCode).to.eq(201);
+      removeProjectScopedSecret = true;
       expect(payload.metadata.namespace).to.eq(targetProject.namespace);
       expect(payload.metadata.labels['management.cattle.io/project-scoped-secret']).to.eq(targetProject.namespace);
       expect(payload.metadata.name).to.eq(projectScopedSecretName);
     });
+  }));
 
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, true);
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, true);
+  afterEach(() => {
+    if (removeProjectScopedSecret) {
+      cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, false);
+      cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, false);
+    }
+
+    cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2457

Backport of https://github.com/rancher/dashboard/pull/18640
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="921" height="250" alt="image" src="https://github.com/user-attachments/assets/e59d8c7f-cec1-44ed-89af-60d42a8bc407" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
