### PR TITLE
[JIRA][18783] Added a fallback to get the data using the missing userId. Fill up th…

### DIFF
--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -59,8 +59,11 @@ export default {
         });
       } catch (e) {
         // Fetching a principal directly requires permissions that a standard
-        // (non-admin) user may not have, so the request above can fail. Fall
-        // through to the user-based fallback below to resolve the display info.
+        // (non-admin) user may not have, so the request above can fail. This is
+        // expected for non-admins - log it (rather than swallowing it silently)
+        // and fall through to the user-based fallback below to resolve the
+        // display info.
+        console.debug('Direct principal fetch failed, falling back to the user list', this.value, e); // eslint-disable-line no-console
       }
 
       // Fall back to the management user list, which a user with permission to
@@ -98,11 +101,18 @@ export default {
 
       // Build a norman principal from the user so the model getters (avatar,
       // displayType, ...) work exactly as they would for a fetched principal.
+      //
+      // Derive the provider from the id being rendered (this.value) rather than
+      // user.provider: user.provider is aggregated across all of the user's
+      // principalIds, so for a user with more than one it resolves to 'multiple'
+      // (or the wrong driver) and mislabels the principal we're actually showing.
+      const provider = this.value.split(':')[0].split('_')[0].toLowerCase();
+
       return this.$store.dispatch('rancher/create', {
         type:          NORMAN.PRINCIPAL,
         id:            this.value,
         principalType: 'user',
-        provider:      user.provider,
+        provider,
         name:          user.displayName || user.nameDisplay,
         loginName:     user.username,
         me:            user.isCurrentUser,

--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -1,5 +1,5 @@
 <script>
-import { NORMAN } from '@shell/config/types';
+import { MANAGEMENT, NORMAN } from '@shell/config/types';
 
 export default {
   props: {
@@ -58,8 +58,55 @@ export default {
           opt:  { url: `/v3/principals/${ principalId }` }
         });
       } catch (e) {
+        // Fetching a principal directly requires permissions that a standard
+        // (non-admin) user may not have, so the request above can fail. Fall
+        // through to the user-based fallback below to resolve the display info.
+      }
+
+      // Fall back to the management user list, which a user with permission to
+      // view users can still read even when they can't read principals.
+      if ( !this.principal ) {
+        this.principal = await this.loadPrincipalFromUser();
+      }
+
+      if ( !this.principal ) {
         console.error('Failed to fetch principal', this.value, principalId); // eslint-disable-line no-console
       }
+    },
+
+    /**
+     * Fallback used when a principal can't be resolved directly (e.g. the
+     * current user lacks permission to read principals). Resolves the matching
+     * `management.cattle.io.user` - which the page is expected to have already
+     * loaded (e.g. ExplorerMembers loads the users its members reference) - and
+     * builds a principal from it so the member can still be displayed.
+     */
+    async loadPrincipalFromUser() {
+      // Only look at users the store has actually loaded. Without this guard the
+      // `all` getter would warn (and register the type) on every page that shows
+      // a principal but never loads users.
+      if ( !this.$store.getters['management/typeRegistered']?.(MANAGEMENT.USER) ) {
+        return null;
+      }
+
+      const users = this.$store.getters['management/all']?.(MANAGEMENT.USER) || [];
+      const user = users.find((u) => (u.principalIds || []).includes(this.value));
+
+      if ( !user ) {
+        return null;
+      }
+
+      // Build a norman principal from the user so the model getters (avatar,
+      // displayType, ...) work exactly as they would for a fetched principal.
+      return this.$store.dispatch('rancher/create', {
+        type:          NORMAN.PRINCIPAL,
+        id:            this.value,
+        principalType: 'user',
+        provider:      user.provider,
+        name:          user.displayName || user.nameDisplay,
+        loginName:     user.username,
+        me:            user.isCurrentUser,
+      });
     }
   },
 

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -145,6 +145,40 @@ describe('component: Principal', () => {
       });
     });
 
