### PR TITLE
Set SASS charset option to `false`

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -585,8 +585,9 @@ module.exports = function(dir, appConfig = {}) {
             @import "~shell/assets/styles/base/_functions.scss";
             @import "~shell/assets/styles/base/_mixins.scss";
             @import 'node_modules/@xterm/xterm/css/xterm.css';
-          `
-        }
+          `,
+          sassOptions: { charset: false }
+        },
       }
     },
     outputDir,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This prevents SASS from emitting a `@charset` by setting the SASS charset option to `false`[^1].

[^1]: https://sass-lang.com/documentation/js-api/interfaces/options/#charset  

Fixes #18766
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Set SASS charset option to `false`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

#17024 introduced a change that improved the copy/paste behavior of masked values. In order to do so, bullets were added to the conceal class for `DetailText.vue` and other components: `      content: '••••••••••••••••••••••••';`. With the inclusion of the bullets, `dart-sass` started emitting `@charset "UTF-8"` for any stylesheet containing the offending non-ASCII characters. In the production CSS path everything after the non-ASCII characters in the scoped block would get lost lost. We never see this behavior in dev environments.

We already specify `<meta charset="utf-8">` in `shell/public/index.html`, so I understand that this SASS option should be redundant.  

If this approach is too difficult to confirm safe, we can consider the alternatives:

1. Move the bullets out of CSS and back into the template
2. Use an ascii glyph that reads correctly

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

I have a dev build of this change at `https://releases.rancher.com/dashboard/detailtext-copy-regression-dev/index.html`. Direct `ui-dashboard-index` to this change and set `ui-offline-preferred` to `Remote`.

Follow the repro steps in the associated issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This does alter SASS behavior, so the risk is high that there are some knock-on effects that are undetected by this change. See alternatives defined above if we deem this to be too high of a risk.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1368" height="1217" alt="image" src="https://github.com/user-attachments/assets/95332438-b460-420a-9297-9bf83a620bc8" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
