### PR TITLE
Fix type-check errors in shell store, models, core and utils tests

### DIFF
--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -56,7 +56,7 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
 
     cy.setRancherResource('v3', 'settings', 'ui-brand', { value: 'suse' });
     // The stored form of the `light` theme preference is `ui-light` (see `mangleWrite` on `THEME` in
-    // `shell/store/prefs.js`). `true` verifies the preference actually landed.
+    // `shell/store/prefs.ts`). `true` verifies the preference actually landed.
     cy.setUserPreference({ theme: 'ui-light' }, true);
   });
 

--- a/docusaurus/docs/internal/code-base-works/stores.md
+++ b/docusaurus/docs/internal/code-base-works/stores.md
@@ -13,6 +13,6 @@ Define the store in a file that resides within `shell/store`. Then add the store
 shell/nuxt/store.js
 ```js
 ...
-resolveStoreModules(require('../store/i18n.js'), 'i18n.js')
+resolveStoreModules(require('../store/i18n.ts'), 'i18n.ts')
 ...
 ```

--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 1037
+# Total errors: 819
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
 pkg/aks/components/Config.vue: error TS2532: Object is possibly 'undefined'.
@@ -403,9 +403,6 @@ shell/components/nav/NotificationCenter/Notification.vue: error TS7053: Element 
 shell/components/nav/__tests__/Group.test.ts: error TS2322: Type 'Record<string, unknown>' is not assignable to type 'Stubs | undefined'.
 shell/components/nav/__tests__/TopLevelMenu.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 shell/components/user.retention/user-retention-header.vue: error TS2307: Cannot find module '@shell/components/TabTitle' or its corresponding type declarations.
-shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2322: Type 'null' is not assignable to type 'string'.
-shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2322: Type 'undefined' is not assignable to type 'string'.
-shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 shell/composables/useUserRetentionValidation.ts: error TS2769: No overload matches this call.
 shell/config/__test__/home-links.test.ts: error TS2345: Argument of type '(language: String, value: string | boolean | null) => void' is not assignable to parameter of type '(...args: (string | boolean)[] | (boolean | null)[]) => any'.
 shell/config/__test__/home-links.test.ts: error TS7006: Parameter 'link' implicitly has an 'any' type.
@@ -413,29 +410,6 @@ shell/config/__test__/uiplugins.test.ts: error TS2345: Argument of type 'boolean
 shell/config/__test__/uiplugins.test.ts: error TS2345: Argument of type 'boolean' is not assignable to parameter of type '(() => any) & void'.
 shell/config/__test__/uiplugins.test.ts: error TS2769: No overload matches this call.
 shell/config/__test__/uiplugins.test.ts: error TS2769: No overload matches this call.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS18048: 'route.meta' is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS18048: 'route.meta' is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'children' does not exist on type '{ weight?: number | undefined; } | { weight?: number | undefined; localOnly?: boolean | undefined; } | { children: ProductChild[]; weight?: number | undefined; default?: string | undefined; }'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2339: Property 'name' does not exist on type 'ProductChild'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number | bigint'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS18048: 'currentMatch' is possibly 'undefined'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS2339: Property 'current' does not exist on type 'string | { metric: { name: string; }; current: { averageValue: number; }; }'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS2339: Property 'metric' does not exist on type 'string | { metric: { name: string; }; current: { averageValue: number; }; }'.
@@ -540,51 +514,10 @@ shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS7053: Element impl
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"poolId"' can't be used to index type '{}'.
 shell/machine-config/components/__tests__/EC2Networking.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/machine-config/components/__tests__/EC2Networking.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
-shell/mixins/__tests__/brand.spec.ts: error TS2345: Argument of type '(_: any, options: any) => Promise<never[]>' is not assignable to parameter of type '(action: any, ...args: any[]) => never[] | undefined'.
-shell/mixins/__tests__/brand.spec.ts: error TS2345: Argument of type '(_: any, options: any) => Promise<{ metadata: { name: string; }; }[]>' is not assignable to parameter of type '(action: any, ...args: any[]) => never[] | undefined'.
-shell/mixins/__tests__/brand.spec.ts: error TS7006: Parameter 'action' implicitly has an 'any' type.
-shell/mixins/__tests__/brand.spec.ts: error TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
-shell/mixins/__tests__/chart.test.ts: error TS2339: Property 'map' does not exist on type 'never'.
-shell/mixins/__tests__/chart.test.ts: error TS2345: Argument of type '(chartId: string | number | null, expected: string | number | null) => Promise<void>' is not assignable to parameter of type '(...args: (string | number)[] | (number | null)[]) => any'.
-shell/mixins/__tests__/chart.test.ts: error TS2345: Argument of type 'string | number | null' is not assignable to parameter of type 'number'.
-shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
-shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
-shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
-shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
 shell/mixins/compact-input.ts: error TS2339: Property 'label' does not exist on type '{ isCompact(): boolean; }'.
 shell/mixins/compact-input.ts: error TS2339: Property 'labelKey' does not exist on type '{ isCompact(): boolean; }'.
 shell/mixins/compact-input.ts: error TS2551: Property 'compact' does not exist on type '{ isCompact(): boolean; }'. Did you mean 'isCompact'?
 shell/mixins/compact-input.ts: error TS2551: Property 'compact' does not exist on type '{ isCompact(): boolean; }'. Did you mean 'isCompact'?
-shell/models/__tests__/management.cattle.io.cluster.test.ts: error TS2345: Argument of type '(clusterData: Object, expected: String) => void' is not assignable to parameter of type '(...args: (string | { provider: string; driver: string; })[] | {}[]) => any'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'moveAction' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS18048: 'typeItem' is possibly 'undefined'.
-shell/models/__tests__/namespace.test.ts: error TS2339: Property 'annotations' does not exist on type '{}'.
-shell/models/__tests__/namespace.test.ts: error TS2339: Property 'annotations' does not exist on type '{}'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2339: Property 'mgmt' does not exist on type 'Object'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2339: Property 'mgmt' does not exist on type 'Object'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2339: Property 'mgmt' does not exist on type 'Object'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2339: Property 'provisioner' does not exist on type 'Object'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2339: Property 'spec' does not exist on type 'Object'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2345: Argument of type '(clusterData: Object, expected: Boolean) => void' is not assignable to parameter of type '(...args: (boolean | { clusterName: string; provisioner: string; spec: {}; mgmt: MgmtCluster; })[]) => any'.
-shell/models/__tests__/provisioning.cattle.io.cluster.test.ts: error TS2345: Argument of type '(testName: string, conditions: any, expected: Boolean) => void' is not assignable to parameter of type '(...args: (string | boolean | { error: boolean; lastUpdateTime: string; status: string; transitioning: boolean; type: string; }[])[]) => any'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18047: 'card' is possibly 'null'.
-shell/models/__tests__/workload.test.ts: error TS18048: 'ingressesRow' is possibly 'undefined'.
-shell/models/__tests__/workload.test.ts: error TS2339: Property '$store' does not exist on type 'Workload'.
-shell/models/__tests__/workload.test.ts: error TS2531: Object is possibly 'null'.
 shell/models/ext.cattle.io.kubeconfig.ts: error TS2305: Module '"vue-router"' has no exported member 'Location'.
 shell/models/ext.cattle.io.kubeconfig.ts: error TS2416: Property '_availableActions' in type 'Kubeconfig' is not assignable to the same property in base type 'SteveModel'.
 shell/models/ext.cattle.io.kubeconfig.ts: error TS2769: No overload matches this call.
@@ -621,10 +554,7 @@ shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error T
 shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/index.vue: error TS18047: '$event.target' is possibly 'null'.
-shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'fleetWorkspaces' does not exist on type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'gitRepos' does not exist on type '{}'.
-shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'gitRepos' does not exist on type '{}'.
-shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'helmOps' does not exist on type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'helmOps' does not exist on type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'value' does not exist on type 'EventTarget'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'workspaces' does not exist on type '{}'.
@@ -741,7 +671,6 @@ shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property 'installing' does not exist on type '{ name: any; label: any; description: any; id: any; versions: any[]; installed: boolean; builtin: boolean; chart: any; incompatibilityMessage: string; }'.
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property 'primeOnly' does not exist on type '{ name: any; label: any; description: any; id: any; versions: any[]; installed: boolean; builtin: boolean; chart: any; incompatibilityMessage: string; }'.
 shell/pages/home.vue: error TS18048: '__VLS_ctx.altClusterListFeature.configuration' is possibly 'undefined'.
-shell/pages/home.vue: error TS2345: Argument of type '{ maxExponent: number; minExponent: number; addSuffix: boolean; firstSuffix: string; increment: number; maxPrecision: number; startingExponent: number; suffix: string; }' is not assignable to parameter of type '{ increment?: number | undefined; addSuffix?: boolean | undefined; addSuffixSpace?: boolean | undefined; suffix?: string | undefined; firstSuffix?: null | undefined; startingExponent?: number | undefined; minExponent?: number | undefined; maxExponent?: number | undefined; maxPrecision?: number | undefined; canRoundT...'.
 shell/plugins/__tests__/mutations.tests.ts: error TS18048: 'ctx.getters' is possibly 'undefined'.
 shell/plugins/__tests__/mutations.tests.ts: error TS18048: 'originalResourceRef.metadata' is possibly 'undefined'.
 shell/plugins/__tests__/mutations.tests.ts: error TS2339: Property 'a' does not exist on type '{}'.
@@ -877,139 +806,7 @@ shell/plugins/steve/__tests__/subscribe.spec.ts: error TS7031: Binding element '
 shell/plugins/steve/__tests__/subscribe.spec.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ setSocket(state: any, socket: any): void; setWantSocket(state: any, want: any): void; enqueuePendingFrame(state: any, obj: any): void; dequeuePendingFrame(state: any, obj: any): void; ... 6 more ...; debug(state: any, on: any, store: any): void; }'.
 shell/plugins/steve/__tests__/utils/mutation.test.helpers.ts: error TS2339: Property 'id' does not exist on type 'Resource'.
 shell/plugins/steve/accept-or-reject-socket-message.ts: error TS2353: Object literal may only specify known properties, and 'type' does not exist in type 'ActionFindAllArgs'.
