### PR TITLE
Reset stale customized answers in the Questions.yaml

### DIFF
--- a/shell/components/Questions/__tests__/index.test.ts
+++ b/shell/components/Questions/__tests__/index.test.ts
@@ -176,8 +176,8 @@ describe('component: Questions', () => {
 
       // Initially, child is shown
       expect(wrapper.vm.shownQuestions).toHaveLength(2);
-      expect(wrapper.vm.shownQuestions[0].variable).toBe('parent');
-      expect(wrapper.vm.shownQuestions[1].variable).toBe('child');
+      expect(wrapper.vm.shownQuestions?.[0].variable).toBe('parent');
+      expect(wrapper.vm.shownQuestions?.[1].variable).toBe('child');
       expect(value.child).toBe('some-value');
 
       // Now set parent to false to hide child question
@@ -191,7 +191,7 @@ describe('component: Questions', () => {
 
       // The child's value should have been deleted/removed from value
       expect(wrapper.vm.shownQuestions).toHaveLength(1);
-      expect(wrapper.vm.shownQuestions[0].variable).toBe('parent');
+      expect(wrapper.vm.shownQuestions?.[0].variable).toBe('parent');
       expect(wrapper.vm.value.child).toBeUndefined();
     });
 
@@ -212,7 +212,7 @@ describe('component: Questions', () => {
       });
 
       expect(wrapper.vm.shownQuestions).toHaveLength(2);
-      expect(wrapper.vm.shownQuestions[1].variable).toBe('nested.child');
+      expect(wrapper.vm.shownQuestions?.[1].variable).toBe('nested.child');
       expect(wrapper.vm.value.nested.child).toBe('some-nested-value');
 
       wrapper.setProps({

--- a/shell/components/Questions/__tests__/index.test.ts
+++ b/shell/components/Questions/__tests__/index.test.ts
@@ -156,4 +156,169 @@ describe('component: Questions', () => {
       });
     });
   });
+
+  describe('watch: shownQuestions', () => {
+    it('should remove values of questions that transition from shown to hidden', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'child', show_if: 'parent=true' }
+      ];
+      const value = {
+        parent: true,
+        child:  'some-value'
+      };
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source: { questions: { questions } }, value
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      // Initially, child is shown
+      expect(wrapper.vm.shownQuestions).toHaveLength(2);
+      expect(wrapper.vm.shownQuestions[0].variable).toBe('parent');
+      expect(wrapper.vm.shownQuestions[1].variable).toBe('child');
+      expect(value.child).toBe('some-value');
+
+      // Now set parent to false to hide child question
+      wrapper.setProps({
+        value: {
+          parent: false,
+          child:  'some-value'
+        }
+      });
+      await wrapper.vm.$nextTick();
+
+      // The child's value should have been deleted/removed from value
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.shownQuestions[0].variable).toBe('parent');
+      expect(wrapper.vm.value.child).toBeUndefined();
+    });
+
+    it('should remove nested values of questions that transition from shown to hidden', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'nested.child', show_if: 'parent=true' }
+      ];
+      const value = {
+        parent: true,
+        nested: { child: 'some-nested-value' }
+      };
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source: { questions: { questions } }, value
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(2);
+      expect(wrapper.vm.shownQuestions[1].variable).toBe('nested.child');
+      expect(wrapper.vm.value.nested.child).toBe('some-nested-value');
+
+      wrapper.setProps({
+        value: {
+          parent: false,
+          nested: { child: 'some-nested-value' }
+        }
+      });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.value.nested.child).toBeUndefined();
+    });
+
+    it('should restore default values of questions that transition from shown to hidden if default exists in source.values', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'ingress.path', show_if: 'parent=true' }
+      ];
+      const source = {
+        values: {
+          parent:  true,
+          ingress: { path: '/' }
+        },
+        questions: { questions }
+      };
+      const value = {
+        parent:  true,
+        ingress: { path: '/api' }
+      };
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source, value
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(2);
+      expect(wrapper.vm.value.ingress.path).toBe('/api');
+
+      wrapper.setProps({
+        value: {
+          parent:  false,
+          ingress: { path: '/api' }
+        }
+      });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.value.ingress.path).toBe('/');
+    });
+
+    it('should restore falsy default values of questions that transition from shown to hidden if default exists in source.values', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'ingress.enabled', show_if: 'parent=true' },
+        { variable: 'ingress.limit', show_if: 'parent=true' },
+        { variable: 'ingress.path', show_if: 'parent=true' }
+      ];
+      const source = {
+        values: {
+          parent:  true,
+          ingress: {
+            enabled: false,
+            limit:   0,
+            path:    ''
+          }
+        },
+        questions: { questions }
+      };
+      const value = {
+        parent:  true,
+        ingress: {
+          enabled: true,
+          limit:   10,
+          path:    '/api'
+        }
+      };
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source, value
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(4);
+      expect(wrapper.vm.value.ingress.enabled).toBe(true);
+      expect(wrapper.vm.value.ingress.limit).toBe(10);
+      expect(wrapper.vm.value.ingress.path).toBe('/api');
+
+      wrapper.setProps({
+        value: {
+          parent:  false,
+          ingress: {
+            enabled: true,
+            limit:   10,
+            path:    '/api'
+          }
+        }
+      });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.value.ingress.enabled).toBe(false);
+      expect(wrapper.vm.value.ingress.limit).toBe(0);
+      expect(wrapper.vm.value.ingress.path).toBe('');
+    });
+  });
 });