+    // Regression: user.provider is aggregated across all of the user's principalIds,
+    // so a user with more than one resolves to 'multiple' (or the wrong driver). The
+    // rendered principal must take its provider from its own id so it isn't mislabeled.
+    // (The missing github profile picture is handled by Principal.avatarSrc, which falls
+    // back to an identicon rather than throwing - covered in the principal model tests.)
+    it('should derive the provider from the id, not the aggregated user.provider (github, multi-principal user)', async() => {
+      const githubValue = 'github_user://12345';
+      const user = {
+        principalIds:  [githubValue, 'local://u-abc123'],
+        displayName:   'GH User',
+        username:      'gh-user',
+        provider:      'multiple', // aggregated - must NOT be used for the rendered id
+        isCurrentUser: false,
+      };
+      const { $store, dispatch } = createStore({ users: [user], find: forbidden });
+
+      const wrapper = shallowMount(Principal, {
+        props:  { value: githubValue },
+        global: { mocks: { $fetchState: { pending: false }, $store } },
+      }) as VueWrapper<any, any>;
+
+      await wrapper.vm.loadData();
+
+      expect(dispatch).toHaveBeenCalledWith('rancher/create', {
+        type:          NORMAN.PRINCIPAL,
+        id:            githubValue,
+        principalType: 'user',
+        provider:      'github',
+        name:          'GH User',
+        loginName:     'gh-user',
+        me:            false,
+      });
+    });
+
     it('should resolve the display name from the matching user', async() => {
       const user = {
         principalIds: [value], displayName: 'Base User', username: 'base-user'

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -1,6 +1,6 @@
-import { mount, type VueWrapper } from '@vue/test-utils';
+import { mount, shallowMount, type VueWrapper } from '@vue/test-utils';
 import Principal from '@shell/components/auth/Principal.vue';
-import { NORMAN } from '@shell/config/types';
+import { MANAGEMENT, NORMAN } from '@shell/config/types';
 
 describe('component: Principal', () => {
   it('should render the component', () => {
@@ -73,5 +73,127 @@ describe('component: Principal', () => {
     // Chinese characters encoded as valid UTF-8 (not the deprecated escape() %uXXXX)
     expect(calledUrl).toContain('%E5%BC%A0%E4%B8%89');
     expect(calledUrl).not.toMatch(/%u[0-9a-fA-F]{4}/);
+  });
+
+  // A standard (non-admin) user may lack permission to read principals but still
+  // be able to read the user list. In that case the direct principal fetch fails
+  // and Principal.vue falls back to resolving the member from the users the page
+  // has already loaded into the store (e.g. via ExplorerMembers).
+  describe('given the principal fetch fails (user-based fallback)', () => {
+    const value = 'local://u-abc123';
+
+    const forbidden = () => {
+      throw new Error('forbidden');
+    };
+
+    /**
+     * Build a dispatch spy + $store mock for the fallback scenarios.
+     * @param usersLoaded whether the user type has been registered/loaded in the store
+     * @param users the users the store returns from the `management/all` getter
+     * @param find behaviour of the direct `rancher/find` principal lookup
+     */
+    const createStore = ({ usersLoaded = true, users = [] as any[], find = () => null }) => {
+      const dispatch = jest.fn((action: string, payload: any) => {
+        switch (action) {
+        case 'rancher/find':
+          return find();
+        case 'rancher/create':
+          // classify() returns a model instance - echo the data back for the test
+          return Promise.resolve(payload);
+        default:
+          return undefined;
+        }
+      });
+
+      const $store = {
+        getters: {
+          'rancher/byId':              () => null,
+          'management/typeRegistered': (type: string) => usersLoaded && type === MANAGEMENT.USER,
+          'management/all':            (type: string) => (type === MANAGEMENT.USER ? users : []),
+        },
+        dispatch,
+      };
+
+      return { $store, dispatch };
+    };
+
+    const mountComponent = ($store: any): VueWrapper<any, any> => shallowMount(Principal, {
+      props:  { value },
+      global: { mocks: { $fetchState: { pending: false }, $store } },
+    }) as VueWrapper<any, any>;
+
+    it('should build a principal from the matching user', async() => {
+      const user = {
+        principalIds:  [value],
+        displayName:   'Base User',
+        username:      'base-user',
+        provider:      'local',
+        isCurrentUser: false,
+      };
+      const { $store, dispatch } = createStore({ users: [user], find: forbidden });
+
+      await mountComponent($store).vm.loadData();
+
+      expect(dispatch).toHaveBeenCalledWith('rancher/create', {
+        type:          NORMAN.PRINCIPAL,
+        id:            value,
+        principalType: 'user',
+        provider:      'local',
+        name:          'Base User',
+        loginName:     'base-user',
+        me:            false,
+      });
+    });
+
+    it('should resolve the display name from the matching user', async() => {
+      const user = {
+        principalIds: [value], displayName: 'Base User', username: 'base-user'
+      };
+      const { $store } = createStore({ users: [user], find: forbidden });
+      const wrapper = mountComponent($store);
+
+      await wrapper.vm.loadData();
+
+      expect(wrapper.vm.principal.name).toStrictEqual('Base User');
+    });
+
+    it('should fall back to nameDisplay when the user has no display name', async() => {
+      const user = {
+        principalIds: [value], username: 'base-user', nameDisplay: 'base-user'
+      };
+      const { $store } = createStore({ users: [user], find: forbidden });
+      const wrapper = mountComponent($store);
+
+      await wrapper.vm.loadData();
+
+      expect(wrapper.vm.principal.name).toStrictEqual('base-user');
+    });
+
+    it('should not build a principal when no users are loaded', async() => {
+      const { $store, dispatch } = createStore({ usersLoaded: false, find: forbidden });
+
+      await mountComponent($store).vm.loadData();
+
+      expect(dispatch).not.toHaveBeenCalledWith('rancher/create', expect.anything());
+    });
+
+    it('should leave the principal null when no users are loaded', async() => {
+      const { $store } = createStore({ usersLoaded: false, find: forbidden });
+      const wrapper = mountComponent($store);
+
+      await wrapper.vm.loadData();
+
+      expect(wrapper.vm.principal).toBeNull();
+    });
+
+    it('should leave the principal null when no user matches the principal id', async() => {
+      const users = [{ principalIds: ['local://u-other'], username: 'other' }];
+      const { $store } = createStore({ users, find: forbidden });
+      const wrapper = mountComponent($store);
+
+      await wrapper.vm.loadData();
+
+      expect(wrapper.vm.principal).toBeNull();
+    });
   });
 });

--- a/shell/models/__tests__/principal.test.ts
+++ b/shell/models/__tests__/principal.test.ts
@@ -1,0 +1,32 @@
+import Principal from '@shell/models/principal';
+
+// NormanModel is JS, so type the constructor to accept a plain data object.
+const PrincipalModel = Principal as unknown as new (data: object) => Principal;
+
+describe('class Principal', () => {
+  describe('avatarSrc', () => {
+    it('should use the github profile picture (sized) when one is set', () => {
+      const principal = new PrincipalModel({
+        id: 'github_user://123', provider: 'github', profilePicture: 'https://avatars.example/u/123.png'
+      });
+
+      expect(principal.avatarSrc).toStrictEqual('https://avatars.example/u/123.png?s=80');
+    });
+
+    // Regression: principals resolved from the user list (Principal.vue's fallback) are
+    // github but carry no profilePicture. avatarSrc must not call addParam(undefined) -
+    // it should fall back to a generated identicon rather than throwing and blanking the row.
+    it('should fall back to a generated identicon for a github principal without a picture', () => {
+      const principal = new PrincipalModel({ id: 'github_user://123', provider: 'github' });
+
+      expect(() => principal.avatarSrc).not.toThrow();
+      expect(principal.avatarSrc).toMatch(/^data:image\/png;base64,/);
+    });
+
+    it('should use a generated identicon for non-github providers', () => {
+      const principal = new PrincipalModel({ id: 'local://u-abc', provider: 'local' });
+
+      expect(principal.avatarSrc).toMatch(/^data:image\/png;base64,/);
+    });
+  });
+});

--- a/shell/models/principal.js
+++ b/shell/models/principal.js
@@ -6,18 +6,23 @@ import NormanModel from '@shell/plugins/steve/norman-class';
 
 export default class Principal extends NormanModel {
   get avatarSrc() {
-    if ( this.provider === 'github' ) {
+    // A github principal renders its profile picture, but only when one is
+    // actually set. Principals resolved from the user list (Principal.vue's
+    // fallback for users who can't read /v3/principals) carry no picture, so
+    // fall through to the generated identicon instead of calling
+    // addParam(undefined) - which throws and blanks the whole row.
+    if ( this.provider === 'github' && this.profilePicture ) {
       return addParam(this.profilePicture, 's', 80); // Double the size it will be rendered, for @2x displays
-    } else {
-      let id = this.id || 'Unknown';
-
-      id = id.replace(/[^:]+:\/\//, '');
-
-      const hash = md5(id, 'hex');
-      const out = `data:image/png;base64,${ new Identicon(hash, 80, 0.01).toString() }`;
-
-      return out;
     }
+
+    let id = this.id || 'Unknown';
+
+    id = id.replace(/[^:]+:\/\//, '');
+
+    const hash = md5(id, 'hex');
+    const out = `data:image/png;base64,${ new Identicon(hash, 80, 0.01).toString() }`;
+
+    return out;
   }
 
   get roundAvatar() {


### PR DESCRIPTION
…e principal data that is shown in the table.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18783
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- The list of users on the Cluster and Project Members is not rendered properly even if the User accessing it has access to the list of users on the User & Management screen
- To fix that we fetch the data from the User Management to fill the Principal list so it shows properly.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- The user data is already fetched by the page, and Principal doesn't re-request it, it only uses it to fill up the Principal data.
- It was necessary to fill up the Principal data instead because if not would be a big refactor. The Principal data is the data shown on the page.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- List of Cluster and Project Members
  - Base User with access to Users

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Before: 
<img width="1375" height="1092" alt="image" src="https://github.com/user-attachments/assets/ca15d761-7f33-49ab-b82f-75e721305908" />

After:
<img width="1375" height="1092" alt="image" src="https://github.com/user-attachments/assets/bbedbcac-a2cf-43af-8f73-a9e8d08ee985" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