-shell/store/__tests__/action-menu.test.ts: error TS2339: Property 'key' does not exist on type '{}'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/catalog.test.ts: error TS2353: Object literal may only specify known properties, and 'searchQuery' does not exist in type '{ clusterProvider?: string | undefined; showDeprecated?: boolean | undefined; showHidden?: boolean | undefined; showPrerelease?: boolean | undefined; hideRepos?: never[] | undefined; showRepos?: never[] | undefined; showTypes?: never[] | undefined; hideTypes?: never[] | undefined; }'.
-shell/store/__tests__/growl.test.ts: error TS2322: Type '{ id: number; color: string; title: string; }' is not assignable to type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2322: Type '{ id: number; color: string; title: string; }' is not assignable to type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'id' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'id' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'started' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'started' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'title' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'title' does not exist on type 'never'.
-shell/store/__tests__/growl.test.ts: error TS2339: Property 'title' does not exist on type 'never'.
-shell/store/__tests__/prefs.test.ts: error TS2322: Type '{ name: string; }' is not assignable to type 'null'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"new-test-def"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-ascookie"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-def-value"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-def-value"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-inherit"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-mangle"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-mangle"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-no-ascookie"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-no-parsejson"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-no-userupref"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-options"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-parsejson"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"test-pref-userupref-default"' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/prefs.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
-shell/store/__tests__/wm.test.ts: error TS2322: Type '{ tabs: never[]; active: {}; open: {}; panelHeight: { bottom: string | null; }; panelWidth: { left: string | null; right: string | null; }; userPin: null; lockedPositions: never[]; }' is not assignable to type 'State'.
-shell/types/store/__tests__/pagination.types.spec.ts: error TS2322: Type 'null' is not assignable to type 'boolean | undefined'.
-shell/types/store/__tests__/pagination.types.spec.ts: error TS2322: Type 'null' is not assignable to type 'boolean | undefined'.
-shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"bannerFooter"' can't be used to index type '{}'.
-shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"bannerHeader"' can't be used to index type '{}'.
-shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
-shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
-shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
-shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
-shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
-shell/utils/__tests__/chart.test.ts: error TS2353: Object literal may only specify known properties, and 'cluster' does not exist in type '{ showAppReadme?: boolean | undefined; hideReadmeFirstTitle?: boolean | undefined; }'.
-shell/utils/__tests__/chart.test.ts: error TS2353: Object literal may only specify known properties, and 'cluster' does not exist in type '{ showAppReadme?: boolean | undefined; hideReadmeFirstTitle?: boolean | undefined; }'.
-shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.
-shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.
-shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.
-shell/utils/__tests__/cspAdaptor.test.ts: error TS2493: Tuple type '[action: string]' of length '1' has no element at index '1'.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/fleet.test.ts: error TS2554: Expected 3 arguments, but got 2.
-shell/utils/__tests__/object.test.ts: error TS2353: Object literal may only specify known properties, and 'replaceObjectProps' does not exist in type '{ mutateOriginal?: boolean | undefined; replaceArray?: boolean | undefined; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'template' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateVersionId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/parse-externalid.test.ts: error TS2339: Property 'templateVersionId' does not exist on type '{ kind: null; group: null; base: null; id: null; name: null; version: null; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'left' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/position.test.ts: error TS2339: Property 'top' does not exist on type '{ position: string; }'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'err' does not exist on type '{}'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'err' does not exist on type '{}'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'ok' does not exist on type '{}'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'reject' does not exist on type '{ promise: Promise<any>; }'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'reject' does not exist on type '{ promise: Promise<any>; }'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'resolve' does not exist on type '{ promise: Promise<any>; }'.
-shell/utils/__tests__/promise.test.ts: error TS2339: Property 'resolve' does not exist on type '{ promise: Promise<any>; }'.
-shell/utils/__tests__/require-asset.test.ts: error TS2345: Argument of type 'Mock<any, any, any>' is not assignable to parameter of type 'WebpackRequireContext'.
-shell/utils/__tests__/require-asset.test.ts: error TS2345: Argument of type 'Mock<any, any, any>' is not assignable to parameter of type 'WebpackRequireContext'.
-shell/utils/__tests__/require-asset.test.ts: error TS2345: Argument of type 'Mock<any, any, any>' is not assignable to parameter of type 'WebpackRequireContext'.
-shell/utils/__tests__/require-asset.test.ts: error TS2345: Argument of type 'Mock<any, any, any>' is not assignable to parameter of type 'WebpackRequireContext'.
-shell/utils/__tests__/require-asset.test.ts: error TS2345: Argument of type 'Mock<any, any, any>' is not assignable to parameter of type 'WebpackRequireContext'.
-shell/utils/__tests__/string-utils.test.ts: error TS2345: Argument of type 'RegExp' is not assignable to parameter of type 'null | undefined'.
-shell/utils/__tests__/units.test.ts: error TS2322: Type 'string' is not assignable to type 'null | undefined'.
-shell/utils/__tests__/units.test.ts: error TS2345: Argument of type '{ increment: number; suffix: string; firstSuffix: string; } | { increment: number; suffix: string; firstSuffix?: undefined; }' is not assignable to parameter of type '{ increment?: number | undefined; addSuffix?: boolean | undefined; addSuffixSpace?: boolean | undefined; suffix?: string | undefined; firstSuffix?: null | undefined; startingExponent?: number | undefined; minExponent?: number | undefined; maxExponent?: number | undefined; maxPrecision?: number | undefined; canRoundT...'.
-shell/utils/__tests__/units.test.ts: error TS2345: Argument of type '{ suffix: string; firstSuffix?: undefined; addSuffixSpace?: undefined; addSuffix?: undefined; } | { suffix: string; firstSuffix: string; addSuffixSpace?: undefined; addSuffix?: undefined; } | { ...; } | { ...; }' is not assignable to parameter of type '{ increment?: number | undefined; addSuffix?: boolean | undefined; addSuffixSpace?: boolean | undefined; suffix?: string | undefined; firstSuffix?: null | undefined; startingExponent?: number | undefined; minExponent?: number | undefined; maxExponent?: number | undefined; maxPrecision?: number | undefined; canRoundT...'.
-shell/utils/__tests__/url.test.ts: error TS2322: Type 'null' is not assignable to type 'string'.
-shell/utils/__tests__/url.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'QueryParams'.
-shell/utils/__tests__/url.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string | string[]'.
-shell/utils/__tests__/url.test.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'QueryParams'.
-shell/utils/__tests__/width.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'Element'.
-shell/utils/__tests__/width.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'Element'.
-shell/utils/__tests__/width.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Element'.
-shell/utils/__tests__/width.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Element'.
-shell/utils/__tests__/width.test.ts: error TS2353: Object literal may only specify known properties, and 'length' does not exist in type 'Element'.
 shell/utils/duration.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'null | undefined'.
-shell/utils/dynamic-content/__tests__/announcement.test.ts: error TS2741: Property 'isPrime' is missing in type '{ version: semver.SemVer; }' but required in type 'VersionInfo'.
-shell/utils/dynamic-content/__tests__/announcement.test.ts: error TS2741: Property 'primary' is missing in type '{ secondary: { action: string; link: string; }; }' but required in type '{ primary: CallToAction; secondary?: CallToAction | undefined; }'.
 shell/utils/dynamic-content/__tests__/config.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
 shell/utils/dynamic-content/__tests__/config.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
 shell/utils/dynamic-content/__tests__/config.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
@@ -1018,23 +815,8 @@ shell/utils/dynamic-content/__tests__/info.test.ts: error TS2339: Property 'isRa
 shell/utils/dynamic-content/__tests__/info.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
 shell/utils/dynamic-content/__tests__/info.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
 shell/utils/dynamic-content/__tests__/info.test.ts: error TS2339: Property 'isRancherPrime' does not exist on type 'typeof import("@shell/config/version")'.
-shell/utils/dynamic-content/__tests__/support-notice.test.ts: error TS2322: Type 'null' is not assignable to type 'SemVer'.
 shell/utils/dynamic-content/config.ts: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/utils/gc/gc-interval.ts: error TS2769: No overload matches this call.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2322: Type '{ resource: string; }' is not assignable to type 'string | { resource: string; context: string[]; }'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2341: Property 'isEnabledInStore' is private and only accessible within class 'PaginationUtils'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type '(string[] | (({ rootGetters, $extension }: any, enabledFor: PaginationResourceContext) => boolean) | { (ctx: any): PaginationSettingsStores; (serverPagination: PaginationSettings): PaginationSettingsStores; } | ... 11 more ... | (({ rootGetters }: any) => number | undefined)) & void'.
-shell/utils/unit-tests/pagination-utils.spec.ts: error TS2769: No overload matches this call.
 shell/utils/validators/private-registry.ts: error TS2307: Cannot find module 'types/store/vuex' or its corresponding type declarations.
 shell/utils/versions.ts: error TS2724: '"@shell/config/version"' has no exported member named 'setKubeVersionData'. Did you mean 'getVersionData'?
 shell/utils/versions.ts: error TS2724: '"@shell/config/version"' has no exported member named 'setVersionData'. Did you mean 'getVersionData'?

--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 819
+# Total errors: 816
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
 pkg/aks/components/Config.vue: error TS2532: Object is possibly 'undefined'.
@@ -534,7 +534,6 @@ shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2339: Property 
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2339: Property 'isLocal' does not exist on type '{ id: string; metadata: { creationTimestamp: number; }; status: { provider: string; }; }'.
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2339: Property 'isLocal' does not exist on type '{ id: string; metadata: { creationTimestamp: number; }; status: { provider: string; }; }'.
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'componentStatuses' does not exist in type '{ provider: string; }'.
-shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2696: The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2740: Type '(type: string) => boolean' is missing the following properties from type 'Mock<any, any, any>': getMockName, mock, mockClear, mockReset, and 13 more.
 shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
@@ -769,8 +768,6 @@ shell/plugins/steve/__tests__/actions.test.ts: error TS2769: No overload matches
 shell/plugins/steve/__tests__/getters.test.ts: error TS7006: Parameter 'type' implicitly has an 'any' type.
 shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'id' does not exist on type 'Resource'.
 shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'namespace' does not exist on type 'Resource'.
-shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'podsByNamespace' does not exist on type '{ types: { pod: any; }; ctx?: undefined; type?: undefined; data?: undefined; } | { ctx: { rootGetters: { 'type-map/optionsFor': (type: string) => {}; }; getters: { classify: (resource: any) => typeof Resource; cleanResource: (existing: Resource, resource: any) => any; keyFieldForType: () => string; }; }; type: strin...'.
-shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'podsByNamespace' does not exist on type '{ types: { pod: any; }; ctx?: undefined; type?: undefined; data?: undefined; } | { ctx: { rootGetters: { 'type-map/optionsFor': (type: string) => {}; }; getters: { classify: (resource: any) => typeof Resource; cleanResource: (existing: Resource, resource: any) => any; keyFieldForType: () => string; }; }; type: strin...'.
 shell/plugins/steve/__tests__/mutations.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/plugins/steve/__tests__/resource-utils.test.ts: error TS2554: Expected 1-2 arguments, but got 0.
 shell/plugins/steve/__tests__/steve-pagination-utils.test.ts: error TS2341: Property 'convertPaginationParams' is private and only accessible within class 'StevePaginationUtils'.

--- a/shell/composables/useIsNewDetailPageEnabled.test.ts
+++ b/shell/composables/useIsNewDetailPageEnabled.test.ts
@@ -6,9 +6,9 @@ const mockRoute: any = { query: {} };
 jest.mock('vuex', () => ({ useStore: () => mockStore }));
 jest.mock('vue-router', () => ({ useRoute: () => mockRoute }));
 
-const mockGetVersionInfo = jest.fn(() => ({ fullVersion: '2.12.0' }));
+const mockGetVersionInfo = jest.fn<{ fullVersion: string | null | undefined }, [unknown]>(() => ({ fullVersion: '2.12.0' }));
 
-jest.mock('@shell/utils/version', () => ({ getVersionInfo: (...args: any[]) => mockGetVersionInfo(...args) }));
+jest.mock('@shell/utils/version', () => ({ getVersionInfo: (store: unknown) => mockGetVersionInfo(store) }));
 
 describe('useIsNewDetailPageEnabled', () => {
   beforeEach(() => {

--- a/shell/config/__test__/home-links.test.ts
+++ b/shell/config/__test__/home-links.test.ts
@@ -1,6 +1,8 @@
 import { createStore } from 'vuex';
 import { ensureSupportLink } from '@shell/config/home-links.js';
-import { getters, state, mutations } from '@shell/store/i18n.js';
+import {
+  getters, state, mutations, I18nState, I18nGetterRootState
+} from '@shell/store/i18n';
 
 jest.mock('@shell/assets/translations/en-us.yaml', () => ({
   locale: {
@@ -11,7 +13,7 @@ jest.mock('@shell/assets/translations/en-us.yaml', () => ({
 }));
 
 describe('fx: ensureSupportLink', () => {
-  const store = createStore({
+  const store = createStore<I18nState & I18nGetterRootState>({
     state,
     getters: {
       'i18n/selectedLocaleLabel': getters.selectedLocaleLabel,

--- a/shell/config/store.js
+++ b/shell/config/store.js
@@ -25,7 +25,7 @@ let store = {};
   resolveStoreModules(require('../store/github.js'), 'github.js');
   resolveStoreModules(require('../store/gitlab.js'), 'gitlab.js');
   resolveStoreModules(require('../store/growl.ts'), 'growl.ts');
-  resolveStoreModules(require('../store/i18n.js'), 'i18n.js');
+  resolveStoreModules(require('../store/i18n.ts'), 'i18n.ts');
   resolveStoreModules(require('../store/linode.js'), 'linode.js');
   resolveStoreModules(require('../store/modal.ts'), 'modal.ts');
   resolveStoreModules(require('../store/plugins.js'), 'plugins.js');
@@ -56,7 +56,7 @@ let store = {};
       '../store/github.js',
       '../store/gitlab.js',
       '../store/growl.ts',
-      '../store/i18n.js',
+      '../store/i18n.ts',
       '../store/index.js',
       '../store/linode.js',
       '../store/modal.ts',

--- a/shell/config/store.js
+++ b/shell/config/store.js
@@ -19,18 +19,18 @@ let store = {};
   resolveStoreModules(require('../store/action-menu.js'), 'action-menu.js');
   resolveStoreModules(require('../store/auth.js'), 'auth.js');
   resolveStoreModules(require('../store/aws.js'), 'aws.js');
-  resolveStoreModules(require('../store/catalog.js'), 'catalog.js');
+  resolveStoreModules(require('../store/catalog.ts'), 'catalog.ts');
   resolveStoreModules(require('../store/digitalocean.js'), 'digitalocean.js');
   resolveStoreModules(require('../store/features.js'), 'features.js');
   resolveStoreModules(require('../store/github.js'), 'github.js');
   resolveStoreModules(require('../store/gitlab.js'), 'gitlab.js');
-  resolveStoreModules(require('../store/growl.js'), 'growl.js');
+  resolveStoreModules(require('../store/growl.ts'), 'growl.ts');
   resolveStoreModules(require('../store/i18n.js'), 'i18n.js');
   resolveStoreModules(require('../store/linode.js'), 'linode.js');
   resolveStoreModules(require('../store/modal.ts'), 'modal.ts');
   resolveStoreModules(require('../store/plugins.js'), 'plugins.js');
   resolveStoreModules(require('../store/pnap.js'), 'pnap.js');
-  resolveStoreModules(require('../store/prefs.js'), 'prefs.js');
+  resolveStoreModules(require('../store/prefs.ts'), 'prefs.ts');
   resolveStoreModules(require('../store/resource-fetch.js'), 'resource-fetch.js');
   resolveStoreModules(require('../store/slideInPanel.ts'), 'slideInPanel.ts');
   resolveStoreModules(require('../store/type-map.js'), 'type-map.js');
@@ -50,19 +50,19 @@ let store = {};
       '../store/action-menu.js',
       '../store/auth.js',
       '../store/aws.js',
-      '../store/catalog.js',
+      '../store/catalog.ts',
       '../store/digitalocean.js',
       '../store/features.js',
       '../store/github.js',
       '../store/gitlab.js',
-      '../store/growl.js',
+      '../store/growl.ts',
       '../store/i18n.js',
       '../store/index.js',
       '../store/linode.js',
       '../store/modal.ts',
       '../store/plugins.js',
       '../store/pnap.js',
-      '../store/prefs.js',
+      '../store/prefs.ts',
       '../store/resource-fetch.js',
       '../store/slideInPanel.ts',
       '../store/type-map.js',

--- a/shell/config/types.d.ts
+++ b/shell/config/types.d.ts
@@ -1,0 +1,366 @@
+/**
+ * Declarations for the untyped `types.js` in this directory, so that `.ts` modules
+ * importing it still type-check when an extension builds against `@rancher/shell`
+ * (its own `tsconfig` sets `checkJs: false`, so the `.js` has no types of its own).
+ *
+ * Seeded from:
+ *   ./node_modules/.bin/tsc shell/config/types.js --declaration --allowJs --emitDeclarationOnly --outDir <tmp>
+ * then adjusted so the constant objects are declared as values (`export const X: {...}`)
+ * rather than namespaces, which cannot be used where a value is expected.
+ */
+
+export const STEVE: {
+    PREFERENCE: string;
+    SCHEMA_DEFINITION: string;
+};
+export const NORMAN: {
+    APP: string;
+    AUTH_CONFIG: string;
+    CLUSTER: string;
+    CLUSTER_TOKEN: string;
+    CLUSTER_ROLE_TEMPLATE_BINDING: string;
+    CLOUD_CREDENTIAL: string;
+    FLEET_WORKSPACES: string;
+    GLOBAL_ROLE: string;
+    GLOBAL_ROLE_BINDING: string;
+    NODE_POOL: string;
+    NODE: string;
+    PRINCIPAL: string;
+    PROJECT: string;
+    PROJECT_ROLE_TEMPLATE_BINDING: string;
+    SETTING: string;
+    SPOOFED: {
+        GROUP_PRINCIPAL: string;
+    };
+    ROLE_TEMPLATE: string;
+    TOKEN: string;
+    USER: string;
+    KONTAINER_DRIVER: string;
+    NODE_DRIVER: string;
+};
+export const PUBLIC: {
+    AUTH_PROVIDER: string;
+};
+export const API_GROUP: 'apiGroups';
+export const API_SERVICE: 'apiregistration.k8s.io.apiservice';
+export const CONFIG_MAP: 'configmap';
+export const COUNT: 'count';
+export const CRD: 'apiextensions.k8s.io.customresourcedefinition';
+export const EVENT: 'event';
+export const ENDPOINTS: 'endpoints';
+export const HPA: 'autoscaling.horizontalpodautoscaler';
+export const INGRESS: 'networking.k8s.io.ingress';
+export const INGRESS_CLASS: 'networking.k8s.io.ingressclass';
+export const LIMIT_RANGE: 'limitrange';
+export const NAMESPACE: 'namespace';
+export const NODE: 'node';
+export const NETWORK_POLICY: 'networking.k8s.io.networkpolicy';
+export const POD: 'pod';
+export const POD_DISRUPTION_BUDGET: 'policy.poddisruptionbudget';
+export const PV: 'persistentvolume';
+export const PVC: 'persistentvolumeclaim';
+export const RESOURCE_QUOTA: 'resourcequota';
+export const AUDIT_POLICY: 'auditlog.cattle.io.auditpolicy';
+export const SCHEMA: 'schema';
+export const SERVICE: 'service';
+export const SECRET: 'secret';
+export const SERVICE_ACCOUNT: 'serviceaccount';
+export const STORAGE_CLASS: 'storage.k8s.io.storageclass';
+export const CSI_DRIVER: 'storage.k8s.io.csidriver';
+export const OBJECT_META: 'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta';
+export const NETWORK_ATTACHMENT: 'k8s.cni.cncf.io.networkattachmentdefinition';
+export const USER: 'user';
+export const GROUP: 'group';
+export const RBAC: {
+    ROLE: string;
+    CLUSTER_ROLE: string;
+    ROLE_BINDING: string;
+    CLUSTER_ROLE_BINDING: string;
+};
+export const WORKLOAD: 'workload';
+export const WORKLOAD_DASHBOARD: 'workload-dashboard';
+export const WORKLOAD_TYPES: {
+    DEPLOYMENT: string;
+    CRON_JOB: string;
+    DAEMON_SET: string;
+    JOB: string;
+    STATEFUL_SET: string;
+    REPLICA_SET: string;
+    REPLICATION_CONTROLLER: string;
+};
+export const WORKLOAD_KINDS: {
+    DEPLOYMENT: string;
+    CRON_JOB: string;
+    DAEMON_SET: string;
+    JOB: string;
+    STATEFUL_SET: string;
+    REPLICA_SET: string;
+    REPLICATION_CONTROLLER: string;
+};
+/**
+ * Map Rancher Workload types to Kube Workload Kinds
+ */
+export const WORKLOAD_TYPE_TO_KIND_MAPPING: {
+    [x: string]: string;
+};
+/**
+ * Map Kube Workload Kinds types to Rancher Workload
+ */
+export const WORKLOAD_KIND_TO_TYPE_MAPPING: {
+    [x: string]: string;
+};
+export const METRICS_SUPPORTED_KINDS: string[];
+export const SCALABLE_WORKLOAD_TYPES: Record<string, string>;
+export const LIST_WORKLOAD_TYPES: {
+    POD: typeof POD;
+};
+export const METRIC: {
+    NODE: string;
+    POD: string;
+};
+export const CATALOG: {
+    CLUSTER_REPO: string;
+    OPERATION: string;
+    APP: string;
+    REPO: string;
+};
+export const CATALOG_SORT_OPTIONS: {
+    RECOMMENDED: string;
+    LAST_UPDATED_DESC: string;
+    ALPHABETICAL_ASC: string;
+    ALPHABETICAL_DESC: string;
+};
+export const UI_PLUGIN: 'catalog.cattle.io.uiplugin';
+export const HELM: {
+    PROJECTHELMCHART: string;
+};
+export const MONITORING: {
+    ALERTMANAGER: string;
+    ALERTMANAGERCONFIG: string;
+    PODMONITOR: string;
+    PROMETHEUS: string;
+    PROMETHEUSRULE: string;
+    SERVICEMONITOR: string;
+    THANOSRULER: string;
+    SPOOFED: {
+        RECEIVER: string;
+        RECEIVER_SPEC: string;
+        RECEIVER_EMAIL: string;
+        RECEIVER_SLACK: string;
+        RECEIVER_WEBHOOK: string;
+        RECEIVER_PAGERDUTY: string;
+        RECEIVER_OPSGENIE: string;
+        RECEIVER_HTTP_CONFIG: string;
+        RESPONDER: string;
+        ROUTE: string;
+        ROUTE_SPEC: string;
+    };
+};
+export const LONGHORN: {
+    ENGINES: string;
+    ENGINE_IMAGES: string;
+    NODES: string;
+    REPLICAS: string;
+    SETTINGS: string;
+    VOLUMES: string;
+};
+export const LONGHORN_DRIVER: 'driver.longhorn.io';
+export const LONGHORN_VERSION_V1: 'LonghornV1';
+export const LONGHORN_VERSION_V2: 'LonghornV2';
+export const SNAPSHOT: 'rke.cattle.io.etcdsnapshot';
+export const OPERATION: {
+    ETCD_SNAPSHOT: string;
+    ETCD_SNAPSHOT_RESTORE: string;
+    ENCRYPTION_KEY_ROTATE: string;
+};
+export const MANAGEMENT: {
+    AUTH_CONFIG: string;
+    CATALOG_TEMPLATE: string;
+    CLUSTER: string;
+    CLUSTER_ROLE_TEMPLATE_BINDING: string;
+    FEATURE: string;
+    KONTAINER_DRIVER: string;
+    MULTI_CLUSTER_APP: string;
+    NODE: string;
+    NODE_DRIVER: string;
+    NODE_POOL: string;
+    NODE_TEMPLATE: string;
+    PROJECT: string;
+    PROJECT_ROLE_TEMPLATE_BINDING: string;
+    ROLE_TEMPLATE: string;
+    SETTING: string;
+    USER: string;
+    TOKEN: string;
+    GLOBAL_ROLE: string;
+    GLOBAL_ROLE_BINDING: string;
+    PSA: string;
+    MANAGED_CHART: string;
+    USER_NOTIFICATION: string;
+    GLOBAL_DNS_PROVIDER: string;
+    RKE_TEMPLATE: string;
+    RKE_TEMPLATE_REVISION: string;
+    CLUSTER_PROXY_CONFIG: string;
+    OIDC_CLIENT: string;
+    PROXY_ENDPOINT: string;
+};
+export const BRAND: {
+    SUSE: string;
+    CSP: string;
+    FEDERAL: string;
+    RGS: string;
+};
+export const EXT: {
+    USER_ACTIVITY: string;
+    SELFUSER: string;
+    GROUP_MEMBERSHIP_REFRESH_REQUESTS: string;
+    PASSWORD_CHANGE_REQUESTS: string;
+    KUBECONFIG: string;
+};
+export const CAPI: {
+    CAPI_CLUSTER: string;
+    MACHINE_DEPLOYMENT: string;
+    MACHINE_SET: string;
+    MACHINE: string;
+    RANCHER_CLUSTER: string;
+    MACHINE_CONFIG_GROUP: string;
+    CAPI_PROVIDER: string;
+};
+export const FLEET: {
+    APPLICATION: string;
+    BUNDLE: string;
+    BUNDLE_DEPLOYMENT: string;
+    CLUSTER: string;
+    CLUSTER_GROUP: string;
+    DASHBOARD: string;
+    GIT_REPO: string;
+    HELM_OP: string;
+    SUSE_APP_COLLECTION: string;
+    WORKSPACE: string;
+    TOKEN: string;
+    BUNDLE_NAMESPACE_MAPPING: string;
+    GIT_REPO_RESTRICTION: string;
+};
+export const GATEKEEPER: {
+    CONSTRAINT_TEMPLATE: string;
+    SPOOFED: {
+        CONSTRAINT: string;
+    };
+};
+export const ISTIO: {
+    VIRTUAL_SERVICE: string;
+    DESTINATION_RULE: string;
+    GATEWAY: string;
+};
+export const GATEWAY_API: {
+    GATEWAY: string;
+    HTTP_ROUTE: string;
+};
+export const LOGGING: {
+    CLUSTER_FLOW: string;
+    CLUSTER_OUTPUT: string;
+    FLOW: string;
+    OUTPUT: string;
+    SPOOFED: {
+        FILTERS: string;
+        FILTER: string;
+        CONCAT: string;
+        DEDOT: string;
+        DETECTEXCEPTIONS: string;
+        GEOIP: string;
+        GREP: string;
+        PARSER: string;
+        PROMETHEUS: string;
+        RECORD_MODIFIER: string;
+        RECORD_TRANSFORMER: string;
+        STDOUT: string;
+        SUMOLOGIC: string;
+        TAG_NORMALISER: string;
+        THROTTLE: string;
+        RECORD: string;
+        REGEXPSECTION: string;
+        EXCLUDESECTION: string;
+        ORSECTION: string;
+        ANDSECTION: string;
+        PARSESECTION: string;
+        METRICSECTION: string;
+        REPLACE: string;
+        SINGLEPARSESECTION: string;
+    };
+};
+export const BACKUP_RESTORE: {
+    RESOURCE_SET: string;
+    BACKUP: string;
+    RESTORE: string;
+};
+export const COMPLIANCE: {
+    CLUSTER_SCAN: string;
+    CLUSTER_SCAN_PROFILE: string;
+    BENCHMARK: string;
+    REPORT: string;
+};
+export const UI: {
+    NAV_LINK: string;
+};
+export const VIRTUAL_TYPES: {
+    CLUSTER_MEMBERS: string;
+    PROJECT_NAMESPACES: string;
+    NAMESPACES: string;
+    PROJECT_SECRETS: string;
+    JWT_AUTHENTICATION: string;
+};
+export const HCI: {
+    CLUSTER: string;
+    DASHBOARD: string;
+    IMAGE: string;
+    VGPU_DEVICE: string;
+    SETTING: string;
+    RESOURCE_QUOTA: string;
+    HARVESTER_CONFIG: string;
+};
+export const VIRTUAL_HARVESTER_PROVIDER: 'harvester';
+export const ADDRESSES: {
+    HOSTNAME: string;
+    INTERNAL_IP: string;
+    EXTERNAL_IP: string;
+};
+export const DEFAULT_WORKSPACE: 'fleet-default';
+export const AUTH_TYPE: {
+    _NONE: string;
+    _BASIC: string;
+    _SSH: string;
+    _S3: string;
+    _RKE: string;
+    _IMAGE_PULL_SECRET: string;
+    _GITHUB_APP: string;
+};
+export const LOCAL_CLUSTER: 'local';
+export const CLUSTER_REPO_TYPES: {
+    HELM_URL: string;
+    GIT_REPO: string;
+    OCI_URL: string;
+    SUSE_APP_COLLECTION: string;
+};
+/**
+ * The `generateName` prefix used when creating authentication secrets
+ * for SUSE App Collection repositories.
+ */
+export const CLUSTER_REPO_APPCO_AUTH_GENERATE_NAME: 'clusterrepo-appco-auth-';
+/**
+ * The `generateName` prefix used when creating authentication secrets
+ * for standard repositories.
+ */
+export const CLUSTER_REPO_AUTH_GENERATE_NAME: 'clusterrepo-auth-';
+/**
+ * The `generateName` prefix used when creating Helm Op authentication secrets
+ * for standard Helm sources.
+ */
+export const AUTH_GENERATE_NAME: 'auth-';
+export const ZERO_TIME: '0001-01-01T00:00:00Z';
+export const DEFAULT_GRAFANA_STORAGE_SIZE: '10Gi';
+export const DEPRECATED: 'Deprecated';
+export const EXPERIMENTAL: 'Experimental';
+export const AUTOSCALER_CONFIG_MAP_ID: 'kube-system/cluster-autoscaler-status';
+export const HOSTED_PROVIDER: 'hostedprovider';
+export const SAVED_COUNTS: {
+    K8S_CLUSTERS: string;
+};

--- a/shell/core/__tests__/plugin-products-helpers.test.ts
+++ b/shell/core/__tests__/plugin-products-helpers.test.ts
@@ -1,8 +1,60 @@
+import { RouteMeta } from 'vue-router';
 import {
   ProductChild, ProductChildGroup, ProductChildCustomPage, ProductChildResourcePage, ProductChildPage
 } from '@shell/core/plugin-products-external';
 import pluginProductsHelpers from '@shell/core/plugin-products-helpers';
+import { hasNameProperty, isProductChildGroup } from '@shell/core/plugin-products-type-guards';
+import { RouteRecordRawWithParams } from '@shell/core/plugin-types';
 import { BLANK_CLUSTER } from '@shell/store/store-types';
+
+/**
+ * `gatherChildrenOrdering` hands back the `ProductChild` union. Narrow a result back down to a
+ * group, with the same type guard the product code uses, before reaching for `sideMenu.children`.
+ */
+const getGroup = (child: ProductChild): ProductChildGroup => {
+  if (!isProductChildGroup(child)) {
+    throw new Error('Expected the product child to be a group');
+  }
+
+  return child;
+};
+
+/**
+ * Only some members of the `ProductChild` union carry a `name`, so narrow with the same type guard
+ * the product code uses before asserting on it.
+ */
+const getName = (child: ProductChild): string => {
+  if (!hasNameProperty(child)) {
+    throw new Error('Expected the product child to have a name');
+  }
+
+  return child.name;
+};
+
+/**
+ * `sideMenu` and its `weight` are both optional on the union, so narrow the weight that
+ * `gatherChildrenOrdering` assigned down to a number before comparing it.
+ */
+const getWeight = (child: ProductChild): number => {
+  const weight = child.sideMenu?.weight;
+
+  if (typeof weight !== 'number') {
+    throw new Error('Expected the product child to have been assigned a weight');
+  }
+
+  return weight;
+};
+
+/**
+ * The generated routes have an optional `meta`, so narrow it before an assertion reaches into it.
+ */
+const getMeta = (route: RouteRecordRawWithParams): RouteMeta => {
+  if (!route.meta) {
+    throw new Error('Expected the generated route to have meta');
+  }
+
+  return route.meta;
+};
 
 const gatherChildrenOrdering = pluginProductsHelpers.gatherChildrenOrdering.bind(pluginProductsHelpers);
 const generateTopLevelExtensionSimpleBaseRoute = pluginProductsHelpers.generateTopLevelExtensionSimpleBaseRoute.bind(pluginProductsHelpers);
@@ -52,9 +104,9 @@ describe('plugin-products-helpers', () => {
 
       const result = gatherChildrenOrdering(children);
 
-      expect(result[0].sideMenu?.weight).toBe(50);
-      expect(result[1].sideMenu?.weight).toBeLessThan(50); // 49
-      expect(result[2].sideMenu?.weight).toBeLessThan(result[1].sideMenu?.weight); // 48
+      expect(getWeight(result[0])).toBe(50);
+      expect(getWeight(result[1])).toBeLessThan(50); // 49
+      expect(getWeight(result[2])).toBeLessThan(getWeight(result[1])); // 48
     });
 
     it('should use 999 as minWeight when no explicit weights are provided', () => {
@@ -74,9 +126,9 @@ describe('plugin-products-helpers', () => {
 
       // minWeight starts at 999, then each item gets minWeight - (index + 1)
       // so: 999 - 1 = 998, 999 - 2 = 997, 999 - 3 = 996
-      expect(result[0].sideMenu?.weight).toBe(998);
-      expect(result[1].sideMenu?.weight).toBe(997);
-      expect(result[2].sideMenu?.weight).toBe(996);
+      expect(getWeight(result[0])).toBe(998);
+      expect(getWeight(result[1])).toBe(997);
+      expect(getWeight(result[2])).toBe(996);
     });
 
     it('should recursively apply ordering to nested children', () => {
@@ -103,9 +155,11 @@ describe('plugin-products-helpers', () => {
 
       const result = gatherChildrenOrdering(children);
 
-      expect(result[0].sideMenu.children[0].name).toBe('nested-a'); // 20
-      expect(result[0].sideMenu.children[1].name).toBe('nested-b'); // 10
-      expect(result[0].sideMenu.children[2].name).toBe('nested-c'); // auto-assigned 9
+      const nested = getGroup(result[0]).sideMenu.children;
+
+      expect(getName(nested[0])).toBe('nested-a'); // 20
+      expect(getName(nested[1])).toBe('nested-b'); // 10
+      expect(getName(nested[2])).toBe('nested-c'); // auto-assigned 9
     });
 
     it('should handle empty children array', () => {
@@ -131,9 +185,9 @@ describe('plugin-products-helpers', () => {
       const result = gatherChildrenOrdering(children);
 
       // second should be first due to highest weight
-      expect(result[0].name).toBe('second');
-      expect(result[1].name).toBe('first');
-      expect(result[2].name).toBe('third');
+      expect(getName(result[0])).toBe('second');
+      expect(getName(result[1])).toBe('first');
+      expect(getName(result[2])).toBe('third');
     });
   });
 
@@ -331,10 +385,10 @@ describe('plugin-products-helpers', () => {
 
       const routes = generateResourceRoutes('my-product', page);
 
-      expect(routes[2].meta.asyncSetup).toBe(true); // detail route
-      expect(routes[3].meta.asyncSetup).toBe(true); // edit route
-      expect(routes[0].meta.asyncSetup).toBeUndefined(); // list route
-      expect(routes[1].meta.asyncSetup).toBeUndefined(); // create route
+      expect(getMeta(routes[2]).asyncSetup).toBe(true); // detail route
+      expect(getMeta(routes[3]).asyncSetup).toBe(true); // edit route
+      expect(getMeta(routes[0]).asyncSetup).toBeUndefined(); // list route
+      expect(getMeta(routes[1]).asyncSetup).toBeUndefined(); // create route
     });
 
     it('should generate cluster-level extension resource routes when extendProduct is true', () => {
@@ -361,8 +415,8 @@ describe('plugin-products-helpers', () => {
       const routes = generateResourceRoutes('my-product', page);
 
       routes.forEach((route) => {
-        expect((route.meta as any).cluster).toBe(BLANK_CLUSTER);
-        expect(route.meta.product).toBe('my-product');
+        expect(getMeta(route).cluster).toBe(BLANK_CLUSTER);
+        expect(getMeta(route).product).toBe('my-product');
       });
     });
 
@@ -372,8 +426,8 @@ describe('plugin-products-helpers', () => {
       const routes = generateResourceRoutes('my-product', page, { extendProduct: true });
 
       routes.forEach((route) => {
-        expect((route.meta as any).cluster).toBeUndefined();
-        expect(route.meta.product).toBe('my-product');
+        expect(getMeta(route).cluster).toBeUndefined();
+        expect(getMeta(route).product).toBe('my-product');
       });
     });
 
@@ -409,15 +463,15 @@ describe('plugin-products-helpers', () => {
       const ordered = gatherChildrenOrdering(config);
 
       // Should be sorted by weight descending: 15, 10, 5
-      expect(ordered[0].sideMenu?.weight).toBe(15);
-      expect(ordered[0].name).toBe('resources');
-      expect(ordered[1].sideMenu?.weight).toBe(10);
-      expect(ordered[1].name).toBe('overview');
-      expect(ordered[2].sideMenu?.weight).toBe(5);
-      expect(ordered[2].name).toBe('settings');
+      expect(getWeight(ordered[0])).toBe(15);
+      expect(getName(ordered[0])).toBe('resources');
+      expect(getWeight(ordered[1])).toBe(10);
+      expect(getName(ordered[1])).toBe('overview');
+      expect(getWeight(ordered[2])).toBe(5);
+      expect(getName(ordered[2])).toBe('settings');
 
       // Test route generation for each
-      const overviewRoute = generateVirtualTypeRoute('my-product', ordered[1].name);
+      const overviewRoute = generateVirtualTypeRoute('my-product', getName(ordered[1]));
 
       expect(overviewRoute.name).toContain('overview');
 
@@ -449,9 +503,11 @@ describe('plugin-products-helpers', () => {
       ];
       const ordered = gatherChildrenOrdering(config);
 
-      expect(ordered[0].sideMenu?.children[0].name).toBe('page1'); // 100
-      expect(ordered[0].sideMenu?.children[1].name).toBe('page3'); // 50
-      expect(ordered[0].sideMenu?.children[2].name).toBe('page2'); // auto 49
+      const nested = getGroup(ordered[0]).sideMenu.children;
+
+      expect(getName(nested[0])).toBe('page1'); // 100
+      expect(getName(nested[1])).toBe('page3'); // 50
+      expect(getName(nested[2])).toBe('page2'); // auto 49
     });
   });
 });

--- a/shell/mixins/__tests__/brand.spec.ts
+++ b/shell/mixins/__tests__/brand.spec.ts
@@ -15,7 +15,7 @@ describe('brandMixin', () => {
     };
 
     const store = {
-      dispatch: (action, ...args) => {
+      dispatch: (action: string, ...args: unknown[]): unknown => {
         switch (action) {
         case 'management/findAll':
           if (args[0] === MANAGEMENT.SETTING) {

--- a/shell/mixins/__tests__/chart.test.ts
+++ b/shell/mixins/__tests__/chart.test.ts
@@ -1,12 +1,16 @@
 import ChartMixin from '@shell/mixins/chart';
 import { OPA_GATE_KEEPER_ID } from '@shell/pages/c/_cluster/gatekeeper/index.vue';
 import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import { APP_UPGRADE_STATUS } from '@shell/store/catalog';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { CATALOG } from '@shell/config/types';
 
 describe('chartMixin', () => {
-  const testCases = {
+  const testCases: {
+    opa: [string | null, number][],
+    managedApps: [boolean, string, number][],
+  } = {
     opa: [
       [null, 0],
       [OPA_GATE_KEEPER_ID, 1],
@@ -40,10 +44,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const instance = mount(
         DummyComponent,
@@ -84,10 +88,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const instance = mount(
         DummyComponent,
@@ -128,10 +132,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -186,10 +190,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -254,10 +258,15 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      // `mode` is owned by the component hosting the mixin (see `shell/pages/c/_cluster/apps/charts/install.vue`),
+      // the mixin's `fetchChart` only sets it
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+        data(): { mode: string | null } {
+          return { mode: null };
+        },
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -283,10 +292,10 @@ describe('chartMixin', () => {
   });
 
   describe('action', () => {
-    const DummyComponent = {
+    const DummyComponent = defineComponent({
       mixins:   [ChartMixin],
       template: '<div></div>',
-    };
+    });
 
     const mockStore = {
       dispatch: jest.fn(() => Promise.resolve()),
@@ -433,10 +442,10 @@ describe('chartMixin', () => {
   });
 
   describe('isChartTargeted', () => {
-    const DummyComponent = {
+    const DummyComponent = defineComponent({
       mixins:   [ChartMixin],
       template: '<div></div>',
-    };
+    });
 
     const mockStore = {
       dispatch: jest.fn(() => Promise.resolve()),
@@ -525,10 +534,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -603,10 +612,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -624,7 +633,7 @@ describe('chartMixin', () => {
           }
         });
 
-      const result = (wrapper.vm as any).mappedVersions;
+      const result = wrapper.vm.mappedVersions;
 
       expect(result[0].label).toBe('1.0.0 (Current, Linux-only)');
     });
@@ -650,10 +659,10 @@ describe('chartMixin', () => {
         }
       };
 
-      const DummyComponent = {
+      const DummyComponent = defineComponent({
         mixins:   [ChartMixin],
         template: '<div></div>',
-      };
+      });
 
       const wrapper = mount(
         DummyComponent,
@@ -671,7 +680,7 @@ describe('chartMixin', () => {
           }
         });
 
-      const result = (wrapper.vm as any).mappedVersions;
+      const result = wrapper.vm.mappedVersions;
 
       expect(result[0].label).toBe('1.0.0 (Current)');
     });

--- a/shell/models/__tests__/management.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/management.cattle.io.cluster.test.ts
@@ -13,14 +13,14 @@ jest.mock('@shell/utils/download', () => {
 
 describe('class MgmtCluster', () => {
   describe('provisioner', () => {
-    const testCases = [
+    const testCases: [Record<string, string>, string][] = [
       [{ provider: 'rke2', driver: 'imported' }, 'rke2'],
       [{ provider: 'k3s', driver: 'K3S' }, 'K3S'],
       [{ provider: 'aks', driver: 'AKS' }, 'AKS'],
       [{}, 'imported'],
     ];
 
-    it.each(testCases)('should return provisioner value properly based on the props data', (clusterData: Object, expected: String) => {
+    it.each(testCases)('should return provisioner value properly based on the props data', (clusterData, expected) => {
       const cluster = new MgmtCluster({ status: clusterData });
 
       expect(cluster.provisioner).toBe(expected);

--- a/shell/models/__tests__/namespace.test.ts
+++ b/shell/models/__tests__/namespace.test.ts
@@ -25,11 +25,13 @@ describe('class Namespace', () => {
     ])('should return true if it has the correct annotation', (name, annotation, expectation) => {
       const namespace = new Namespace({});
 
-      namespace.metadata = { ...namespace.metadata, name };
+      const metadata: { name: string, annotations?: Record<string, string> } = { ...namespace.metadata, name };
 
       if (annotation) {
-        namespace.metadata.annotations = { [annotation]: 'true' };
+        metadata.annotations = { [annotation]: 'true' };
       }
+
+      namespace.metadata = metadata;
 
       expect(namespace.isSystem).toBe(expectation);
     });
@@ -76,11 +78,13 @@ describe('class Namespace', () => {
     ])('should return a value if is system AND has the correct prefix', (name, annotation, expectation) => {
       const namespace = new Namespace({});
 
-      namespace.metadata = { ...namespace.metadata, name };
+      const metadata: { name: string, annotations?: Record<string, string> } = { ...namespace.metadata, name };
 
       if (annotation) {
-        namespace.metadata.annotations = { [annotation]: 'true' };
+        metadata.annotations = { [annotation]: 'true' };
       }
+
+      namespace.metadata = metadata;
 
       expect(namespace.isObscure).toBe(expectation);
     });
@@ -188,7 +192,7 @@ describe('class Namespace', () => {
       const moveAction = namespace.availableActions.find((a: any) => a.action === 'move');
 
       expect(moveAction).toBeDefined();
-      expect(moveAction.enabled).toBe(true);
+      expect(moveAction?.enabled).toBe(true);
     });
 
     it('should exclude the move action when user cannot update the namespace', () => {
@@ -346,8 +350,9 @@ describe('class Namespace', () => {
       const result = namespace.glance;
       const typeItem = result.find((item: any) => item.name === 'type');
 
-      expect(typeItem.formatter).toBeUndefined();
-      expect(typeItem.formatterOpts).toBeUndefined();
+      expect(typeItem).toBeDefined();
+      expect(typeItem?.formatter).toBeUndefined();
+      expect(typeItem?.formatterOpts).toBeUndefined();
     });
 
     it('should keep type Link formatter when in manager product with local cluster access', () => {
@@ -371,8 +376,9 @@ describe('class Namespace', () => {
       const result = namespace.glance;
       const typeItem = result.find((item: any) => item.name === 'type');
 
-      expect(typeItem.formatter).toBe('Link');
-      expect(typeItem.formatterOpts).toBeDefined();
+      expect(typeItem).toBeDefined();
+      expect(typeItem?.formatter).toBe('Link');
+      expect(typeItem?.formatterOpts).toBeDefined();
     });
 
     it('should keep type Link formatter when not in manager product', () => {
@@ -392,8 +398,9 @@ describe('class Namespace', () => {
       const result = namespace.glance;
       const typeItem = result.find((item: any) => item.name === 'type');
 
-      expect(typeItem.formatter).toBe('Link');
-      expect(typeItem.formatterOpts).toBeDefined();
+      expect(typeItem).toBeDefined();
+      expect(typeItem?.formatter).toBe('Link');
+      expect(typeItem?.formatterOpts).toBeDefined();
     });
   });
 

--- a/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -34,21 +34,28 @@ jest.mock('@shell/utils/clipboard', () => {
 });
 
 describe('class ProvCluster', () => {
-  const gkeClusterWithPrivateEndpoint = {
+  type PrivateHostedCluster = {
+    clusterName: string,
+    provisioner: string,
+    spec: Record<string, unknown>,
+    mgmt: MgmtCluster,
+  };
+
+  const gkeClusterWithPrivateEndpoint: PrivateHostedCluster = {
     clusterName: 'test',
     provisioner: 'GKE',
     spec:        { },
     mgmt:        new MgmtCluster({ spec: { gkeConfig: { privateClusterConfig: { enablePrivateEndpoint: true } } } }),
   };
 
-  const eksClusterWithPrivateEndpoint = {
+  const eksClusterWithPrivateEndpoint: PrivateHostedCluster = {
     clusterName: 'test',
     provisioner: 'EKS',
     spec:        { },
     mgmt:        new MgmtCluster({ spec: { eksConfig: { privateAccess: true } } }),
   };
 
-  const aksClusterWithPrivateEndpoint = {
+  const aksClusterWithPrivateEndpoint: PrivateHostedCluster = {
     clusterName: 'test',
     provisioner: 'AKS',
     spec:        { },
@@ -57,7 +64,7 @@ describe('class ProvCluster', () => {
 
   // Related to https://github.com/rancher/dashboard/issues/9402
   describe('isHostedKubernetesProvider + isPrivateHostedProvider', () => {
-    const testCases = [
+    const testCases: [PrivateHostedCluster, boolean][] = [
       [gkeClusterWithPrivateEndpoint, true],
       [eksClusterWithPrivateEndpoint, true],
       [aksClusterWithPrivateEndpoint, true],
@@ -67,7 +74,7 @@ describe('class ProvCluster', () => {
       jest.clearAllMocks();
     };
 
-    it.each(testCases)('should return the isHostedKubernetesProvider and isPrivateHostedProvider values properly based on the props data', (clusterData: Object, expected: Boolean) => {
+    it.each(testCases)('should return the isHostedKubernetesProvider and isPrivateHostedProvider values properly based on the props data', (clusterData, expected) => {
       const cluster = new ProvCluster({ spec: clusterData.spec });
 
       jest.spyOn(clusterData.mgmt, 'provCluster', 'get').mockReturnValue(
@@ -215,6 +222,15 @@ describe('class ProvCluster', () => {
   });
 
   describe('hasError', () => {
+    type ClusterCondition = {
+      error: boolean,
+      lastUpdateTime: string,
+      status: string,
+      message?: string,
+      transitioning: boolean,
+      type: string,
+    };
+
     const conditionsWithoutError = [
       {
         error:          false,
@@ -292,7 +308,7 @@ describe('class ProvCluster', () => {
       }
     ];
 
-    const testCases = [
+    const testCases: [string, ClusterCondition[], boolean][] = [
       ['conditionsWithoutError', conditionsWithoutError, false],
       ['conditionsWithoutReady', conditionsWithoutReady, true],
       ['noConditions', noConditions, false],
@@ -306,7 +322,7 @@ describe('class ProvCluster', () => {
       jest.clearAllMocks();
     };
 
-    it.each(testCases)('should return the hasError value properly based on the "status.conditions" props data for testcase %p', (testName: string, conditions: Array, expected: Boolean) => {
+    it.each(testCases)('should return the hasError value properly based on the "status.conditions" props data for testcase %p', (testName, conditions, expected) => {
       const ctx = { rootGetters: { 'management/byId': jest.fn() } };
       const mgmtCluster = new MgmtCluster({ status: { conditions } }, ctx);
       const cluster = new ProvCluster({}, ctx);

--- a/shell/models/__tests__/workload.test.ts
+++ b/shell/models/__tests__/workload.test.ts
@@ -147,7 +147,11 @@ describe('class: Workload', () => {
       });
 
       workload.scaleUp = scaleUpMock;
-      workload.$store = { dispatch: dispatchMock };
+      // `$store` does not exist anywhere on the model hierarchy, so the catch block in `scale` only
+      // reaches a dispatch because the test injects one. Once `workload.js:200` is corrected to
+      // `this.$dispatch(...)` the assertion below passes unchanged, since `$dispatch` is
+      // `this.$ctx.dispatch`, the same `dispatchMock`, and only this line gets deleted.
+      Object.defineProperty(workload, '$store', { get: () => ({ dispatch: dispatchMock }) });
 
       await workload.scale(true);
 
@@ -276,9 +280,9 @@ describe('class: Workload', () => {
       const card = workload.podsCard;
 
       expect(card).not.toBeNull();
-      expect(card.props.title).toBe('component.resource.detail.card.podsCard.title');
-      expect(card.props.showScaling).toBe(true);
-      expect(card.props.noResourcesMessage).toBe('component.resource.detail.card.podsCard.noPods');
+      expect(card?.props.title).toBe('component.resource.detail.card.podsCard.title');
+      expect(card?.props.showScaling).toBe(true);
+      expect(card?.props.noResourcesMessage).toBe('component.resource.detail.card.podsCard.noPods');
     });
 
     it('should return card for DaemonSet type without scaling', () => {
@@ -298,7 +302,7 @@ describe('class: Workload', () => {
       const card = workload.podsCard;
 
       expect(card).not.toBeNull();
-      expect(card.props.showScaling).toBe(false);
+      expect(card?.props.showScaling).toBe(false);
     });
 
     it('should return null for unsupported types like CronJob', () => {
@@ -334,8 +338,8 @@ describe('class: Workload', () => {
       const card = workload.podsCard;
 
       expect(card).not.toBeNull();
-      expect(card.props.resources).toStrictEqual([]);
-      expect(card.props.noResourcesMessage).toBe('component.resource.detail.card.podsCard.noPods');
+      expect(card?.props.resources).toStrictEqual([]);
+      expect(card?.props.noResourcesMessage).toBe('component.resource.detail.card.podsCard.noPods');
     });
 
     it('should return null for non-scalable type with empty pods', () => {
@@ -391,7 +395,7 @@ describe('class: Workload', () => {
 
       const card = workload.podsCard;
 
-      expect(card.props.showScaling).toBe(false);
+      expect(card?.props.showScaling).toBe(false);
     });
   });
 
@@ -414,8 +418,8 @@ describe('class: Workload', () => {
       const card = workload.jobsCard;
 
       expect(card).not.toBeNull();
-      expect(card.props.title).toBe('component.resource.detail.card.jobsCard.title');
-      expect(card.props.showScaling).toBe(false);
+      expect(card?.props.title).toBe('component.resource.detail.card.jobsCard.title');
+      expect(card?.props.showScaling).toBe(false);
     });
 
     it('should return null for non-CronJob types', () => {
@@ -479,7 +483,7 @@ describe('class: Workload', () => {
       const cards = workload.cards;
 
       // Cards should include podsCard (not null), jobsCard (null for deployment), and _cards from parent
-      const nonNullCards = cards.filter((c: any) => c !== null);
+      const nonNullCards = cards.filter((c): c is NonNullable<typeof c> => c !== null);
 
       expect(nonNullCards.length).toBeGreaterThanOrEqual(1);
       expect(nonNullCards[0].props.title).toBe('component.resource.detail.card.podsCard.title');
@@ -796,7 +800,7 @@ describe('class: Workload', () => {
       const ingressesRow = rows.find((r: any) => r.label === 'component.resource.detail.card.resourcesCard.rows.ingresses');
 
       expect(ingressesRow).toBeDefined();
-      expect(ingressesRow.to).toBe('#ingresses');
+      expect(ingressesRow?.to).toBe('#ingresses');
     });
 
     it('should order services before ingresses', () => {

--- a/shell/plugins/steve/__tests__/mutations.test.ts
+++ b/shell/plugins/steve/__tests__/mutations.test.ts
@@ -9,7 +9,8 @@ describe('steve-store: mutations', () => {
       const res = mutationHelpers.loadAll.createNewEntry();
       const pod = res.params[1].data[0];
 
-      res.params[0].podsByNamespace = {};
+      // `params[0]` is the store state; the steve mutation is what adds `podsByNamespace` to it
+      (res.params[0] as Record<string, any>).podsByNamespace = {};
       res.expected.podsByNamespace = {
         [pod.namespace]: {
           list: [new Resource(pod)],
@@ -34,7 +35,7 @@ describe('steve-store: mutations', () => {
     ])('%s', (_, run) => { // eslint-disable-line jest/no-identical-title
       mutations.loadAdd(...run.params);
       const { map: cacheMap, ...cacheState } = run.params[0].types?.[POD] ;
-      const cachePodsByNamespace = run.params[0].podsByNamespace ;
+      const cachePodsByNamespace = (run.params[0] as Record<string, any>).podsByNamespace;
       const { map: expectedMap, ...expected } = run.expected.types?.[POD];
       const expectedPodsByNamespace = run.expected.podsByNamespace ;
 

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -27,7 +27,7 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/config/product/*.js --declaration
 # # store
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/features.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/plugins.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
-${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/prefs.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
+${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/prefs.ts --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/store-types.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/type-map.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 

--- a/shell/store/__tests__/action-menu.test.ts
+++ b/shell/store/__tests__/action-menu.test.ts
@@ -437,7 +437,7 @@ describe('action-menu store', () => {
         s.modalData = { key: 'old' };
         mutations.updateModalData(s, [{ key: 'key', value: 'new' }]);
 
-        expect(s.modalData.key).toStrictEqual('new');
+        expect(s.modalData).toStrictEqual({ key: 'new' });
       });
     });
 

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -468,14 +468,14 @@ describe('catalog', () => {
         };
 
         const allCharts = [regularChart, deprecatedChart];
-        const state = {};
+        const localState = state();
         const localGetters = {
           charts: allCharts,
-          chart:  (args: any) => getters.chart(state, { charts: allCharts })(args)
+          chart:  (args: any) => getters.chart(localState, { charts: allCharts })(args)
         };
 
         // Scenario 1: Get a version from a regular chart
-        const result1 = getters.version(state, localGetters)({
+        const result1 = getters.version(localState, localGetters)({
           repoType:       'cluster',
           repoName:       'rancher-charts',
           chartName:      'regular-chart',
@@ -486,7 +486,7 @@ describe('catalog', () => {
         expect(result1).toStrictEqual({ version: '1.2.3' });
 
         // Scenario 2: Get a version from a deprecated chart
-        const result2 = getters.version(state, localGetters)({
+        const result2 = getters.version(localState, localGetters)({
           repoType:       'cluster',
           repoName:       'rancher-charts',
           chartName:      'deprecated-chart',
@@ -497,7 +497,7 @@ describe('catalog', () => {
         expect(result2).toStrictEqual({ version: '2.0.0' });
 
         // Scenario 3: Try to get a version from a deprecated chart without the flag should fail
-        const result3 = getters.version(state, localGetters)({
+        const result3 = getters.version(localState, localGetters)({
           repoType:       'cluster',
           repoName:       'rancher-charts',
           chartName:      'deprecated-chart',

--- a/shell/store/__tests__/growl.test.ts
+++ b/shell/store/__tests__/growl.test.ts
@@ -13,10 +13,10 @@ describe('growl store', () => {
 
   describe('getters', () => {
     const item1 = {
-      id: 1, color: 'success', title: 'item 1'
+      id: 1, started: 1000, color: 'success', title: 'item 1'
     };
     const item2 = {
-      id: 2, color: 'error', title: 'item 2'
+      id: 2, started: 2000, color: 'error', title: 'item 2'
     };
     let mockState: ReturnType<typeof state>;
 

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -34,18 +34,11 @@ function makeTranslations() {
 }
 
 type I18nState = ReturnType<typeof state>;
-type TestI18nState = Omit<I18nState, 'selected' | 'previous' | 'default' | 'available' | 'translations'> & {
-  selected: string | null;
-  previous: string | null;
-  default: string;
-  available: string[];
-  translations: Record<string, any>;
-};
 
-function makeState(overrides?: Partial<TestI18nState>): TestI18nState {
-  const base = state() as TestI18nState;
+function makeState(overrides?: Partial<I18nState>): I18nState {
+  const base = state();
 
-  base.translations = makeTranslations() as any;
+  base.translations = makeTranslations();
   base.selected = 'en-us';
   base.default = 'en-us';
   base.available = ['en-us', 'zh-hans'];
@@ -55,7 +48,7 @@ function makeState(overrides?: Partial<TestI18nState>): TestI18nState {
 
 // ----- helpers to build mock getters (for testing getters.withFallback / multiWithFallback) -----
 
-function makeMockGetters(st: TestI18nState) {
+function makeMockGetters(st: I18nState) {
   const g: Record<string, any> = {};
 
   g.t = getters.t(st);

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -188,6 +188,29 @@ describe('i18n store', () => {
         expect(translate('template.message', { count: 3 })).toStrictEqual('Found 3 items');
       });
 
+      it('formats an ICU argument that needs locale data when no locale has been selected yet', () => {
+        // `selected` is null until the setSelected mutation runs. IntlMessageFormat only
+        // substitutes its own default for `undefined`, so a null locale reaches Intl.* and
+        // throws. t() has to fall back to the store default instead.
+        const s = makeState({ selected: null });
+
+        (s.translations as any)['en-us'].preInitPlural = '{count, plural, one {# cluster} other {# clusters}}';
+
+        const translate = getters.t(s);
+
+        expect(translate('preInitPlural', { count: 2 })).toStrictEqual('2 clusters');
+      });
+
+      it('formats a number argument when no locale has been selected yet', () => {
+        const s = makeState({ selected: null });
+
+        (s.translations as any)['en-us'].preInitNumber = 'There are {count, number} items';
+
+        const translate = getters.t(s);
+
+        expect(translate('preInitNumber', { count: 1234 })).toStrictEqual('There are 1,234 items');
+      });
+
       it('returns undefined when the key is not found in any locale', () => {
         const s = makeState({ selected: 'en-us' });
         const translate = getters.t(s);
@@ -326,6 +349,20 @@ describe('i18n store', () => {
 
         // 'onlyInZh' is not in the default (en-us) translations
         expect(check('onlyInZh')).toBe(false);
+      });
+
+      it('shares the formatter cache with t() when no locale has been selected yet', () => {
+        // Both getters have to resolve the same locale, or exists() looks the message up
+        // under a different cache key than the one t() wrote it to.
+        const s = makeState({ selected: null });
+
+        (s.translations as any)['en-us'].preInitCached = '{count, plural, one {# cluster} other {# clusters}}';
+
+        getters.t(s)('preInitCached', { count: 1 });
+
+        delete (s.translations as any)['en-us'].preInitCached;
+
+        expect(getters.exists(s)('preInitCached')).toBe(true);
       });
 
       it('returns true for a key in the default translations regardless of selected locale', () => {

--- a/shell/store/__tests__/wm.test.ts
+++ b/shell/store/__tests__/wm.test.ts
@@ -44,7 +44,7 @@ describe('wm store', () => {
       localStorage.setItem(STORAGE_KEY[BOTTOM], '300');
       const fresh = state();
 
-      expect(fresh.panelHeight[BOTTOM]).toStrictEqual('300');
+      expect(fresh.panelHeight[BOTTOM]).toStrictEqual(300);
     });
 
     it('reads panelWidth for LEFT and RIGHT from localStorage on initialization', () => {
@@ -52,14 +52,26 @@ describe('wm store', () => {
       localStorage.setItem(STORAGE_KEY[RIGHT], '350');
       const fresh = state();
 
-      expect(fresh.panelWidth[LEFT]).toStrictEqual('250');
-      expect(fresh.panelWidth[RIGHT]).toStrictEqual('350');
+      expect(fresh.panelWidth[LEFT]).toStrictEqual(250);
+      expect(fresh.panelWidth[RIGHT]).toStrictEqual(350);
     });
 
     it('panelHeight and panelWidth are null when localStorage is empty', () => {
       expect(s.panelHeight[BOTTOM]).toBeNull();
       expect(s.panelWidth[LEFT]).toBeNull();
       expect(s.panelWidth[RIGHT]).toBeNull();
+    });
+
+    it.each([
+      ['a non-numeric value', 'not-a-number'],
+      ['the string NaN', 'NaN'],
+      ['a null written by an earlier session', 'null'],
+      ['an empty string', ''],
+    ])('panelHeight is null when localStorage holds %s', (_label, stored) => {
+      localStorage.setItem(STORAGE_KEY[BOTTOM], stored);
+      const fresh = state();
+
+      expect(fresh.panelHeight[BOTTOM]).toBeNull();
     });
   });
 

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -767,6 +767,28 @@ export function compatibleVersionsFor(chart, os, includePrerelease = true) {
   });
 }
 
+/**
+ * Filter a list of charts and sort what is left.
+ *
+ * @typedef {object} FilterChartsOptions
+ * @property {string} [clusterProvider]
+ * @property {string | string[]} [operatingSystems] - Single os or a list of them, as taken by `compatibleVersionsFor`.
+ * @property {string[]} [category]
+ * @property {string[]} [tag]
+ * @property {string} [searchQuery]
+ * @property {string} [sort] - Which order to sort in, one of the `CATALOG_SORT_OPTIONS` values.
+ * When unset, the charts are sorted by certification, then repo, then name.
+ * @property {boolean} [showDeprecated]
+ * @property {boolean} [showHidden]
+ * @property {boolean} [showPrerelease]
+ * @property {string[]} [hideRepos]
+ * @property {(string | undefined)[]} [showRepos] - Repo keys to keep, which callers build from a repo that may not have loaded.
+ * @property {string | string[]} [showTypes]
+ * @property {string[]} [hideTypes]
+ *
+ * @param {any[]} charts - The charts to filter.
+ * @param {FilterChartsOptions} [opt] - Which charts to keep and how to sort them.
+ */
 export function filterAndArrangeCharts(charts, {
   clusterProvider = '',
   operatingSystems,

--- a/shell/store/catalog.ts
+++ b/shell/store/catalog.ts
@@ -11,6 +11,7 @@ import { ensureRegex } from '@shell/utils/string';
 import { isPrerelease } from '@shell/utils/version';
 import difference from 'lodash/difference';
 import { lookup } from '@shell/plugins/dashboard-store/model-loader';
+import { ActionContext, MutationTree } from 'vuex';
 
 const ALLOWED_CATEGORIES = [
   'Storage',
@@ -25,10 +26,9 @@ const ALLOWED_CATEGORIES = [
 ];
 
 const CERTIFIED_SORTS = {
-  [CATALOG_ANNOTATIONS._RANCHER]:      1,
-  [CATALOG_ANNOTATIONS._EXPERIMENTAL]: 1,
-  [CATALOG_ANNOTATIONS._PARTNER]:      2,
-  other:                               3,
+  [CATALOG_ANNOTATIONS._RANCHER]: 1,
+  [CATALOG_ANNOTATIONS._PARTNER]: 2,
+  other:                          3,
 };
 
 export const APP_STATUS = {
@@ -47,7 +47,27 @@ export const APP_UPGRADE_STATUS = {
 export const WINDOWS = 'windows';
 export const LINUX = 'linux';
 
-export const state = function() {
+/**
+ * Charts, repos and version info are model instances from the steve store, which is untyped, so
+ * they are `any` here.
+ */
+export interface CatalogState {
+  loaded: Record<string, boolean>;
+  clusterRepos: any[];
+  namespacedRepos: any[];
+  charts: Record<string, any>;
+  /** Version info by `repoType/repoName/chartName/versionName`. */
+  versionInfos: Record<string, any>;
+  config: { namespace: string };
+  /** Which store the repos were loaded from, `cluster` or `management`. */
+  inStore: string | undefined;
+  /** Set by `setCharts`, so unset until the first load. */
+  errors?: string[];
+}
+
+type CatalogContext = ActionContext<CatalogState, any>;
+
+export const state = function(): CatalogState {
   return {
     loaded:          {},
     clusterRepos:    [],
@@ -59,14 +79,18 @@ export const state = function() {
   };
 };
 
+/**
+ * The getters are annotated one by one rather than as a vuex `GetterTree`, because `Getter`
+ * declares all four of its arguments as required and the unit tests call these with two.
+ */
 export const getters = {
-  isLoaded(state) {
-    return (repo) => {
+  isLoaded(state: CatalogState) {
+    return (repo: any) => {
       return !!state.loaded[repo._key];
     };
   },
 
-  repos(state) {
+  repos(state: CatalogState) {
     const clustered = state.clusterRepos || [];
     const namespaced = state.namespacedRepos || [];
 
@@ -74,20 +98,20 @@ export const getters = {
   },
 
   // Raw charts
-  rawCharts(state) {
+  rawCharts(state: CatalogState) {
     return state.charts;
   },
 
-  repo(state, getters) {
-    return ({ repoType, repoName }) => {
+  repo(state: CatalogState, getters: any) {
+    return ({ repoType, repoName }: { repoType?: string, repoName?: string }) => {
       const ary = (repoType === 'cluster' ? state.clusterRepos : state.namespacedRepos);
 
       return findBy(ary, 'metadata.name', repoName);
     };
   },
 
-  charts(state, getters, rootState, rootGetters) {
-    const repoKeys = getters.repos.map((x) => x._key);
+  charts(state: CatalogState, getters: any, rootState: any, rootGetters: any) {
+    const repoKeys = getters.repos.map((x: any) => x._key);
     let cluster = rootGetters['currentCluster'];
 
     if ( rootGetters['currentProduct']?.inStore === 'management' ) {
@@ -112,9 +136,17 @@ export const getters = {
     return sortBy(out, ['certifiedSort', 'repoName', 'chartName']);
   },
 
-  chart(state, getters) {
+  chart(state: CatalogState, getters: any) {
     return ({
       key, repoType, repoName, chartName, includeHidden, showDeprecated, multiple
+    }: {
+      key?: string,
+      repoType?: string,
+      repoName?: string,
+      chartName?: string,
+      includeHidden?: boolean,
+      showDeprecated?: boolean,
+      multiple?: boolean,
     }) => {
       if ( key && !repoType && !repoName && !chartName) {
         const parsed = parseKey(key);
@@ -132,7 +164,7 @@ export const getters = {
       });
 
       if ( includeHidden === false ) {
-        matchingCharts = matchingCharts.filter((x) => !x.hidden);
+        matchingCharts = matchingCharts.filter((x: any) => !x.hidden);
       }
 
       if ( !matchingCharts.length ) {
@@ -147,8 +179,8 @@ export const getters = {
     };
   },
 
-  isInstalled(state, getters, rootState, rootGetters) {
-    return ({ gvr }) => {
+  isInstalled(state: CatalogState, getters: any, rootState: any, rootGetters: any) {
+    return ({ gvr }: { gvr: string }) => {
       let name, version;
       const idx = gvr.indexOf('/');
 
@@ -170,9 +202,11 @@ export const getters = {
     };
   },
 
-  versionSatisfying(state, getters) {
+  versionSatisfying(state: CatalogState, getters: any) {
     return ({
       repoType, repoName, constraint, chartVersion
+    }: {
+      repoType?: string, repoName?: string, constraint: string, chartVersion: string
     }) => {
       let name, wantVersion;
       const idx = constraint.indexOf('=');
@@ -188,7 +222,7 @@ export const getters = {
       name = name.toLowerCase().trim();
       chartVersion = normalizeVersion(chartVersion);
 
-      const matching = getters.charts.filter((chart) => chart.chartName.toLowerCase().trim() === name);
+      const matching = getters.charts.filter((chart: any) => chart.chartName.toLowerCase().trim() === name);
 
       if ( !matching.length ) {
         return;
@@ -204,9 +238,9 @@ export const getters = {
       if ( wantVersion === 'latest' ) {
         version = chart.versions[0];
       } else if ( wantVersion === 'match' || wantVersion === 'matching' ) {
-        version = chart.versions.find((v) => normalizeVersion(v.version) === chartVersion);
+        version = chart.versions.find((v: any) => normalizeVersion(v.version) === chartVersion);
       } else {
-        version = chart.versions.find((v) => normalizeVersion(v.version) === wantVersion);
+        version = chart.versions.find((v: any) => normalizeVersion(v.version) === wantVersion);
       }
 
       if ( version ) {
@@ -215,9 +249,9 @@ export const getters = {
     };
   },
 
-  versionProviding(state, getters) {
-    return ({ repoType, repoName, gvr }) => {
-      const matching = getters.charts.filter((chart) => chart.provides.includes(gvr) );
+  versionProviding(state: CatalogState, getters: any) {
+    return ({ repoType, repoName, gvr }: { repoType?: string, repoName?: string, gvr: string }) => {
+      const matching = getters.charts.filter((chart: any) => chart.provides.includes(gvr) );
 
       if ( !matching.length ) {
         return;
@@ -227,7 +261,7 @@ export const getters = {
         preferSameRepo(matching, repoType, repoName);
       }
 
-      const version = matching[0].versions.find((version) => version.annotations?.[CATALOG_ANNOTATIONS.PROVIDES] === gvr);
+      const version = matching[0].versions.find((version: any) => version.annotations?.[CATALOG_ANNOTATIONS.PROVIDES] === gvr);
 
       if ( version ) {
         return clone(version);
@@ -235,9 +269,15 @@ export const getters = {
     };
   },
 
-  version(state, getters) {
+  version(state: CatalogState, getters: any) {
     return ({
       repoType, repoName, chartName, versionName, showDeprecated
+    }: {
+      repoType?: string,
+      repoName?: string,
+      chartName?: string,
+      versionName?: string,
+      showDeprecated?: boolean,
     }) => {
       const chart = getters['chart']({
         repoType, repoName, chartName, showDeprecated
@@ -261,48 +301,48 @@ export const getters = {
     };
   },
 
-  errors(state) {
+  errors(state: CatalogState) {
     return state.errors || [];
   },
 
-  haveComponent() {
-    return (name) => {
+  haveComponent(state: CatalogState, getters: any) {
+    return (name: string) => {
       return getters['type-map/hasCustomChart'](name);
     };
   },
 
-  importComponent(state, getters) {
-    return (name) => {
+  importComponent(state: CatalogState, getters: any) {
+    return (name: string) => {
       return getters['type-map/importChart'](name);
     };
   },
 
-  inStore(state) {
+  inStore(state: CatalogState) {
     return state.inStore;
   },
 
-  classify: (state, getters, rootState) => (obj) => {
+  classify: (state: CatalogState, getters: any, rootState: any) => (obj: any) => {
     return lookup(state.config.namespace, obj?.type, obj?.metadata?.name, rootState);
   },
 };
 
-export const mutations = {
+export const mutations: MutationTree<CatalogState> = {
   reset(currentState) {
     const newState = state();
 
     Object.assign(currentState, newState);
   },
 
-  setInStore(state, inStore) {
+  setInStore(state, inStore: string) {
     state.inStore = inStore;
   },
 
-  setRepos(state, { cluster, namespaced }) {
+  setRepos(state, { cluster, namespaced }: { cluster: any[], namespaced: any[] }) {
     state.clusterRepos = cluster;
     state.namespacedRepos = namespaced;
   },
 
-  addClusterRepo(state, repo) {
+  addClusterRepo(state, repo: any) {
     if (!state.clusterRepos) {
       state.clusterRepos = [];
     }
@@ -312,7 +352,7 @@ export const mutations = {
     }
   },
 
-  setCharts(state, { charts, errors = [], loaded = [] }) {
+  setCharts(state, { charts, errors = [], loaded = [] }: { charts: Record<string, any>, errors?: string[], loaded?: any[] }) {
     state.charts = charts;
     state.errors = errors;
 
@@ -321,11 +361,11 @@ export const mutations = {
     }
   },
 
-  setVersions(state, versions) {
+  setVersions(state, versions: Record<string, any>) {
     state.versionInfos = versions;
   },
 
-  cacheVersion(state, { key, info }) {
+  cacheVersion(state, { key, info }: { key: string, info: any }) {
     state.versionInfos[key] = info;
   }
 };
@@ -340,12 +380,12 @@ export const actions = {
    * repos will be fetched, and only their existing charts will be cleared from the cache to avoid
    * duplicate chart entries or wiping out unrelated chart data.
    */
-  async load(ctx, { force, reset, repoKeys = [] } = {}) {
+  async load(ctx: CatalogContext, { force, reset, repoKeys = [] }: { force?: boolean, reset?: boolean, repoKeys?: string[] } = {}) {
     const {
       state, getters, rootGetters, commit, dispatch
     } = ctx;
 
-    let promises = {};
+    let promises: Record<string, Promise<any>> = {};
     // Installing an app? This is fine (in cluster store)
     // Fetching list of cluster templates? This is fine (in management store)
     // Installing a cluster template? This isn't fine (in cluster store as per installing app, but if there is no cluster we need to default to management)
@@ -364,11 +404,11 @@ export const actions = {
 
     // As per comment above, when there are no clusters this will be management. Store it such that it can be used for those cases
     commit('setInStore', inStore);
-    hash.cluster = hash.cluster?.filter((repo) => !(repo?.metadata?.annotations?.[CATALOG_ANNOTATIONS.HIDDEN_REPO] === 'true'));
+    hash.cluster = hash.cluster?.filter((repo: any) => !(repo?.metadata?.annotations?.[CATALOG_ANNOTATIONS.HIDDEN_REPO] === 'true'));
 
     commit('setRepos', hash);
 
-    const repos = getters['repos'];
+    const repos: any[] = getters['repos'];
     const loaded = [];
 
     promises = {};
@@ -393,8 +433,8 @@ export const actions = {
     }
 
     const res = await allHashSettled(promises);
-    const charts = reset ? {} : { ...state.charts };
-    let versionInfos = null;
+    const charts: Record<string, any> = reset ? {} : { ...state.charts };
+    let versionInfos: Record<string, any> | null = null;
 
     if (reset) {
       versionInfos = {};
@@ -455,7 +495,7 @@ export const actions = {
     }
   },
 
-  async loadRepo(ctx, { repoName }) {
+  async loadRepo(ctx: CatalogContext, { repoName }: { repoName: string }) {
     const {
       state, getters, rootGetters, commit, dispatch
     } = ctx;
@@ -506,8 +546,8 @@ export const actions = {
    * Globally refreshes all loaded repositories by triggering their refresh actions concurrently,
    * bypassing individual catalog loads, and then performs a single, global catalog/load.
    */
-  async refresh({ getters, commit, dispatch }) {
-    const promises = getters.repos.map((x) => x.refresh(false));
+  async refresh({ getters, commit, dispatch }: Pick<CatalogContext, 'getters' | 'commit' | 'dispatch'>) {
+    const promises = getters.repos.map((x: any) => x.refresh(false));
 
     // @TODO wait for repo state to indicate they're done once the API has that
 
@@ -520,8 +560,10 @@ export const actions = {
     Fetch full information about a specific version of a Helm chart,
     including the standard values and README.
   */
-  async getVersionInfo({ state, getters, commit }, {
+  async getVersionInfo({ state, getters, commit }: Pick<CatalogContext, 'state' | 'getters' | 'commit'>, {
     repoType, repoName, chartName, versionName
+  }: {
+    repoType: string, repoName: string, chartName: string, versionName: string
   }) {
     const key = `${ repoType }/${ repoName }/${ chartName }/${ versionName }`;
     let info = state.versionInfos[key];
@@ -546,7 +588,7 @@ export const actions = {
     return info;
   },
 
-  rehydrate(ctx) {
+  rehydrate(ctx: CatalogContext) {
     const { state, commit } = ctx;
     const charts = state.charts || {};
 
@@ -562,11 +604,11 @@ export const actions = {
   }
 };
 
-export function generateKey(repoType, repoName, chartName) {
+export function generateKey(repoType: string, repoName: string, chartName: string) {
   return `${ repoType }/${ repoName }/${ chartName }`;
 }
 
-export function parseKey(key) {
+export function parseKey(key: string) {
   const parts = key.split('/');
 
   return {
@@ -576,7 +618,7 @@ export function parseKey(key) {
   };
 }
 
-function addChart(ctx, map, chart, repo) {
+function addChart(ctx: CatalogContext, map: Record<string, any>, chart: any, repo: any) {
   const repoType = (repo.type === CATALOG.CLUSTER_REPO ? 'cluster' : 'namespace');
   const repoName = repo.metadata.name;
   const key = generateKey(repoType, repoName, chart.name);
@@ -692,7 +734,7 @@ function addChart(ctx, map, chart, repo) {
   }
 }
 
-function preferSameRepo(matching, repoType, repoName) {
+function preferSameRepo(matching: any[], repoType: string, repoName: string) {
   matching.sort((a, b) => {
     const aSameRepo = a.repoType === repoType && a.repoName === repoName ? 1 : 0;
     const bSameRepo = b.repoType === repoType && b.repoName === repoName ? 1 : 0;
@@ -707,14 +749,14 @@ function preferSameRepo(matching, repoType, repoName) {
   });
 }
 
-function normalizeVersion(v) {
+function normalizeVersion(v: string) {
   return v.replace(/^v/i, '').toLowerCase().trim();
 }
 
-function filterCategories(categories) {
+function filterCategories(categories?: string[]) {
   categories = (categories || []).map((x) => normalizeCategory(x));
 
-  const out = [];
+  const out: string[] = [];
 
   for ( const c of ALLOWED_CATEGORIES ) {
     if ( categories.includes(normalizeCategory(c)) ) {
@@ -725,11 +767,11 @@ function filterCategories(categories) {
   return out;
 }
 
-function normalizeCategory(c) {
+function normalizeCategory(c: string) {
   return c.replace(/\s+/g, '').toLowerCase();
 }
 
-export function normalizeFilterQuery(value) {
+export function normalizeFilterQuery(value?: string | string[] | null) {
   if (Array.isArray(value)) {
     return value.map((v) => v.toLowerCase());
   } else if (value) {
@@ -745,14 +787,15 @@ catalog.cattle.io/deplys-on-os: OS -> requires global.cattle.OS.enabled: true
 catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that are not OS
   default if not found: catalog.cattle.io/permits-os: linux
 */
-export function compatibleVersionsFor(chart, os, includePrerelease = true) {
+export function compatibleVersionsFor(chart: any, os?: string | string[], includePrerelease = true): any[] {
   const versions = chart.versions;
 
   if (os && !isArray(os)) {
-    os = [os];
+    // `isArray` is not a type predicate, so tell the compiler what it just checked
+    os = [os as string];
   }
 
-  return versions.filter((ver) => {
+  return versions.filter((ver: any) => {
     const osPermitted = getPermittedOSs(ver?.annotations, chart?.isRancherRepo);
 
     if ( !includePrerelease && isPrerelease(ver.version) ) {
@@ -767,29 +810,35 @@ export function compatibleVersionsFor(chart, os, includePrerelease = true) {
   });
 }
 
+export interface FilterChartsOptions {
+  clusterProvider?: string;
+  /** Single os or a list of them, as taken by `compatibleVersionsFor`. */
+  operatingSystems?: string | string[];
+  category?: string[];
+  tag?: string[];
+  searchQuery?: string;
+  /**
+   * Which order to sort in, one of the `CATALOG_SORT_OPTIONS` values. When unset, the charts are
+   * sorted by certification, then repo, then name.
+   */
+  sort?: string;
+  showDeprecated?: boolean;
+  showHidden?: boolean;
+  showPrerelease?: boolean;
+  hideRepos?: string[];
+  /** Repo keys to keep, which callers build from a repo that may not have loaded. */
+  showRepos?: (string | undefined)[];
+  /** Single type or a list of them. `provisioning.cattle.io.cluster/index.vue` passes a bare string. */
+  showTypes?: string | string[];
+  hideTypes?: string[];
+}
+
 /**
  * Filter a list of charts and sort what is left.
  *
- * @typedef {object} FilterChartsOptions
- * @property {string} [clusterProvider]
- * @property {string | string[]} [operatingSystems] - Single os or a list of them, as taken by `compatibleVersionsFor`.
- * @property {string[]} [category]
- * @property {string[]} [tag]
- * @property {string} [searchQuery]
- * @property {string} [sort] - Which order to sort in, one of the `CATALOG_SORT_OPTIONS` values.
- * When unset, the charts are sorted by certification, then repo, then name.
- * @property {boolean} [showDeprecated]
- * @property {boolean} [showHidden]
- * @property {boolean} [showPrerelease]
- * @property {string[]} [hideRepos]
- * @property {(string | undefined)[]} [showRepos] - Repo keys to keep, which callers build from a repo that may not have loaded.
- * @property {string | string[]} [showTypes]
- * @property {string[]} [hideTypes]
- *
- * @param {any[]} charts - The charts to filter.
- * @param {FilterChartsOptions} [opt] - Which charts to keep and how to sort them.
+ * @param charts - The charts to filter.
  */
-export function filterAndArrangeCharts(charts, {
+export function filterAndArrangeCharts(charts: any[], {
   clusterProvider = '',
   operatingSystems,
   category,
@@ -803,7 +852,7 @@ export function filterAndArrangeCharts(charts, {
   showRepos = [],
   showTypes = [],
   hideTypes = [],
-} = {}) {
+}: FilterChartsOptions = {}): any[] {
   const out = charts.filter((c) => {
     if (
       ( c.deprecated && !showDeprecated ) ||
@@ -822,12 +871,12 @@ export function filterAndArrangeCharts(charts, {
       return false;
     }
 
-    if (category?.length && !c.categories.some((cat) => category.includes(cat.toLowerCase()))) {
+    if (category?.length && !c.categories.some((cat: string) => category.includes(cat.toLowerCase()))) {
       // The category filter doesn't match
       return false;
     }
 
-    if (tag?.length && !c.tags.some((t) => tag.includes(t.toLowerCase()))) {
+    if (tag?.length && !c.tags.some((t: string) => tag.includes(t.toLowerCase()))) {
       // The tag filter doesn't match
       return false;
     }
@@ -841,7 +890,7 @@ export function filterAndArrangeCharts(charts, {
       for (const token of searchTokens) {
         const nameMatch = c.chartNameDisplay.match(token);
         const descMatch = chartDescription.match(token);
-        const keywordMatch = keywords.some((k) => k.match(token));
+        const keywordMatch = keywords.some((k: string) => k.match(token));
 
         if (!nameMatch && !descMatch && !keywordMatch) {
           return false;
@@ -874,7 +923,7 @@ export function filterAndArrangeCharts(charts, {
 /**
  * Detects if a repository is a Rancher repository.
  */
-export function isRancherRepo(repo, chart) {
+export function isRancherRepo(repo: any, chart: any) {
   return !!(chart?.isRancherRepo || repo?.isRancherSource);
 }
 
@@ -884,7 +933,7 @@ export function isRancherRepo(repo, chart) {
  * Otherwise, if the chart is from a Rancher repository, it defaults to Linux.
  * External charts with no annotations have no OS restrictions (returns empty array).
  */
-export function getPermittedOSs(annotations, isRancher) {
+export function getPermittedOSs(annotations?: Record<string, string>, isRancher?: boolean) {
   const permittedOs = annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS];
   const fallbackOs = isRancher ? LINUX : '';
 

--- a/shell/store/growl.js
+++ b/shell/store/growl.js
@@ -6,6 +6,32 @@ const DEFAULT_TIMEOUT = 5000;
 
 const MAX_GROWLS = 5;
 
+/**
+ * A growl on the stack, as built by the `add` mutation. `id` and `started` are
+ * always set there, everything else comes from the data given to the actions.
+ *
+ * @typedef {object} Growl
+ * @property {number} id - Incrementing id, unique within the stack.
+ * @property {number} started - Epoch ms the growl was added.
+ * @property {string} [color]
+ * @property {string} [icon]
+ * @property {number} [timeout]
+ * @property {string} [title]
+ * @property {string} [message]
+ * @property {string} [notification] - Id of the notification the growl came from.
+ * @property {string} [url] - Socket url, used by the steve subscribe plugin to find its own growl again.
+ * @property {number} [earliestClose] - Epoch ms before which the growl should not be closed.
+ */
+
+/**
+ * @typedef {object} GrowlState
+ * @property {number} nextId - Id the next added growl will get.
+ * @property {Growl[]} stack - Growls currently showing, newest first.
+ */
+
+/**
+ * @returns {GrowlState}
+ */
 export const state = function() {
   return {
     nextId: 1,

--- a/shell/store/growl.ts
+++ b/shell/store/growl.ts
@@ -1,6 +1,7 @@
+import { ActionContext } from 'vuex';
 import { clear, findBy, removeObject } from '@shell/utils/array';
 import { stringify } from '@shell/utils/error';
-import { NotificationLevel } from '@shell/types/notifications';
+import { Notification, NotificationLevel } from '@shell/types/notifications';
 
 const DEFAULT_TIMEOUT = 5000;
 
@@ -9,30 +10,40 @@ const MAX_GROWLS = 5;
 /**
  * A growl on the stack, as built by the `add` mutation. `id` and `started` are
  * always set there, everything else comes from the data given to the actions.
- *
- * @typedef {object} Growl
- * @property {number} id - Incrementing id, unique within the stack.
- * @property {number} started - Epoch ms the growl was added.
- * @property {string} [color]
- * @property {string} [icon]
- * @property {number} [timeout]
- * @property {string} [title]
- * @property {string} [message]
- * @property {string} [notification] - Id of the notification the growl came from.
- * @property {string} [url] - Socket url, used by the steve subscribe plugin to find its own growl again.
- * @property {number} [earliestClose] - Epoch ms before which the growl should not be closed.
  */
+export interface Growl {
+  id: number;
+  /**
+   * Epoch ms the growl was added.
+   */
+  started: number;
+  color?: string;
+  icon?: string;
+  timeout?: number;
+  title?: string;
+  message?: string;
+  notification?: string;
+  /**
+   * Socket url, used by the steve subscribe plugin to find its own growl again.
+   */
+  url?: string;
+  /**
+   * Epoch ms before which the growl should not be closed.
+   */
+  earliestClose?: number;
+}
 
-/**
- * @typedef {object} GrowlState
- * @property {number} nextId - Id the next added growl will get.
- * @property {Growl[]} stack - Growls currently showing, newest first.
- */
+export type GrowlData = Omit<Growl, 'id' | 'started'>;
 
-/**
- * @returns {GrowlState}
- */
-export const state = function() {
+export interface GrowlState {
+  nextId: number;
+  /** Newest first. */
+  stack: Growl[];
+}
+
+type GrowlContext = ActionContext<GrowlState, any>;
+
+export const state = function(): GrowlState {
   return {
     nextId: 1,
     stack:  [],
@@ -40,18 +51,18 @@ export const state = function() {
 };
 
 export const getters = {
-  find: (state) => ({ key, val }) => {
+  find: (state: GrowlState) => ({ key, val }: { key: string, val: unknown }) => {
     return findBy(state.stack, key, val);
   },
 
   // findBy is slow, so more efficient getter for id
-  byId: (state) => (id) => {
+  byId: (state: GrowlState) => (id: number) => {
     return state.stack.find((item) => item.id === id);
   }
 };
 
 export const mutations = {
-  add(state, data) {
+  add(state: GrowlState, data: GrowlData) {
     if (state.stack.length === MAX_GROWLS) {
       // Remove the last one
       state.stack.pop();
@@ -67,7 +78,7 @@ export const mutations = {
     ];
   },
 
-  remove(state, id) {
+  remove(state: GrowlState, id: number) {
     const obj = findBy(state.stack, 'id', id);
 
     if ( obj ) {
@@ -75,21 +86,21 @@ export const mutations = {
     }
   },
 
-  clear(state) {
+  clear(state: GrowlState) {
     clear(state.stack);
   }
 };
 
 export const actions = {
-  clear({ commit } ) {
+  clear({ commit }: GrowlContext ) {
     commit('clear');
   },
 
-  remove({ commit }, id ) {
+  remove({ commit }: GrowlContext, id: number ) {
     commit('remove', id);
   },
 
-  async close({ commit, dispatch, getters }, id ) {
+  async close({ commit, dispatch, getters }: GrowlContext, id: number ) {
     const growl = getters.byId(id);
 
     commit('remove', id);
@@ -100,9 +111,9 @@ export const actions = {
     }
   },
 
-  async success({ commit, dispatch }, data) {
+  async success({ commit, dispatch }: GrowlContext, data: GrowlData) {
     // Send a notification for the growl
-    const notification = await dispatch('notifications/fromGrowl', {
+    const notification: string = await dispatch('notifications/fromGrowl', {
       ...data,
       level: NotificationLevel.Success
     }, { root: true });
@@ -116,7 +127,7 @@ export const actions = {
     });
   },
 
-  info({ commit }, data) {
+  info({ commit }: GrowlContext, data: GrowlData) {
     commit('add', {
       color:   'info',
       icon:    'info',
@@ -125,9 +136,9 @@ export const actions = {
     });
   },
 
-  async warning({ commit, dispatch }, data) {
+  async warning({ commit, dispatch }: GrowlContext, data: GrowlData) {
     // Send a notification for the growl
-    const notification = await dispatch('notifications/fromGrowl', {
+    const notification: string = await dispatch('notifications/fromGrowl', {
       ...data,
       level: NotificationLevel.Warning
     }, { root: true });
@@ -141,9 +152,9 @@ export const actions = {
     });
   },
 
-  async error({ commit, dispatch }, data) {
+  async error({ commit, dispatch }: GrowlContext, data: GrowlData) {
     // Send a notification for the growl
-    const notification = await dispatch('notifications/fromGrowl', {
+    const notification: string = await dispatch('notifications/fromGrowl', {
       ...data,
       level: NotificationLevel.Error
     }, { root: true });
@@ -157,9 +168,9 @@ export const actions = {
     });
   },
 
-  async fromError({ commit, dispatch }, { title, err }) {
+  async fromError({ commit, dispatch }: GrowlContext, { title, err }: { title?: string, err?: unknown }) {
     // Send a notification for the growl
-    const notification = await dispatch('notifications/fromGrowl', {
+    const notification: string = await dispatch('notifications/fromGrowl', {
       title,
       message: stringify(err),
       level:   NotificationLevel.Error
@@ -180,8 +191,10 @@ export const actions = {
    *
    * Growls are only shown for Success, Warning and Error notifications
    */
-  notification({ commit }, notification) {
-    const growl = {
+  notification({ commit }: GrowlContext, notification: Notification) {
+    const growl: GrowlData & {
+      skip?: boolean;
+    } = {
       title:        notification.title,
       message:      notification.message,
       notification: notification.id,

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -94,6 +94,25 @@ export const state = function() {
   return out;
 };
 
+/**
+ * The locale a lookup should resolve against: an explicit override first, then the
+ * selected locale, then the store's own default.
+ *
+ * `selected` is null until the `setSelected` mutation runs, and `IntlMessageFormat`
+ * only substitutes its default for `undefined`, never for null. A null therefore
+ * reaches `Intl.*` and any message with an ICU argument that needs locale data
+ * (`{n, plural}`, `{n, number}`, a date or time) throws. Falling back to
+ * `state.default` keeps the store's own notion of a default authoritative instead of
+ * deferring to `IntlMessageFormat.defaultLocale`.
+ *
+ * @param {I18nState} state
+ * @param {string} [language] - Explicit locale override passed to the getter.
+ * @returns {string}
+ */
+function localeToUse(state, language) {
+  return language || state.selected || state.default;
+}
+
 export const getters = {
   selectedLocaleLabel(state) {
     const key = `locale.${ state.selected }`;
@@ -130,7 +149,7 @@ export const getters = {
       return `%${ key }%`;
     }
 
-    const locale = language || state.selected;
+    const locale = localeToUse(state, language);
     const cacheKey = `${ locale }/${ key }`;
     let formatter = intlCache[cacheKey];
 
@@ -186,7 +205,7 @@ export const getters = {
   },
 
   exists: (state) => (key, language) => {
-    const locale = language || state.selected;
+    const locale = localeToUse(state, language);
     const cacheKey = `${ locale }/${ key }`;
 
     if ( intlCache[cacheKey] ) {

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -64,6 +64,18 @@ const intlCache = {};
 
 let lastLoaded = 0;
 
+/**
+ * @typedef {object} I18nState
+ * @property {string} default - Locale to fall back to when nothing else applies.
+ * @property {string | null} selected - Locale in use, filled in by the `setSelected` mutation.
+ * @property {string | null} previous - Declared for `toggleNone` to switch back to, but nothing in the codebase assigns it, so `toggleNone` always falls back to `default`.
+ * @property {string[]} available - Locales that can be loaded.
+ * @property {Record<string, any>} translations - Loaded translations, keyed by locale.
+ */
+
+/**
+ * @returns {I18nState}
+ */
 export const state = function() {
   // const translationContext = require.context('@shell/assets/translations', true, /.*/);
   // const available = translationContext.keys().map(path => path.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1'));

--- a/shell/store/i18n.ts
+++ b/shell/store/i18n.ts
@@ -1,9 +1,12 @@
 import merge from 'lodash/merge';
 import IntlMessageFormat from 'intl-messageformat';
+import { ActionContext } from 'vuex';
 import { get } from '@shell/utils/object';
 import en from '@shell/assets/translations/en-us.yaml';
 import { getProduct, getVendor, DOCS_BASE } from '@shell/config/private-label';
 import { loadTranslation } from '@shell/utils/dynamic-importer';
+import { ExtensionManager } from '@shell/types/extension-manager';
+import { VuexStoreGetters } from '@shell/types/store/vuex';
 
 const NONE = 'none';
 const DEFAULT_LOCALE = 'en-us';
@@ -16,16 +19,37 @@ export const I18N_GLOBAL_TYPE = 'l10n-global';
 // `[[` is NOT preceded by a backslash (which is the escape sequence).
 const GLOBAL_PATTERN = /(\\?)\[\[([^\]]+)\]\]/g;
 
+export interface I18nState {
+  default: string;
+  selected: string | null;
+  /**
+   * Declared for `toggleNone` to switch back to, but nothing in the codebase
+   * assigns it, so `toggleNone` always falls back to `default`.
+   */
+  previous: string | null;
+  available: string[];
+  translations: Record<string, any>;
+}
+
+type TranslationsModule = Record<string, any> | Promise<Record<string, any>>;
+type TranslationsModuleSource = TranslationsModule | (() => TranslationsModule);
+
+export interface I18nGetterRootState {
+  $extension?: Pick<ExtensionManager, 'getDynamic'>;
+}
+
+interface I18nActionRootState {
+  $extension?: ExtensionManager;
+}
+
+type I18nContext = ActionContext<I18nState, I18nActionRootState>;
+
 /**
  * Look up an i18n global value registered via
  * `extension.register('l10n-global', name, value)`. Values may be registered as
  * a function, in which case they are invoked to produce the current value.
- *
- * @param {string} name
- * @param {any} $extension
- * @returns {string | undefined}
  */
-export function lookupGlobal(name, $extension) {
+export function lookupGlobal(name: string, $extension?: Pick<ExtensionManager, 'getDynamic'>): string | undefined {
   const registered = $extension?.getDynamic?.(I18N_GLOBAL_TYPE, name);
   const value = typeof registered === 'function' ? registered() : registered;
 
@@ -37,17 +61,13 @@ export function lookupGlobal(name, $extension) {
  * `extension.register('l10n-global', name, value)`. If the token is not
  * registered, the name itself is used as the value. Use `\[[` to include a
  * literal `[[` in a translation string.
- *
- * @param {string} msg
- * @param {any} $extension
- * @returns {string}
  */
-export function substituteGlobals(msg, $extension) {
+export function substituteGlobals(msg: string, $extension?: Pick<ExtensionManager, 'getDynamic'>): string {
   if (typeof msg !== 'string' || !msg.includes('[[')) {
     return msg;
   }
 
-  return msg.replace(GLOBAL_PATTERN, (_match, escape, name) => {
+  return msg.replace(GLOBAL_PATTERN, (_match: string, escape: string, name: string) => {
     if (escape) {
       // Preserve the literal token, stripping only the escape character
       return `[[${ name }]]`;
@@ -60,23 +80,11 @@ export function substituteGlobals(msg, $extension) {
 }
 
 // Formatters can't be serialized into state
-const intlCache = {};
+const intlCache: Record<string, IntlMessageFormat | string> = {};
 
-let lastLoaded = 0;
+let lastLoaded: number | undefined = 0;
 
-/**
- * @typedef {object} I18nState
- * @property {string} default - Locale to fall back to when nothing else applies.
- * @property {string | null} selected - Locale in use, filled in by the `setSelected` mutation.
- * @property {string | null} previous - Declared for `toggleNone` to switch back to, but nothing in the codebase assigns it, so `toggleNone` always falls back to `default`.
- * @property {string[]} available - Locales that can be loaded.
- * @property {Record<string, any>} translations - Loaded translations, keyed by locale.
- */
-
-/**
- * @returns {I18nState}
- */
-export const state = function() {
+export const state = function(): I18nState {
   // const translationContext = require.context('@shell/assets/translations', true, /.*/);
   // const available = translationContext.keys().map(path => path.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1'));
   // Using require.context() forces them to all be in the same webpack chunk name... just hardcode the list for now so zh-hans
@@ -95,26 +103,16 @@ export const state = function() {
 };
 
 /**
- * The locale a lookup should resolve against: an explicit override first, then the
- * selected locale, then the store's own default.
- *
- * `selected` is null until the `setSelected` mutation runs, and `IntlMessageFormat`
- * only substitutes its default for `undefined`, never for null. A null therefore
- * reaches `Intl.*` and any message with an ICU argument that needs locale data
- * (`{n, plural}`, `{n, number}`, a date or time) throws. Falling back to
- * `state.default` keeps the store's own notion of a default authoritative instead of
- * deferring to `IntlMessageFormat.defaultLocale`.
- *
- * @param {I18nState} state
- * @param {string} [language] - Explicit locale override passed to the getter.
- * @returns {string}
+ * `selected` is null until `setSelected` runs, and `IntlMessageFormat` only defaults for
+ * `undefined`, so a null throws in `Intl.*` on plurals, numbers and dates. Falls back to
+ * `state.default` to keep the store's own default authoritative.
  */
-function localeToUse(state, language) {
+function localeToUse(state: I18nState, language?: string): string {
   return language || state.selected || state.default;
 }
 
 export const getters = {
-  selectedLocaleLabel(state) {
+  selectedLocaleLabel(state: I18nState) {
     const key = `locale.${ state.selected }`;
 
     if ( state.selected === NONE ) {
@@ -124,8 +122,8 @@ export const getters = {
     }
   },
 
-  availableLocales(state, getters) {
-    const out = {};
+  availableLocales(state: I18nState, getters: VuexStoreGetters) {
+    const out: Record<string, string> = {};
 
     for ( const locale of state.available ) {
       const key = `locale.${ locale }`;
@@ -140,11 +138,11 @@ export const getters = {
     return out;
   },
 
-  hasMultipleLocales(state) {
+  hasMultipleLocales(state: I18nState) {
     return state.available.length > 1;
   },
 
-  t: (state, _getters, rootState) => (key, args, language) => {
+  t: (state: I18nState, _getters?: VuexStoreGetters, rootState?: I18nGetterRootState) => (key: string, args?: Record<string, any>, language?: string) => {
     if (state.selected === NONE && !language) {
       return `%${ key }%`;
     }
@@ -200,11 +198,11 @@ export const getters = {
     }
   },
 
-  global: (_state, _getters, rootState) => (name) => {
+  global: (_state: I18nState, _getters?: VuexStoreGetters, rootState?: I18nGetterRootState) => (name: string) => {
     return lookupGlobal(name, rootState?.$extension);
   },
 
-  exists: (state) => (key, language) => {
+  exists: (state: I18nState) => (key: string, language?: string) => {
     const locale = localeToUse(state, language);
     const cacheKey = `${ locale }/${ key }`;
 
@@ -225,15 +223,15 @@ export const getters = {
     return false;
   },
 
-  current: (state) => () => {
+  current: (state: I18nState) => () => {
     return state.selected;
   },
 
-  default: (state) => () => {
+  default: (state: I18nState) => () => {
     return state.default;
   },
 
-  multiWithFallback: (state, getters) => (items, key = 'key') => {
+  multiWithFallback: (state: I18nState, getters: VuexStoreGetters) => (items: Record<string, any>[], key = 'key') => {
     return items.map((item) => {
       item[key] = getters.withFallback(item[key], null, item[key]);
 
@@ -241,7 +239,7 @@ export const getters = {
     });
   },
 
-  withFallback: (state, getters) => (key, args, fallback, fallbackIsKey = false) => {
+  withFallback: (state: I18nState, getters: VuexStoreGetters) => (key: string, args?: Record<string, any> | string | null, fallback?: string, fallbackIsKey = false) => {
     // Support withFallback(key,fallback) when no args
     if ( !fallback && typeof args === 'string' ) {
       fallback = args;
@@ -260,11 +258,11 @@ export const getters = {
 };
 
 export const mutations = {
-  loadTranslations(state, { locale, translations }) {
+  loadTranslations(state: I18nState, { locale, translations }: { locale: string, translations: Record<string, any> }) {
     state.translations[locale] = translations;
   },
 
-  mergeLoadTranslations(state, { locale, translations }) {
+  mergeLoadTranslations(state: I18nState, { locale, translations }: { locale: string, translations: Record<string, any> }) {
     if (!state.translations[locale]) {
       state.translations[locale] = translations;
     } else {
@@ -272,19 +270,19 @@ export const mutations = {
     }
   },
 
-  setSelected(state, locale) {
+  setSelected(state: I18nState, locale: string) {
     // this will set the lang param on HTML (best place to add this action since all locale changes go through this mutation)
     if (locale === NONE) {
-      document.querySelector('html').removeAttribute('lang');
+      document.documentElement.removeAttribute('lang');
     } else {
-      document.querySelector('html').setAttribute('lang', locale);
+      document.documentElement.setAttribute('lang', locale);
     }
 
     state.selected = locale;
   },
 
   // Add a locale to the list of available locales
-  addLocale(state, { locale, label }) {
+  addLocale(state: I18nState, { locale, label }: { locale: string, label: string }) {
     const hasLocale = state.available.find((l) => l === locale);
 
     if (!hasLocale) {
@@ -296,7 +294,7 @@ export const mutations = {
   },
 
   // Remove locale
-  removeLocale(state, locale) {
+  removeLocale(state: I18nState, locale: string) {
     const index = state.available.findIndex((l) => l === locale);
 
     if (index !== -1) {
@@ -312,7 +310,7 @@ export const mutations = {
 export const actions = {
   init({
     state, commit, dispatch, rootGetters
-  }) {
+  }: I18nContext) {
     let selected = rootGetters['prefs/get']('locale');
 
     // We might be using a locale that is loaded by a plugin that is no longer loaded
@@ -325,7 +323,7 @@ export const actions = {
     return dispatch('switchTo', selected);
   },
 
-  async load({ commit }, locale) {
+  async load({ commit }: I18nContext, locale: string) {
     const translationsModule = await loadTranslation(locale);
     const translations = translationsModule.default || translationsModule;
 
@@ -334,7 +332,7 @@ export const actions = {
     return true;
   },
 
-  async mergeLoad({ commit }, { locale, module }) {
+  async mergeLoad({ commit }: I18nContext, { locale, module }: { locale: string, module: TranslationsModuleSource }) {
     const promise = typeof (module) === 'function' ? module() : Promise.resolve(module);
     const translationsModule = await promise;
     const translations = translationsModule.default || translationsModule;
@@ -343,12 +341,12 @@ export const actions = {
   },
 
   // Add a locale to the list of available locales
-  addLocale({ commit }, { locale, label }) {
+  addLocale({ commit }: I18nContext, { locale, label }: { locale: string, label: string }) {
     commit('addLocale', { locale, label });
   },
 
   // Remove a locale from the list of available locales
-  removeLocale({ commit, getters, dispatch }, { locale }) {
+  removeLocale({ commit, getters, dispatch }: I18nContext, { locale }: { locale: string }) {
     const current = getters['current']();
 
     // If we are removing the current locale, switch back to the default locale
@@ -365,7 +363,7 @@ export const actions = {
     commit,
     dispatch,
     getters
-  }, locale) {
+  }: I18nContext, locale: string) {
     const currentLocale = getters['current']();
 
     if ( locale === NONE ) {
@@ -377,7 +375,7 @@ export const actions = {
 
     const lastLoad = rootState.$extension?.lastLoad;
     const i18nExt = rootState.$extension?.getDynamic('l10n', locale);
-    const reload = lastLoaded < lastLoad;
+    const reload = lastLoaded !== undefined && lastLoad !== undefined && lastLoaded < lastLoad;
 
     lastLoaded = lastLoad;
 
@@ -396,9 +394,9 @@ export const actions = {
 
       // Load all of the locales from the plugins
       if (i18nExt && i18nExt.length) {
-        const p = [];
+        const p: Promise<any>[] = [];
 
-        i18nExt.forEach((fn) => {
+        i18nExt.forEach((fn: TranslationsModuleSource) => {
           p.push(dispatch('mergeLoad', { locale, module: fn }));
         });
 
@@ -407,7 +405,7 @@ export const actions = {
           const defaultI18nExt = rootState.$extension?.getDynamic('l10n', DEFAULT_LOCALE);
 
           if (defaultI18nExt && defaultI18nExt.length) {
-            defaultI18nExt.forEach((fn) => {
+            defaultI18nExt.forEach((fn: TranslationsModuleSource) => {
               p.push(dispatch('mergeLoad', { locale: DEFAULT_LOCALE, module: fn }));
             });
           }
@@ -436,7 +434,7 @@ export const actions = {
     }
   },
 
-  toggleNone({ state, dispatch }) {
+  toggleNone({ state, dispatch }: I18nContext) {
     if ( state.selected === NONE ) {
       return dispatch('switchTo', state.previous || state.default);
     } else {

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -3,6 +3,27 @@ import { MANAGEMENT, STEVE } from '@shell/config/types';
 import { clone } from '@shell/utils/object';
 import { getBrandMeta } from '@shell/utils/brand';
 
+/**
+ * How a single preference behaves, as built by `create` and by the
+ * `setDefinition` mutation.
+ *
+ * @typedef {object} PrefDefinition
+ * @property {any} [def] - Value used when the user has none stored.
+ * @property {any[]} [options] - Allowed values, when the preference is a fixed set.
+ * @property {boolean} [parseJSON] - Value is stored JSON encoded.
+ * @property {boolean} [asCookie] - Value is also kept in a cookie.
+ * @property {boolean} [asUserPreference] - Value is stored on the server.
+ * @property {string} [inheritFrom] - Preference to default to when this one is not on the server.
+ * @property {(value: any) => any} [mangleRead] - Alter the value read from the API.
+ * @property {(value: any) => any} [mangleWrite] - Alter the value written to the API.
+ */
+
+/**
+ * Preferences are open ended: `create` registers the built-in ones at module
+ * load and extensions add their own at runtime, so the keys are not known here.
+ *
+ * @type {Record<string, PrefDefinition>}
+ */
 const definitions = {};
 /**
  * Key/value of prefrences are stored before login here and cookies due lack of access permission.
@@ -135,6 +156,17 @@ const cookieOptions = {
   secure:   true,
 };
 
+/**
+ * @typedef {object} PrefsState
+ * @property {boolean} cookiesLoaded
+ * @property {Record<string, any>} data - Stored value of each preference, keyed by preference name.
+ * @property {Record<string, PrefDefinition>} definitions - The module level `definitions` object itself, not a copy, so every store instance shares the definitions that `create` adds at module load and `setDefinition` adds at runtime.
+ * @property {Record<string, any> | null} authRedirect - Route to return to once the user has logged in.
+ */
+
+/**
+ * @returns {PrefsState}
+ */
 export const state = function() {
   return {
     cookiesLoaded: false,

--- a/shell/store/prefs.ts
+++ b/shell/store/prefs.ts
@@ -2,36 +2,58 @@ import { SETTING } from '@shell/config/settings';
 import { MANAGEMENT, STEVE } from '@shell/config/types';
 import { clone } from '@shell/utils/object';
 import { getBrandMeta } from '@shell/utils/brand';
+import { VuexStoreGetters } from '@shell/types/store/vuex';
 
 /**
  * How a single preference behaves, as built by `create` and by the
  * `setDefinition` mutation.
- *
- * @typedef {object} PrefDefinition
- * @property {any} [def] - Value used when the user has none stored.
- * @property {any[]} [options] - Allowed values, when the preference is a fixed set.
- * @property {boolean} [parseJSON] - Value is stored JSON encoded.
- * @property {boolean} [asCookie] - Value is also kept in a cookie.
- * @property {boolean} [asUserPreference] - Value is stored on the server.
- * @property {string} [inheritFrom] - Preference to default to when this one is not on the server.
- * @property {(value: any) => any} [mangleRead] - Alter the value read from the API.
- * @property {(value: any) => any} [mangleWrite] - Alter the value written to the API.
  */
+export interface PrefDefinition {
+  def?: any;
+  options?: any[];
+  parseJSON?: boolean;
+  asCookie?: boolean;
+  asUserPreference?: boolean;
+  inheritFrom?: string;
+  mangleRead?: (value: any) => any;
+  mangleWrite?: (value: any) => any;
+}
+
+export type PrefOptions = Omit<PrefDefinition, 'def'>;
+
+export interface PrefsState {
+  cookiesLoaded: boolean;
+  data: Record<string, any>;
+  definitions: Record<string, PrefDefinition>;
+  authRedirect: Record<string, any> | null;
+}
+
+interface PrefError {
+  type?: string;
+  status?: number;
+}
+
+interface PrefsActionContext {
+  state: PrefsState;
+  getters: VuexStoreGetters;
+  rootState: Record<string, any>;
+  rootGetters: VuexStoreGetters;
+  commit: (mutation: string, payload?: any, options?: { root?: boolean }) => void;
+  dispatch: (action: string, payload?: any, options?: { root?: boolean }) => Promise<any>;
+}
 
 /**
  * Preferences are open ended: `create` registers the built-in ones at module
  * load and extensions add their own at runtime, so the keys are not known here.
- *
- * @type {Record<string, PrefDefinition>}
  */
-const definitions = {};
+const definitions: Record<string, PrefDefinition> = {};
 /**
  * Key/value of prefrences are stored before login here and cookies due lack of access permission.
  * Once user is logged in while setting asUserPreference, update stored before login Key/value to the backend in loadServer function.
  */
-let prefsBeforeLogin = {};
+let prefsBeforeLogin: Record<string, any> = {};
 
-export const create = function(name, def, opt = {}) {
+export const create = function(name: string, def: any, opt: PrefOptions = {}): string {
   const parseJSON = opt.parseJSON === true;
   const asCookie = opt.asCookie === true;
   const asUserPreference = opt.asUserPreference !== false;
@@ -52,13 +74,13 @@ export const create = function(name, def, opt = {}) {
   return name;
 };
 
-export const mapPref = function(name) {
+export const mapPref = function(name: string) {
   return {
-    get() {
+    get(this: { $store: { getters: VuexStoreGetters } }) {
       return this.$store.getters['prefs/get'](name);
     },
 
-    set(value) {
+    set(this: { $store: { dispatch: (action: string, payload?: any) => void } }, value: any) {
       this.$store.dispatch('prefs/set', { key: name, value });
     }
   };
@@ -157,17 +179,10 @@ const cookieOptions = {
 };
 
 /**
- * @typedef {object} PrefsState
- * @property {boolean} cookiesLoaded
- * @property {Record<string, any>} data - Stored value of each preference, keyed by preference name.
- * @property {Record<string, PrefDefinition>} definitions - The module level `definitions` object itself, not a copy, so every store instance shares the definitions that `create` adds at module load and `setDefinition` adds at runtime.
- * @property {Record<string, any> | null} authRedirect - Route to return to once the user has logged in.
+ * `definitions` is the module level object itself, not a copy, so every store instance
+ * shares what `create` adds at module load and `setDefinition` adds at runtime.
  */
-
-/**
- * @returns {PrefsState}
- */
-export const state = function() {
+export const state = function(): PrefsState {
   return {
     cookiesLoaded: false,
     data:          {},
@@ -177,7 +192,7 @@ export const state = function() {
 };
 
 export const getters = {
-  get: (state) => (key) => {
+  get: (state: PrefsState) => (key: string) => {
     const definition = state.definitions[key];
 
     if (!definition) {
@@ -195,7 +210,7 @@ export const getters = {
     return def;
   },
 
-  defaultValue: (state) => (key) => {
+  defaultValue: (state: PrefsState) => (key: string) => {
     const definition = state.definitions[key];
 
     if (!definition) {
@@ -205,7 +220,7 @@ export const getters = {
     return clone(definition.def);
   },
 
-  options: (state) => (key) => {
+  options: (state: PrefsState) => (key: string) => {
     const definition = state.definitions[key];
 
     if (!definition) {
@@ -219,7 +234,7 @@ export const getters = {
     return definition.options.slice();
   },
 
-  theme: (state, getters, rootState, rootGetters) => {
+  theme: (state: PrefsState, getters: VuexStoreGetters, rootState: unknown, rootGetters: VuexStoreGetters) => {
     const setting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.THEME);
 
     if (setting?.value) {
@@ -247,7 +262,7 @@ export const getters = {
     return theme;
   },
 
-  afterLoginRoute: (state, getters) => {
+  afterLoginRoute: (state: PrefsState, getters: VuexStoreGetters) => {
     const afterLoginRoutePref = getters['get'](AFTER_LOGIN_ROUTE);
 
     if (typeof afterLoginRoutePref !== 'string') {
@@ -281,7 +296,7 @@ export const getters = {
     }
   },
 
-  dev: (state, getters) => {
+  dev: (state: PrefsState, getters: VuexStoreGetters) => {
     try {
       return getters['get'](PLUGIN_DEVELOPER);
     } catch {
@@ -291,15 +306,15 @@ export const getters = {
 };
 
 export const mutations = {
-  load(state, { key, value }) {
+  load(state: PrefsState, { key, value }: { key: string, value: any }) {
     state.data[key] = value;
   },
 
-  cookiesLoaded(state) {
+  cookiesLoaded(state: PrefsState) {
     state.cookiesLoaded = true;
   },
 
-  reset(state) {
+  reset(state: PrefsState) {
     for (const key in state.definitions) {
       if ( state.definitions[key]?.asCookie ) {
         continue;
@@ -308,11 +323,11 @@ export const mutations = {
     }
   },
 
-  setDefinition(state, { name, definition = {} }) {
+  setDefinition(state: PrefsState, { name, definition = {} }: { name: string, definition?: PrefDefinition }) {
     state.definitions[name] = definition;
   },
 
-  setAuthRedirect(state, route) {
+  setAuthRedirect(state: PrefsState, route: Record<string, any> | null) {
     state.authRedirect = route;
   }
 };
@@ -320,7 +335,7 @@ export const mutations = {
 export const actions = {
   async set({
     dispatch, commit, rootGetters, state
-  }, opt) {
+  }: PrefsActionContext, opt: { key: string, value?: any, val?: any }): Promise<PrefError | undefined> {
     let { key, value } = opt; // eslint-disable-line prefer-const
     const definition = state.definitions[key];
     let server;
@@ -372,18 +387,19 @@ export const actions = {
         }
       } catch (e) {
         // Well it failed, but not much to do about it...
+        const error = e as PrefError;
 
         // Return the error
-        return { type: e.type, status: e.status };
+        return { type: error.type, status: error.status };
       }
     }
   },
 
-  async setTheme({ dispatch }, val) {
+  async setTheme({ dispatch }: PrefsActionContext, val: string) {
     await dispatch('set', { key: THEME, value: val });
   },
 
-  loadCookies({ state, commit, rootGetters }) {
+  loadCookies({ state, commit, rootGetters }: PrefsActionContext) {
     if ( state.cookiesLoaded ) {
       return;
     }
@@ -407,7 +423,7 @@ export const actions = {
     commit('cookiesLoaded');
   },
 
-  loadTheme({ dispatch }) {
+  loadTheme({ dispatch }: PrefsActionContext) {
     const watchDark = window.matchMedia('(prefers-color-scheme: dark)');
     const watchLight = window.matchMedia('(prefers-color-scheme: light)');
     const watchNone = window.matchMedia('(prefers-color-scheme: no-preference)');
@@ -446,7 +462,7 @@ export const actions = {
       }
     });
 
-    function changed(value) {
+    function changed(value: string) {
       // console.log('Prefers Theme:', value);
       dispatch('set', { key: PREFERS_SCHEME, value });
     }
@@ -464,8 +480,8 @@ export const actions = {
 
   async loadServer( {
     state, dispatch, commit, rootState, rootGetters
-  }, ignoreKey) {
-    let server = { data: {} };
+  }: PrefsActionContext, ignoreKey?: string) {
+    let server: any = { data: {} };
 
     try {
       const all = await dispatch('management/findAll', {
@@ -533,7 +549,7 @@ export const actions = {
     return server;
   },
 
-  setLastVisited({ state, dispatch, getters }, route) {
+  setLastVisited({ state, dispatch, getters }: PrefsActionContext, route: any) {
     if (!route) {
       return;
     }
@@ -549,13 +565,13 @@ export const actions = {
     return dispatch('set', { key: LAST_VISITED, value: route });
   },
 
-  toggleTheme({ getters, dispatch }) {
+  toggleTheme({ getters, dispatch }: PrefsActionContext) {
     const value = getters[THEME] === 'light' ? 'dark' : 'light';
 
     return dispatch('set', { key: THEME, value });
   },
 
-  setBrandStyle({ rootState, rootGetters }, dark = false) {
+  setBrandStyle({ rootState, rootGetters }: PrefsActionContext, dark = false) {
     if (rootState.managementReady) {
       try {
         const brandSetting = rootGetters['management/brand'];
@@ -565,7 +581,9 @@ export const actions = {
           const hasStylesheet = brandMeta.hasStylesheet === 'true';
 
           if (hasStylesheet) {
-            document.body.classList.add(brandMeta);
+            // `brandMeta` is an object, so this has always added `[object Object]` and thrown
+            // into the catch below. Spelled out to keep that behaviour while typing the call.
+            document.body.classList.add(String(brandMeta));
           } else {
             // TODO option apply color at runtime
           }

--- a/shell/store/wm.ts
+++ b/shell/store/wm.ts
@@ -14,8 +14,14 @@ export interface State {
   tabs: Array<Tab>;
   active: Record<Position | string, string>;
   open: Record<Position | string, boolean>;
-  panelHeight: Record<Position | string, number | null>;
-  panelWidth: Record<Position | string, number | null>;
+  /**
+   * Panel sizes are inconsistently typed at runtime and the union records that rather than endorsing it:
+   * `state()` seeds them from local storage, which hands back strings, while the setPanelHeight and
+   * setPanelWidth mutations write numbers. Tracked in #18807, which coerces in `state()` so this can
+   * narrow back to `number | null`. Read them with care until then.
+   */
+  panelHeight: Record<Position | string, number | string | null>;
+  panelWidth: Record<Position | string, number | string | null>;
   userPin: Position | string | null;
   lockedPositions: Position[];
 }

--- a/shell/store/wm.ts
+++ b/shell/store/wm.ts
@@ -14,14 +14,8 @@ export interface State {
   tabs: Array<Tab>;
   active: Record<Position | string, string>;
   open: Record<Position | string, boolean>;
-  /**
-   * Panel sizes are inconsistently typed at runtime and the union records that rather than endorsing it:
-   * `state()` seeds them from local storage, which hands back strings, while the setPanelHeight and
-   * setPanelWidth mutations write numbers. Tracked in #18807, which coerces in `state()` so this can
-   * narrow back to `number | null`. Read them with care until then.
-   */
-  panelHeight: Record<Position | string, number | string | null>;
-  panelWidth: Record<Position | string, number | string | null>;
+  panelHeight: Record<Position | string, number | null>;
+  panelWidth: Record<Position | string, number | null>;
   userPin: Position | string | null;
   lockedPositions: Position[];
 }
@@ -37,15 +31,25 @@ function moveTabByReference(tabs: Tab[], fromPosition: Position | undefined, toP
   tabs.push(tab);
 }
 
-export const state = function() {
+/**
+ * The key may be unset or hold something unparseable, such as an older `null` written as `'null'`.
+ * Anything that doesn't parse becomes `null`, so the store never holds `NaN` or a string.
+ */
+function storedPanelSize(key: string): number | null {
+  const size = parseInt(window.localStorage.getItem(key) ?? '', 10);
+
+  return Number.isNaN(size) ? null : size;
+}
+
+export const state = function(): State {
   return {
     tabs:        [],
     active:      {},
     open:        {},
-    panelHeight: { [BOTTOM]: window.localStorage.getItem(STORAGE_KEY[BOTTOM]) },
+    panelHeight: { [BOTTOM]: storedPanelSize(STORAGE_KEY[BOTTOM]) },
     panelWidth:  {
-      [LEFT]:  window.localStorage.getItem(STORAGE_KEY[LEFT]),
-      [RIGHT]: window.localStorage.getItem(STORAGE_KEY[RIGHT]),
+      [LEFT]:  storedPanelSize(STORAGE_KEY[LEFT]),
+      [RIGHT]: storedPanelSize(STORAGE_KEY[RIGHT]),
     },
     userPin:         null,
     lockedPositions: [],

--- a/shell/types/resources/settings.d.ts
+++ b/shell/types/resources/settings.d.ts
@@ -9,9 +9,12 @@ export interface PaginationSettingsStore {
      */
     enableSome?: {
       /**
-       * Specific resource type to enable
+       * Specific resource type to enable.
+       *
+       * A bare string, or an object naming the resource, enables it in every context. Supply
+       * `context` to restrict it to the listed contexts only.
        */
-      enabled?: (string | { resource: string, context: string[]})[],
+      enabled?: (string | { resource: string, context?: string[]})[],
       /**
        * Additional resource types that do not have any custom pagination settings (headers, lists, etc) but can be generated automatically (headers from CRD additionalPrinterColumns) can be enabled
        */

--- a/shell/types/store/__tests__/pagination.types.spec.ts
+++ b/shell/types/store/__tests__/pagination.types.spec.ts
@@ -55,12 +55,15 @@ describe('pagination-types', () => {
         expect(filterField.equality).toBe(PaginationFilterEquality.GREATER_THAN);
       });
 
+      // Proves the constructor's throw fires for a value no well-typed caller can produce. The ctor
+      // destructures `equals = true, exact = true`, and a default only fires for `undefined`, never
+      // for `null`, so `null` is the only way to reach the throw.
       it('should throw an error if no equality can be determined', () => {
         expect(() => new PaginationFilterField({
           field:  'f',
           value:  'v',
-          equals: null,
-          exact:  null
+          equals: null as unknown as boolean,
+          exact:  null as unknown as boolean
         })).toThrow('A pagination filter must have either equals or equality set');
       });
 

--- a/shell/types/yaml.d.ts
+++ b/shell/types/yaml.d.ts
@@ -1,0 +1,9 @@
+/**
+ * `shell/vue.config.js` runs YAML through `js-yaml-loader`, so an import yields the
+ * parsed document as the default export.
+ */
+declare module '*.yaml' {
+  const content: Record<string, any>;
+
+  export default content;
+}

--- a/shell/utils/__tests__/banners.test.ts
+++ b/shell/utils/__tests__/banners.test.ts
@@ -54,7 +54,7 @@ describe('banners', () => {
         id:          'ui-banner-login-consent',
         expectedKey: 'bannerConsent',
       },
-    ])('$desc', ({ id, expectedKey }) => {
+    ] as const)('$desc', ({ id, expectedKey }) => {
       const setting = {
         id,
         value: '{"text":"hello"}',

--- a/shell/utils/__tests__/cspAdaptor.test.ts
+++ b/shell/utils/__tests__/cspAdaptor.test.ts
@@ -14,7 +14,7 @@ function makeStore({
       'management/canList':           jest.fn().mockReturnValue(canList),
       'management/paginationEnabled': jest.fn().mockReturnValue(paginationEnabled),
     },
-    dispatch: jest.fn((action: string) => {
+    dispatch: jest.fn<Promise<any>, [action: string, payload: Record<string, any>]>((action) => {
       if (action === 'management/findAll') {
         return Promise.resolve(findAllResult);
       }

--- a/shell/utils/__tests__/fleet.test.ts
+++ b/shell/utils/__tests__/fleet.test.ts
@@ -7,6 +7,9 @@ import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 describe('fx: util.getTargetMode', () => {
   const util = FleetUtils.Application;
 
+  // getTargetMode declares a third `areHarvesterHostsVisible` argument but never reads it, so the
+  // value passed here makes no difference to any of the expectations below.
+
   it('should return "all" when targets contain excludeHarvesterRule and namespace is not fleet-local', () => {
     const targets = [{
       clusterSelector: {
@@ -19,28 +22,28 @@ describe('fx: util.getTargetMode', () => {
     }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('all');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('all');
   });
 
   it('should return "clusters" when targets include clusterName and clusterSelector', () => {
     const targets = [{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('clusters');
   });
 
   it('should return "clusters" when targets only include multiple clusterSelectors', () => {
     const targets: Target[] = [{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('clusters');
   });
 
   it('should return "advanced" when a target contains clusterGroupSelector', () => {
     const targets = [{ clusterGroupSelector: {} }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('advanced');
   });
 
   it('should return "advanced" when any target contains clusterGroup or clusterGroupSelector', () => {
@@ -87,35 +90,35 @@ describe('fx: util.getTargetMode', () => {
     }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('advanced');
   });
 
   it('should return "none" when targets is an empty array', () => {
     const targets: Target[] = [];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('none');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('none');
   });
 
   it('should return "local" when namespace is "fleet-local" regardless of targets', () => {
     const targets: Target[] = [{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }];
     const namespace = 'fleet-local';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('local');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('local');
   });
 
   it('should return "all" if no specific target type (clusterName, clusterSelector, clusterGroup, clusterGroupSelector) is present', () => {
     const targets = [{ name: 'target1' }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('all');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('all');
   });
 
   it('should return "clusters" if multiple targets include only clusterName', () => {
     const targets = [{ clusterName: 'cluster-a' }, { clusterName: 'cluster-b' }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('clusters');
   });
 
   it('should return "clusters" if a mix of clusterName and empty clusterSelector is present', () => {
@@ -123,21 +126,21 @@ describe('fx: util.getTargetMode', () => {
     ];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('clusters');
   });
 
   it('should return "clusters" if one target has clusterGroup but others have clusterName or clusterSelector', () => {
     const targets = [{ clusterName: 'cluster-x' }, { clusterGroup: 'my-group' }, { clusterSelector: { matchLabels: { env: 'prod' } } }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('clusters');
   });
 
   it('should return "advanced" if one target has clusterGroupSelector but others have clusterName or clusterSelector', () => {
     const targets = [{ clusterName: 'cluster-x' }, { clusterGroupSelector: {} }, { clusterSelector: { matchLabels: { env: 'prod' } } }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('advanced');
   });
 
   it('should return "all" when targets contain excludeHarvesterRule along with other irrelevant properties', () => {
@@ -153,7 +156,7 @@ describe('fx: util.getTargetMode', () => {
     }];
     const namespace = 'ws1';
 
-    expect(util.getTargetMode(targets, namespace)).toBe('all');
+    expect(util.getTargetMode(targets, namespace, false)).toBe('all');
   });
 });
 

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -569,7 +569,8 @@ describe('fx: mergeWithReplace', () => {
       }
     ]
   ])('should overwrite duplicate object properties when merging objects', (left, right, expected) => {
-    const result = mergeWithReplace(left, right, { replaceObjectProps: true });
+    // mergeWithReplace has no `replaceObjectProps` option, overwriting is its default behaviour
+    const result = mergeWithReplace(left, right);
 
     expect(result).toStrictEqual(expected);
   });

--- a/shell/utils/__tests__/require-asset.test.ts
+++ b/shell/utils/__tests__/require-asset.test.ts
@@ -1,5 +1,17 @@
 import { toContextKey, requireAsset, requireJson, _setContexts } from '@shell/utils/require-asset';
 
+/**
+ * A stand-in for a webpack require.context. The context is a function, but it also carries
+ * `keys`, `resolve` and `id`, so a bare jest.fn() is not one.
+ */
+function makeContext(impl: (key: string) => any) {
+  return Object.assign(jest.fn(impl), {
+    keys:    () => [] as string[],
+    resolve: (key: string) => key,
+    id:      'mock-context',
+  });
+}
+
 describe('fx: toContextKey', () => {
   it.each([
     ['~shell/assets/images/providers/aws.svg', './images/providers/aws.svg'],
@@ -21,7 +33,7 @@ describe('fx: requireAsset', () => {
   });
 
   it('should return the resolved asset URL from the image context', () => {
-    const mockImgCtx = jest.fn().mockReturnValue('/static/images/aws.svg');
+    const mockImgCtx = makeContext(() => '/static/images/aws.svg');
 
     _setContexts(mockImgCtx, null);
 
@@ -39,7 +51,7 @@ describe('fx: requireAsset', () => {
   });
 
   it('should propagate errors from the context function for missing assets', () => {
-    const mockImgCtx = jest.fn().mockImplementation(() => {
+    const mockImgCtx = makeContext(() => {
       throw new Error('Cannot find module');
     });
 
@@ -57,7 +69,7 @@ describe('fx: requireJson', () => {
 
   it('should return mod.default when available', () => {
     const jsonData = { vendor: 'suse' };
-    const mockJsonCtx = jest.fn().mockReturnValue({ default: jsonData });
+    const mockJsonCtx = makeContext(() => ({ default: jsonData }));
 
     _setContexts(null, mockJsonCtx);
 
@@ -69,7 +81,7 @@ describe('fx: requireJson', () => {
 
   it('should return mod directly when no default export', () => {
     const jsonData = { vendor: 'rancher' };
-    const mockJsonCtx = jest.fn().mockReturnValue(jsonData);
+    const mockJsonCtx = makeContext(() => jsonData);
 
     _setContexts(null, mockJsonCtx);
 
@@ -86,7 +98,7 @@ describe('fx: requireJson', () => {
   });
 
   it('should propagate errors from the context function for missing files', () => {
-    const mockJsonCtx = jest.fn().mockImplementation(() => {
+    const mockJsonCtx = makeContext(() => {
       throw new Error('Cannot find module');
     });
 

--- a/shell/utils/__tests__/string-utils.test.ts
+++ b/shell/utils/__tests__/string-utils.test.ts
@@ -308,7 +308,7 @@ describe('indent', () => {
   });
 
   it('handles null/undefined lines as empty array', () => {
-    expect(indent(null as unknown as string)).toStrictEqual('');
+    expect(indent(null)).toStrictEqual('');
   });
 
   it('indents after a regex match', () => {

--- a/shell/utils/__tests__/url.test.ts
+++ b/shell/utils/__tests__/url.test.ts
@@ -1,5 +1,5 @@
 import {
-  addParam, addParams, removeParam, parseLinkHeader, isMaybeSecure, portMatch, parse, stringify
+  addParam, addParams, removeParam, parseLinkHeader, isMaybeSecure, portMatch, parse, stringify, QueryParams
 } from '@shell/utils/url';
 
 describe('fx: addParam', () => {
@@ -49,8 +49,10 @@ describe('fx: addParams', () => {
     expect(addParams('https://example.com', null)).toStrictEqual('https://example.com');
   });
 
+  // Deliberately passes a value the signature forbids: this models an untyped JS caller and covers
+  // the `typeof params === 'object'` guard, which is unreachable from TypeScript.
   it('should return the URL unchanged if params is a non-object value', () => {
-    expect(addParams('https://example.com', 'not-an-object')).toStrictEqual('https://example.com');
+    expect(addParams('https://example.com', 'not-an-object' as unknown as QueryParams)).toStrictEqual('https://example.com');
   });
 });
 

--- a/shell/utils/banners.js
+++ b/shell/utils/banners.js
@@ -24,6 +24,11 @@ const BANNER_SHOW_KEY_MAP = {
 
 /**
  * Get the individual banner settings
+ *
+ * @param {object} store - The Vuex store to read the management settings from.
+ * @returns {Partial<Record<typeof BANNER_HEADER | typeof BANNER_FOOTER | typeof BANNER_LOGIN, any>>}
+ * The settings, keyed by which banner they configure. Only banners with a setting that has a value
+ * are present.
  */
 export function getIndividualBanners(store) {
   const banners = {};

--- a/shell/utils/chart.js
+++ b/shell/utils/chart.js
@@ -14,8 +14,8 @@ import {
  * If the "up" logic doesn't apply or results in equality, it falls back to `semver.compareBuild` to handle
  * other build metadata differences (e.g. sorting alphabetically).
  *
- * @param {string} v1 - The first version string.
- * @param {string} v2 - The second version string.
+ * @param {string | null | undefined} v1 - The first version string.
+ * @param {string | null | undefined} v2 - The second version string.
  * @returns {number} - 0 if equal, -1 if v1 < v2, 1 if v1 > v2.
  */
 export function compareChartVersions(v1, v2) {
@@ -85,10 +85,33 @@ export function getLatestCompatibleVersion(chart, workerOSs, showPrerelease) {
 }
 
 /**
+ * The chart context to build the readme route from.
+ *
+ * The only production caller passes route values straight through, so the types here are the
+ * vue-router ones: `RouteParamValue | RouteParamValue[]` for the cluster and
+ * `LocationQueryValue | LocationQueryValue[]` for everything read off the query, where a repeated
+ * param (`?chart=a&chart=b`) is an array and a bare param (`?deprecated`) is null.
+ *
+ * @typedef {object} StandaloneReadmeUrlOptions
+ * @property {string | string[]} [cluster] - Id of the cluster the readme is being opened from.
+ * @property {string | null | (string | null)[]} [repoType] - Which kind of repo holds the chart, `cluster` or `catalog`.
+ * @property {string | null | (string | null)[]} [repoName] - Name of the repo holding the chart.
+ * @property {string | null | (string | null)[]} [chartName] - Name of the chart.
+ * @property {string | null | (string | null)[]} [versionName] - Version of the chart to show the readme for.
+ * @property {string | null | (string | null)[]} [deprecated] - Whether the chart is deprecated, as carried by the query param.
+ * @property {boolean} [showAppReadme] - Whether the readme page also shows the app readme. Defaults to true.
+ * @property {boolean} [hideReadmeFirstTitle] - Whether the readme page hides the first title. Defaults to true.
+ */
+
+/**
  * Builds the route URL for the standalone chart readme page.
  *
  * The helper maps chart context into query params so the readme page can fetch
  * version info directly (instead of relying on local/session storage transfer).
+ *
+ * @param {import('vue-router').Router} router - The router used to resolve the route.
+ * @param {StandaloneReadmeUrlOptions} [opt] - The chart context to put in the route.
+ * @returns {string} The href of the readme route.
  */
 export function getStandaloneReadmeUrl(router, {
   cluster,

--- a/shell/utils/dynamic-content/__tests__/announcement.test.ts
+++ b/shell/utils/dynamic-content/__tests__/announcement.test.ts
@@ -2,7 +2,7 @@ import { processAnnouncements, ANNOUNCEMENT_PREFIX } from '../announcement';
 import { NotificationLevel, Notification } from '@shell/types/notifications';
 import { READ_ANNOUNCEMENTS } from '@shell/store/prefs';
 import { DynamicContentAnnouncementHandlerName } from '../notification-handler';
-import { Context, VersionInfo, Announcement } from '../types';
+import { Context, Announcement } from '../types';
 import semver from 'semver';
 
 jest.mock('semver', () => ({
@@ -126,9 +126,8 @@ describe('processAnnouncements', () => {
         audience: 'admin'
       },
     ];
-    const versionInfo: VersionInfo = { version: VERSION_270.version };
 
-    await processAnnouncements(mockContext, announcements, versionInfo);
+    await processAnnouncements(mockContext, announcements, VERSION_270);
 
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.any(Object));

--- a/shell/utils/dynamic-content/__tests__/support-notice.test.ts
+++ b/shell/utils/dynamic-content/__tests__/support-notice.test.ts
@@ -3,7 +3,7 @@ import { NotificationLevel } from '@shell/types/notifications';
 import { READ_SUPPORT_NOTICE, READ_UPCOMING_SUPPORT_NOTICE } from '@shell/store/prefs';
 import { Context, VersionInfo, SupportInfo } from '../types';
 import * as util from '../util'; // To mock removeMatchingNotifications
-import semver from 'semver';
+import semver, { SemVer } from 'semver';
 import day from 'dayjs';
 
 describe('processSupportNotices', () => {
@@ -81,9 +81,12 @@ describe('processSupportNotices', () => {
       upcoming: {} as any
     };
 
-    await processSupportNotices(mockContext, statusInfo, null as any);
+    // `versionInfo` is required and its `version` is a required `SemVer`, so both of these are
+    // states no well-typed caller can produce. The casts cover the `!versionInfo` and
+    // `!versionInfo.version` guards, which are unreachable from TypeScript.
+    await processSupportNotices(mockContext, statusInfo, null as unknown as VersionInfo);
     expect(mockDispatch).not.toHaveBeenCalled();
-    await processSupportNotices(mockContext, statusInfo, { version: null, isPrime: true });
+    await processSupportNotices(mockContext, statusInfo, { version: null as unknown as SemVer, isPrime: true });
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 

--- a/shell/utils/dynamic-content/types.d.ts
+++ b/shell/utils/dynamic-content/types.d.ts
@@ -119,7 +119,7 @@ export type Announcement = {
   audience?: 'admin' | 'all'; // Audience - show for just Admins or for all users
   icon?: string;
   cta?: {
-    primary: CallToAction, // Must have a primary call to action, if we have a cta field
+    primary?: CallToAction, // Primary call to action - the content is remote, so it may be absent
     secondary?: CallToAction,
   },
   style?: string; // Styling information that will be interpreted by the rendering component

--- a/shell/utils/object.d.ts
+++ b/shell/utils/object.d.ts
@@ -1,0 +1,100 @@
+/**
+ * Declarations for the untyped `object.js` in this directory, so that `.ts` modules
+ * importing it still type-check when an extension builds against `@rancher/shell`
+ * (its own `tsconfig` sets `checkJs: false`, so the `.js` has no types of its own).
+ *
+ * Seeded from:
+ *   ./node_modules/.bin/tsc shell/utils/object.js --declaration --allowJs --emitDeclarationOnly --outDir <tmp>
+ * then adjusted to declare `isEqual` directly, since the private `isEqualBasic` it
+ * aliases in the `.js` is not part of the module's public surface.
+ */
+
+export function set(obj: any, path: any, value: any): any;
+export function getAllValues(obj: any, path: any): any[];
+export function get(obj: any, path: any): any;
+export function remove(obj: any, path: any, pruneEmptyParents?: boolean): any;
+/**
+ * `delete` a property at the given path.
+ *
+ * This is similar to `remove` but doesn't need any fancy kube obj path splitting
+ * and doesn't use `Vue.set` (avoids reactivity)
+ */
+export function deleteProperty(obj: any, path: any): void;
+export function getter(path: any): (obj: any) => any;
+export function clone(obj: any): any;
+export function isEmpty(obj: any): boolean;
+/**
+ * Checks to see if the object is a simple key value pair where all values are
+ * just primitives.
+ * @param {any} obj
+ */
+export function isSimpleKeyValue(obj: any): boolean;
+export function cleanUp(obj: any): any;
+export function definedKeys(obj: any): any;
+export function diff(from: any, to: any, preventNull?: boolean): any;
+export function changeset(from: any, to: any, parentPath?: any[]): {};
+export function changesetConflicts(a: any, b: any): any[];
+export function applyChangeset(obj: any, changeset: any): any;
+/**
+ * Creates an object composed of the `object` properties `predicate` returns
+ */
+export function pickBy(obj?: {}, predicate?: (value: any, key: any) => boolean): {};
+export function dropKeys(obj: any, keys: any): void;
+/**
+ * Recursively convert a reactive object to a raw object
+ * @param {*} obj
+ * @param {*} cache
+ * @returns
+ */
+export function deepToRaw(obj: any, cache?: any): any;
+/**
+ * Helper function to alter Lodash merge function default behaviour on merging
+ * arrays and objects.
+ *
+ * In rke2.vue, the syncMachineConfigWithLatest function updates machine pool configuration by
+ * merging the latest configuration received from the backend with the current configuration updated by the user.
+ * However, Lodash's merge function treats arrays like object so index values are merged and not appended to arrays
+ * resulting in undesired outcomes for us, Example:
+ *
+ * const lastSavedConfigFromBE = { a: ["test"] };
+ * const currentConfigByUser = { a: [] };
+ * merge(lastSavedConfigFromBE, currentConfigByUser); // returns { a: ["test"] }; but we expect { a: [] };
+ *
+ * More info: https://github.com/lodash/lodash/issues/1313
+
+ * This helper function addresses the issue by always replacing the old array with the new array during the merge process.
+ *
+ * This helper is also used for another case in rke2.vue to handle merging addon chart default values with the user's current values.
+ * It fixed https://github.com/rancher/dashboard/issues/12418
+ *
+ * If `mutateOriginal` is true, the merge is done directly into `obj1` (mutating it).
+ * This is useful in cases like:
+ *   machinePool.config = mergeWithReplace(clonedLatestConfig, clonedCurrentConfig, { mutateOriginal: true })
+ * where merging into a new empty object may lead to incomplete structure.
+ *
+ * Use `mutateOriginal` when you want to preserve obj1’s original shape, references,
+ * or when assigning the result directly to an existing object.
+ *
+ * @param {Object} [obj1={}] - The first object to merge
+ * @param {Object} [obj2={}] - The second object to merge
+ * @param {Object} [options={}] - Options for customizing merge behavior
+ * @param {boolean} [options.mutateOriginal=false] - true: mutates obj1
+ *                  directly. false: returns a new object
+ * @param {boolean} [options.replaceArray=true] - true: replaces arrays in obj1
+ *                  with arrays in obj2 when both properties are arrays
+ *                  false: default lodash merge behavior - recursively merges
+ *                  array members
+ */
+export function mergeWithReplace(obj1?: any, obj2?: any, { mutateOriginal, replaceArray }?: {
+    mutateOriginal?: boolean;
+    replaceArray?: boolean;
+}): any;
+export function toDictionary(array: any, callback: any): any;
+export function convertKVToString(input: any): string;
+export function convertStringToKV(input: string): {};
+/**
+ * Super simple lodash isEqual equivalent.
+ *
+ * Only checks root properties for strict equality
+ */
+export function isEqual(from: any, to: any): boolean;

--- a/shell/utils/parse-externalid.js
+++ b/shell/utils/parse-externalid.js
@@ -10,11 +10,26 @@ const EXTERNAL_ID = {
   CATALOG_DEFAULT_GROUP: 'library',
 };
 
-// Parses externalIds on services into
-// {
-//  kind: what kind of id this is supposed to be
-//  group: for catalog, what group it's in
-//  id: the actual external id
+/**
+ * @typedef {object} ParsedExternalId
+ * @property {string | null | undefined} kind - What kind of id this is supposed to be. `undefined`
+ * on the old-style branch, which assigns `EXTERNAL_ID.KIND_CATALOG`, and `KIND_CATALOG` is not a key
+ * of `EXTERNAL_ID`.
+ * @property {string | null} group - For catalog, what group it's in.
+ * @property {string | null} base - The part of the name before the base separator, when there is one.
+ * @property {string | null} id - The actual external id.
+ * @property {string | null} name - The chart name.
+ * @property {string | null} version - The chart version, when the id carries one.
+ * @property {string} [templateId] - `group:name`, only present when a name could be parsed out.
+ */
+
+/**
+ * Parses externalIds on services.
+ *
+ * @param {string | null | undefined} externalId - The external id to parse.
+ * @returns {ParsedExternalId} The parsed id. When `externalId` is falsy every field is null and
+ * `templateId` is absent.
+ */
 export function parseExternalId(externalId) {
   let nameVersion;
   const out = {
@@ -93,6 +108,28 @@ export function parseExternalId(externalId) {
   return out;
 }
 
+/**
+ * @typedef {object} ParsedHelmExternalId
+ * @property {string | null} kind - What kind of id this is supposed to be.
+ * @property {string | null} group - For catalog, what group it's in.
+ * @property {string | null} base - Unused by this format, kept so both parsers return the same fields.
+ * @property {string | null} id - The external id, unchanged.
+ * @property {string | null} name - Unused by this format, kept so both parsers return the same fields.
+ * @property {string | null} version - The chart version, from the `version` pair of the id.
+ * @property {string} [catalog] - The catalog, from the `catalog` pair of the id.
+ * @property {string} [template] - The chart, from the `template` pair of the id.
+ * @property {string} [templateId] - `catalog-template`, with the catalog namespaced.
+ * @property {string} [templateVersionId] - `catalog-template-version`, with the catalog namespaced.
+ */
+
+/**
+ * Parses the helm form of an externalId, `kind:///catalog=x&template=y&version=z`.
+ *
+ * @param {string | null | undefined} externalId - The external id to parse.
+ * @returns {ParsedHelmExternalId} The parsed id. When `externalId` is falsy every field is null and
+ * `catalog`, `template`, `templateId` and `templateVersionId` are absent. Note that a truthy id
+ * without a `://` never assigns `out.catalog`, and the `catalog.includes('/')` below then throws.
+ */
 export function parseHelmExternalId(externalId) {
   const out = {
     kind:    null,

--- a/shell/utils/position.js
+++ b/shell/utils/position.js
@@ -50,6 +50,44 @@ export function screenRect() {
   };
 }
 
+/**
+ * @typedef {object} FitOnScreenOptions
+ * @property {string} [positionX] - Preferred horizontal position, `LEFT`, `CENTER`, `RIGHT` or
+ * `AUTO`. Defaults to `AUTO`, which picks whichever side leaves more room.
+ * @property {string} [positionY] - Preferred vertical position, `TOP`, `MIDDLE`, `BOTTOM` or
+ * `AUTO`. Defaults to `AUTO`.
+ * @property {number} [fudgeX] - Pixels to shift the result horizontally. Defaults to 0.
+ * @property {number} [fudgeY] - Pixels to shift the result vertically. Defaults to 0.
+ * @property {boolean} [overlapX] - Whether the content may sit on top of the trigger horizontally.
+ * Defaults to true.
+ * @property {boolean} [overlapY] - Whether the content may sit on top of the trigger vertically.
+ * Defaults to false.
+ */
+
+/**
+ * @typedef {object} FitOnScreenStyle
+ * @property {string} position - Always `absolute`.
+ * @property {string} [left] - The horizontal offset in `px`.
+ * @property {string} [top] - The vertical offset in `px`.
+ *
+ * `left` and `top` are optional only because TypeScript cannot see through the two switches below.
+ * `CENTER` and `MIDDLE` are both `'center'`, so between them the switches cover every value
+ * `positionX` and `positionY` can resolve to, and both properties are always assigned for legal
+ * input.
+ */
+
+/**
+ * Work out where to place a floating element so that it fits on screen next to its trigger.
+ *
+ * @param {Element | null | undefined} contentElem - The element being positioned. Its size is
+ * measured to decide which side it fits on; pass nothing together with `useDefaults`.
+ * @param {Element | Event} triggerElemOrEvent - What to position against, either the element the
+ * content hangs off or the event whose coordinates it hangs off.
+ * @param {FitOnScreenOptions} [opt] - How to position it.
+ * @param {boolean} [useDefaults] - Use a fixed 147x80 content size instead of measuring
+ * `contentElem`, for callers positioning something that has not been rendered yet.
+ * @returns {FitOnScreenStyle} Inline style for the content element.
+ */
 export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
   let {
     positionX = AUTO, // Preferred horizontal position

--- a/shell/utils/promise.js
+++ b/shell/utils/promise.js
@@ -1,5 +1,26 @@
 import Queue from './queue';
 
+/**
+ * The values of a hash of promises, keyed the same way as the hash they came from.
+ *
+ * @typedef {Record<string, any>} ResolvedHash
+ */
+
+/**
+ * The `PromiseSettledResult` of each promise in a hash, keyed the same way as the hash they came
+ * from.
+ *
+ * @typedef {Record<string, PromiseSettledResult<any>>} SettledHash
+ */
+
+/**
+ * Run `Promise[fnName]` over the values of `hash` and put the results back under the same keys.
+ *
+ * @param hash - An object whose values are promises. Non-promise values are passed through, since
+ * that is what `Promise.all`/`Promise.allSettled` do with them.
+ * @param {'all' | 'allSettled'} fnName - Which `Promise` combinator to use.
+ * @returns {Promise<ResolvedHash>} The results, keyed as `hash` was.
+ */
 async function _hash(hash, fnName) {
   const keys = Object.keys(hash);
   const promises = Object.values(hash);
@@ -14,10 +35,25 @@ async function _hash(hash, fnName) {
   return out;
 }
 
+/**
+ * Resolve every promise in `hash` and return their values keyed the same way. Rejects as soon as
+ * any of them rejects.
+ *
+ * @param hash - An object whose values are the promises to resolve.
+ * @returns {Promise<ResolvedHash>} The resolved value of each promise.
+ */
 export function allHash(hash) {
   return _hash(hash, 'all');
 }
 
+/**
+ * Settle every promise in `hash` and return their `PromiseSettledResult`s keyed the same way.
+ * Never rejects.
+ *
+ * @param hash - An object whose values are the promises to settle.
+ * @returns {Promise<SettledHash>} The settled result of each promise, so `status` plus either
+ * `value` or `reason`.
+ */
 export function allHashSettled(hash) {
   return _hash(hash, 'allSettled');
 }
@@ -83,6 +119,23 @@ export function eachLimit(items, limit, iterator, debug = false) {
   });
 }
 
+/**
+ * A promise together with the two functions that settle it.
+ *
+ * @typedef {object} Deferred
+ * @property {Promise<any>} promise - The promise being deferred.
+ * @property {(value?: any) => void} resolve - Resolves `promise` with the given value.
+ * @property {(reason?: any) => void} reject - Rejects `promise` with the given reason.
+ */
+
+/**
+ * Create a promise whose settling is controlled from outside its executor.
+ *
+ * @param {string} [name] - Ignored. It is passed as the second argument to `new Promise`, which
+ * native promises do not take; a leftover from when this used Bluebird. No production caller passes
+ * it.
+ * @returns {Deferred}
+ */
 export function deferred(name) {
   const out = {};
 

--- a/shell/utils/string.js
+++ b/shell/utils/string.js
@@ -185,6 +185,16 @@ export function resourceNames(names, plusMore, t, endString) {
   }, '');
 }
 
+/**
+ * Indents every line of the given input.
+ *
+ * @param {string | string[] | null | undefined} lines - The line, or lines, to indent.
+ * @param {number} [count] - How many copies of `token` to indent by.
+ * @param {string} [token] - The string one level of indent is made of.
+ * @param {RegExp | null} [afterRegex] - When given, the indent goes after whatever each line matches
+ * instead of at the start of the line.
+ * @returns {string} The indented lines, joined by newlines.
+ */
 export function indent(lines, count = 2, token = ' ', afterRegex = null) {
   if (typeof lines === 'string') {
     lines = lines.split(/\n/);

--- a/shell/utils/unit-tests/pagination-utils.spec.ts
+++ b/shell/utils/unit-tests/pagination-utils.spec.ts
@@ -17,7 +17,7 @@ describe('pagination-utils', () => {
     });
 
     it('should return false if no store settings are provided', () => {
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:           { rootGetters: mockRootGetters },
         storeSettings: undefined as unknown as PaginationSettingsStore,
         enabledFor:    { store: 'cluster' }
@@ -28,7 +28,7 @@ describe('pagination-utils', () => {
 
     it('should return true if no specific resource is being checked', () => {
       const storeSettings: PaginationSettingsStore = { resources: {} };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster' }
@@ -39,7 +39,7 @@ describe('pagination-utils', () => {
 
     it('should return true if enableAll is true for the store', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableAll: true } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -50,7 +50,7 @@ describe('pagination-utils', () => {
 
     it('should return false if a resource is checked but has no id', () => {
       const storeSettings: PaginationSettingsStore = { resources: {} };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: undefined as unknown as string } }
@@ -65,7 +65,7 @@ describe('pagination-utils', () => {
       mockRootGetters['type-map/hasCustomList'].mockReturnValue(false);
 
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { generic: true } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -78,7 +78,7 @@ describe('pagination-utils', () => {
       mockRootGetters['type-map/hasCustomList'].mockReturnValue(true);
 
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { generic: true } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -89,7 +89,7 @@ describe('pagination-utils', () => {
 
     it('should return true if resource id is in enabled list as a string', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { enabled: ['pod'] } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -100,7 +100,7 @@ describe('pagination-utils', () => {
 
     it('should return true if resource id is in enabled list as an object without context', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { enabled: [{ resource: 'pod' }] } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -111,7 +111,7 @@ describe('pagination-utils', () => {
 
     it('should return false if resource id is in enabled list as an object with empty context', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { enabled: [{ resource: 'pod', context: [] }] } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod' } }
@@ -122,7 +122,7 @@ describe('pagination-utils', () => {
 
     it('should return true if resource id and context match an enabled setting', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { enabled: [{ resource: 'pod', context: ['list'] }] } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod', context: 'list' } }
@@ -133,7 +133,7 @@ describe('pagination-utils', () => {
 
     it('should return false if resource context does not match enabled setting', () => {
       const storeSettings: PaginationSettingsStore = { resources: { enableSome: { enabled: [{ resource: 'pod', context: ['detail'] }] } } };
-      const result = paginationUtils.isEnabledInStore({
+      const result = paginationUtils['isEnabledInStore']({
         ctx:        { rootGetters: mockRootGetters },
         storeSettings,
         enabledFor: { store: 'cluster', resource: { id: 'pod', context: 'list' } }
@@ -161,12 +161,21 @@ describe('pagination-utils', () => {
     });
 
     it('should return false if pagination settings are not defined', () => {
-      jest.spyOn(paginationUtils, 'getSettings').mockReturnValue(undefined);
+      mockRootGetters['features/get'].mockReturnValue(true);
+
+      // The stored `ui-performance` setting explicitly blanks out `serverPagination`, which is the only
+      // way it can be missing (the defaults are merged in for every key the setting omits)
+      mockRootGetters['management/byId'].mockImplementation((type: string, id: string) => {
+        if (type === 'management.cattle.io.setting' && id === SETTING.UI_PERFORMANCE) {
+          return { value: JSON.stringify({ serverPagination: null }) };
+        }
+
+        return null;
+      });
+
       const result = paginationUtils.isEnabled({ rootGetters: mockRootGetters, $extension: mockPlugin }, enabledFor);
 
       expect(result).toBe(false);
-
-      jest.clearAllMocks();
     });
 
     it('should return false if enabledFor is not provided', () => {

--- a/shell/utils/units.js
+++ b/shell/utils/units.js
@@ -1,6 +1,29 @@
 export const UNITS = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
 export const FRACTIONAL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y']; // milli micro nano pico femto
 
+/**
+ * @typedef {object} FormatSiOptions
+ * @property {number} [increment] - How much of one unit makes the next one up, normally 1000 or 1024.
+ * @property {boolean} [addSuffix] - Whether the unit is appended to the number at all.
+ * @property {boolean} [addSuffixSpace] - Whether a space goes between the number and the unit.
+ * @property {string} [suffix] - Appended after the unit letter, for example `iB` to make `KiB`.
+ * @property {string | null} [firstSuffix] - Used in place of `suffix` when the result is in the base unit.
+ * @property {number} [startingExponent] - Which unit the value is already expressed in.
+ * @property {number} [minExponent] - The smallest unit the value may be scaled to.
+ * @property {number} [maxExponent] - The largest unit the value may be scaled to. Negative to scale down.
+ * @property {number} [maxPrecision] - How many decimal places to keep, for results below 10. A
+ * result of 10 or more is rounded to an integer whatever this is.
+ * @property {boolean} [canRoundToZero] - Whether a small non-zero value is allowed to format as `0`.
+ */
+
+/**
+ * Format a number with an SI unit, scaling it to the largest unit that keeps it readable.
+ *
+ * @param {number | string} inValue - The value to format. Strings are compared and divided as
+ * numbers, which is what callers that pass a stringified number rely on.
+ * @param {FormatSiOptions} [opt] - How to format it.
+ * @returns {string} The formatted value.
+ */
 export function formatSi(inValue, {
   increment = 1000,
   addSuffix = true,

--- a/shell/utils/url.ts
+++ b/shell/utils/url.ts
@@ -10,7 +10,7 @@ interface ParsedUri extends UriFields {
   query: QueryParams;
 }
 
-export function addParam(url: string, key: string, val: string | string[]): string {
+export function addParam(url: string, key: string, val: string | number | null | (string | number | null)[]): string {
   let out = url + (url.includes('?') ? '&' : '?');
 
   // val can be a string or an array of strings
@@ -28,7 +28,7 @@ export function addParam(url: string, key: string, val: string | string[]): stri
   return out;
 }
 
-export function addParams(url: string, params: QueryParams): string {
+export function addParams(url: string, params: QueryParams | null | undefined): string {
   if ( params && typeof params === 'object' ) {
     Object.keys(params).forEach((key) => {
       url = addParam(url, key, params[key]);

--- a/shell/utils/width.js
+++ b/shell/utils/width.js
@@ -1,6 +1,6 @@
 /**
  * Sets the width of a DOM element. Adapted from [youmightnotneedjquery.com](https://youmightnotneedjquery.com/#set_width)
- * @param {Element} el - The target DOM element
+ * @param {Element | null | undefined} el - The target DOM element, ignored when there isn't one
  * @param {function | string | number} val - The desired width represented as a Number
  */
 export function setWidth(el, val) {
@@ -23,8 +23,12 @@ export function setWidth(el, val) {
 
 /**
  * Gets the width of a DOM element. Adapted from [youmightnotneedjquery.com](https://youmightnotneedjquery.com/#get_width)
- * @param {Element} el - The target DOM element
- * @returns Number representing the width for the provided element
+ * @param {Element | ArrayLike<Element> | null | undefined} el - An array-like of elements, of which
+ * the first is measured. A single `Element` is accepted by callers but always returns `undefined`:
+ * the `!el.length` guard below returns early for anything without a `length`, so the `else` branch
+ * that would measure it is unreachable.
+ * @returns {number | undefined} Number representing the width of the first element, or undefined
+ * when there is nothing to measure
  */
 export function getWidth(el) {
   if (!el || !el.length) {

--- a/storybook/.storybook/store/growl.ts
+++ b/storybook/.storybook/store/growl.ts
@@ -35,7 +35,7 @@ export default  {
     },
     ],
   },
-  getters: require("../../../shell/store/growl.js").getters,
-  actions: require("../../../shell/store/growl.js").actions,
-  mutations: require("../../../shell/store/growl.js").mutations
+  getters: require("../../../shell/store/growl").getters,
+  actions: require("../../../shell/store/growl").actions,
+  mutations: require("../../../shell/store/growl").mutations
 }

--- a/storybook/.storybook/store/i18n.ts
+++ b/storybook/.storybook/store/i18n.ts
@@ -1,6 +1,6 @@
 export default  {
   namespaced: true,
-  getters: require("../../../shell/store/i18n.js").getters,
-  actions: require("../../../shell/store/i18n.js").actions,
-  mutations: require("../../../shell/store/i18n.js").mutations
+  getters: require("../../../shell/store/i18n").getters,
+  actions: require("../../../shell/store/i18n").actions,
+  mutations: require("../../../shell/store/i18n").mutations
 }


### PR DESCRIPTION
### Summary
Fixes #18596

### Occurred changes and/or fixed issues

- **Removes 250 type errors from the baseline, 1655 -> 1405 (With other changes that have merged this is now 816).** The issue counted 254, and 214 is the whole of what was left to fix: 32 had already left the tree, and 8 are the `isRancherPrime` errors caused by the `@shell/config/version` ambient shim, which is #18570's. The other 4 fall out of annotating `allHash` and `formatSi`.
- 21 test files and 16 production files. **No executable line changes in the first commit**: every production edit there is a JSDoc comment, a type annotation or a `.d.ts` member.

Five commits, each droppable in reverse order:

1. **The type-check fixes.** The 250 above. Type-level only.
2. **Converting `growl`, `prefs` and `catalog` to TypeScript**, answering the review question about whether the stores can move. No blockers and no new type errors.
3. **Two behaviour fixes**, for the defects commits 1 and 2 were otherwise working around. See below.
4. **Converting `i18n`**, which commit 3 unblocked. Separate because it also needs an ambient `*.yaml` declaration the others did not, since it is the only TypeScript module in the repo that imports YAML.
5. **Declarations for `config/types` and `utils/object`**, so the converted stores still type-check when an extension compiles shell from source. Commit 2 made `prefs` the first `.ts` module in shell to import either of them, and extensions build with `checkJs: false`, so those untyped imports raised `TS7016` and failed the build where the previous JavaScript did not. Both are declared in full: a partial declaration shadows the real module and hides its remaining exports, which is what the incomplete `@shell/config/version` shim already does.

So all four stores this PR annotates are now TypeScript.

### Technical notes summary

Not VTU 2 drift. Inference collapses against untyped JS: a literal built up after creation infers without its later members, so a state seeded `[]` is `never[]`, `null` is `null`, and `{}` rejects every string index. Five groups:

- **Vuex store state annotated in the production store** (`growl`, `i18n`, `prefs`, `catalog`, `wm`). `prefs.definitions` is the issue's documented open-set exception and gets an index signature; the rest are closed types.
- **Util return and options types** where the literal gains members after creation (`position`, `promise`, `parse-externalid`, `banners`).
- **Existing JSDoc that was simply wrong**, corrected against real callers (`width`, `units`, `chart`, `string`, `url`).
- **Two `.d.ts` members made optional** (`cta.primary`, `enabled[].context`). Both required forms made an existing guard dead code, so this deletes a false claim rather than weakening a contract.
- **Test-side**: element access for the 11 `TS2341`s per #18591, narrowed nullable reads, and real drift fixed (wrong arity, unknown option keys, stale mock shapes).

### Areas or cases that should be tested

No runtime changes. Run the tests and the gate:

```bash
yarn test:ci
node scripts/type-check-diff.mjs
```

- Correct result: **8647 passed, 11 skipped, 16 todo**, identical to `master`, and `✔ No new type errors.`
- The gate was also run against the pre-existing baseline before regenerating, which is what proves no annotation is narrower than existing code. Worth a human eye: `wm.ts`, whose `State` is exported to extensions.

### Areas which could experience regressions

- Extension builds. `config/types` and `utils/object` now carry declarations, so an extension compiling shell from source sees real types where it previously saw `any`. Verified by linking this branch into `kubewarden-ui` and building it: errors fall from 22 to 12, and the 12 that remain are upstream modules this PR does not touch.
- windowmanager - the shell window sizing.
- i18n - The app crashing or not loading the correct translations, it would be immediately obvious.

### Screenshot/Video

Not applicable: type annotations, comments and test files only.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