--- a/shell/components/Questions/__tests__/index.test.ts
+++ b/shell/components/Questions/__tests__/index.test.ts
@@ -320,5 +320,70 @@ describe('component: Questions', () => {
       expect(wrapper.vm.value.ingress.limit).toBe(0);
       expect(wrapper.vm.value.ingress.path).toBe('');
     });
+
+    it('should restore the user-entered value of a question that is hidden and then shown again (no default in source.values)', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'nested.child', show_if: 'parent=true' }
+      ];
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source: { questions: { questions } }, value: { parent: true, nested: { child: 'my-custom-value' } }
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      expect(wrapper.vm.value.nested.child).toBe('my-custom-value');
+
+      // Hide the question
+      wrapper.setProps({ value: { parent: false, nested: { child: 'my-custom-value' } } });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.value.nested).toBeUndefined();
+
+      // Show the question again
+      wrapper.setProps({ value: { parent: true } });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(2);
+      expect(wrapper.vm.value.nested.child).toBe('my-custom-value');
+    });
+
+    it('should restore the user-entered value of a question that is hidden and then shown again (default exists in source.values)', async() => {
+      const questions = [
+        { variable: 'parent', type: 'boolean' },
+        { variable: 'ingress.path', show_if: 'parent=true' }
+      ];
+      const source = {
+        values: {
+          parent:  true,
+          ingress: { path: '/' }
+        },
+        questions: { questions }
+      };
+      const wrapper = shallowMount(Questions, {
+        props: {
+          ...defaultProps, source, value: { parent: true, ingress: { path: '/api' } }
+        },
+        global: { mocks: defaultMocks },
+      });
+
+      expect(wrapper.vm.value.ingress.path).toBe('/api');
+
+      // Hide the question, its value is reset to the chart default
+      wrapper.setProps({ value: { parent: false, ingress: { path: '/api' } } });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(1);
+      expect(wrapper.vm.value.ingress.path).toBe('/');
+
+      // Show the question again, the user's custom answer should come back, not the default
+      wrapper.setProps({ value: { parent: true, ingress: { path: '/' } } });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.shownQuestions).toHaveLength(2);
+      expect(wrapper.vm.value.ingress.path).toBe('/api');
+    });
   });
 });

--- a/shell/components/Questions/__tests__/index.test.ts
+++ b/shell/components/Questions/__tests__/index.test.ts
@@ -224,7 +224,7 @@ describe('component: Questions', () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.shownQuestions).toHaveLength(1);
-      expect(wrapper.vm.value.nested.child).toBeUndefined();
+      expect(wrapper.vm.value.nested).toBeUndefined();
     });
 
     it('should restore default values of questions that transition from shown to hidden if default exists in source.values', async() => {

--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -1,7 +1,7 @@
 <script>
 import Jexl from 'jexl';
 import Tab from '@shell/components/Tabbed/Tab';
-import { get, set } from '@shell/utils/object';
+import { get, set, remove } from '@shell/utils/object';
 import { sortBy, camelCase } from 'lodash';
 import { _EDIT } from '@shell/config/query-params';
 import StringType from './String';
@@ -286,6 +286,31 @@ export default {
       handler() {
         this.valueGeneration++;
       },
+    },
+
+    shownQuestions(neu, old) {
+      if (old?.length) {
+        const neuVars = (neu || []).map((q) => q.variable).filter(Boolean);
+        const oldVars = (old || []).map((q) => q.variable).filter(Boolean);
+
+        for (const variable of oldVars) {
+          // If a question was previously visible but is now hidden (e.g. toggled off)
+          if (!neuVars.includes(variable)) {
+            const defaultValue = this.source?.values ? get(this.source.values, variable) : undefined;
+
+            if (defaultValue !== undefined) {
+              // If the variable existed in the default values.yaml of the chart,
+              // restore it to its original default value rather than deleting it.
+              // This prevents the diff utility from treating it as a deletion (null).
+              set(this.value, variable, defaultValue);
+            } else {
+              // If the variable did not exist in the default values.yaml (dynamic subquestion),
+              // remove it completely so it won't show up in the custom values diff.
+              remove(this.value, variable);
+            }
+          }
+        }
+      }
     }
   },
 

--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -180,7 +180,7 @@ export default {
   },
 
   data() {
-    return { valueGeneration: 0 };
+    return { valueGeneration: 0, hiddenValuesCache: {} };
   },
 
   computed: {
@@ -289,26 +289,45 @@ export default {
     },
 
     shownQuestions(neu, old) {
-      if (old?.length) {
-        const neuVars = (neu || []).map((q) => q.variable).filter(Boolean);
-        const oldVars = (old || []).map((q) => q.variable).filter(Boolean);
+      if (!old?.length) {
+        return;
+      }
 
-        for (const variable of oldVars) {
-          // If a question was previously visible but is now hidden (e.g. toggled off)
-          if (!neuVars.includes(variable)) {
-            const defaultValue = this.source?.values ? get(this.source.values, variable) : undefined;
+      const neuVars = (neu || []).map((q) => q.variable).filter(Boolean);
+      const oldVars = (old || []).map((q) => q.variable).filter(Boolean);
 
-            if (defaultValue !== undefined) {
-              // If the variable existed in the default values.yaml of the chart,
-              // restore it to its original default value rather than deleting it.
-              // This prevents the diff utility from treating it as a deletion (null).
-              set(this.value, variable, defaultValue);
-            } else {
-              // If the variable did not exist in the default values.yaml (dynamic subquestion),
-              // remove it completely so it won't show up in the custom values diff.
-              remove(this.value, variable, true);
-            }
+      for (const variable of oldVars) {
+        // If a question was previously visible but is now hidden (e.g. toggled off)
+        if (!neuVars.includes(variable)) {
+          const currentValue = get(this.value, variable);
+
+          if (currentValue !== undefined) {
+            // Remember the user's answer so it can be restored if the question is shown again,
+            // instead of it being silently lost.
+            this.hiddenValuesCache[variable] = currentValue;
           }
+
+          const defaultValue = this.source?.values ? get(this.source.values, variable) : undefined;
+
+          if (defaultValue !== undefined) {
+            // If the variable existed in the default values.yaml of the chart,
+            // restore it to its original default value rather than deleting it.
+            // This prevents the diff utility from treating it as a deletion (null).
+            set(this.value, variable, defaultValue);
+          } else {
+            // If the variable did not exist in the default values.yaml (dynamic subquestion),
+            // remove it completely so it won't show up in the custom values diff.
+            remove(this.value, variable, true);
+          }
+        }
+      }
+
+      for (const variable of neuVars) {
+        // If a question was previously hidden and is now shown again, restore the user's last
+        // answer (if any) rather than leaving it at the default from when it was hidden.
+        if (!oldVars.includes(variable) && variable in this.hiddenValuesCache) {
+          set(this.value, variable, this.hiddenValuesCache[variable]);
+          delete this.hiddenValuesCache[variable];
         }
       }
     }

--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -306,7 +306,7 @@ export default {
             } else {
               // If the variable did not exist in the default values.yaml (dynamic subquestion),
               // remove it completely so it won't show up in the custom values diff.
-              remove(this.value, variable);
+              remove(this.value, variable, true);
             }
           }
         }

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -161,6 +161,21 @@ describe('fx: remove', () => {
 
     expect(result).toStrictEqual(expected);
   });
+
+  describe('with pruneEmptyParents', () => {
+    it.each([
+      [{ level1: { level2: true } }, 'level1.level2', {}],
+      [{ level1: { level2: true, other: true } }, 'level1.level2', { level1: { other: true } }],
+      [{ level1: { level2: true }, other: true }, 'level1.level2', { other: true }],
+      [{ level1: { level2: { level3: true } } }, 'level1.level2.level3', {}],
+      [{ level1: { level2: { level3: true, other: true } } }, 'level1.level2.level3', { level1: { level2: { other: true } } }],
+      [{ level1: { level2: { level3: true } }, other: true }, 'level1.level2.level3', { other: true }],
+    ])('should evaluate %p as %p', (obj, path, expected) => {
+      const result = remove(obj, path, true);
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
 });
 
 describe('fx: diff', () => {

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -90,7 +90,7 @@ export function get(obj, path) {
   return obj;
 }
 
-export function remove(obj, path) {
+export function remove(obj, path, pruneEmptyParents = false) {
   const parentAry = splitObjectPath(path);
 
   // Remove the very last part of the path
@@ -105,6 +105,21 @@ export function remove(obj, path) {
     if ( parent ) {
       parent[leafKey] = undefined;
       delete parent[leafKey];
+
+      if ( pruneEmptyParents ) {
+        // Walk back up the path, deleting any ancestor objects that are now empty,
+        // stopping as soon as one still has content.
+        while ( parentAry.length ) {
+          const ancestorKey = parentAry.pop();
+          const ancestor = parentAry.length ? get(obj, joinObjectPath(parentAry)) : obj;
+
+          if ( ancestor && isEmpty(ancestor[ancestorKey]) ) {
+            delete ancestor[ancestorKey];
+          } else {
+            break;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6811

Toggling parent options in Helm charts (e.g., NeuVector) hid subquestions but kept their stale customized answers in the custom values object. This caused unselected options' values to persist in the final YAML and Helm release values.

### Occurred changes and/or fixed issues
- Added a Vue watcher on `shownQuestions` in the `Questions` component to clean up variables that transition from visible to hidden.
- Subquestions that have chart-level default values in `source.values` are reset back to their original defaults. If they don't have a default value then they get deleted entirely.

### Technical notes summary
- Uses `get(this.source.values, variable)` to check if a hidden question was part of the original chart `values.yaml` defaults.
- Safe for initial load as watcher only executes if previous state exists (`old?.length`).

### Areas or cases that should be tested
- Install a Helm chart with conditional subquestions (e.g., NeuVector).
- Select "Ingress Configuration" tab, and enable "Manager Ingress Status" option
- Change some values on the newly shown options
- Compare the changes in YAML
- Disable "Manager Ingress Status" option
- Compare the changes in YAML again, if there are no other changes made by you the "Compare Changes" tab should not be clickable

### Areas which could experience regressions
- Rendered Helm chart questions and default values.
- Saving or upgrading Helm charts from the UI.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/29722fb6-f308-4407-9f88-f175c8c555fd


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
