### PR TITLE
Bump brace-expansion to 1.1.18, 2.1.4 and 5.0.9

### DIFF
--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -3706,17 +3706,17 @@ boxen@^7.0.0:
     wrap-ansi "^8.1.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -4803,17 +4803,17 @@ bowser@^2.11.0:
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
### Summary

No issue needed. Closes all 7 open brace-expansion Dependabot alerts (1054-1056, 1067-1068, 1071-1072), across [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895). 

### Occurred changes and/or fixed issues

- 1.1.16 to 1.1.18 and 2.1.2 to 2.1.4 in `shell/yarn.lock`; 1.1.16 to 1.1.18 and 5.0.8 to 5.0.9 in `docusaurus/yarn.lock`.
- Lockfiles only: brace-expansion is transitive everywhere, has no `resolutions` entry, and every existing range already admits the patched version.

### Technical notes summary

- Three copies survive because three generations of `minimatch` pull them. They cannot be collapsed onto 5.0.9: 5.x exports `{ expand }` where 1.x and 2.x export the function itself, so forcing it gives `TypeError: expand is not a function` in `minimatch` 3 and 9. Consistency means upgrading minimatch, which 8 packages pin transitively.
- `yarn.lock` and `storybook/yarn.lock` still carry 1.1.16 and 2.1.2 and are **deliberately untouched**. Their alerts are auto-dismissed as `scope: development`; all 7 left open are `scope: runtime` on the two manifests changed here.
- The new limits truncate rather than throw and only engage past 100,000 expansions, so no consumer sees a behaviour change.

### Areas or cases that should be tested

`yarn install --frozen-lockfile` is the real check: it fails if any manifest and lockfile disagree. It passes in both directories on node 24.

```bash
for d in shell docusaurus; do (cd "$d" && rm -f node_modules/.yarn-integrity && yarn install --frozen-lockfile); done
find shell/node_modules docusaurus/node_modules -path '*brace-expansion/package.json' \
  -exec node -p "require('./{}').version" \;
```

A correct result is 1.1.18, 2.1.4 and 5.0.9 only, and no lockfile modified by the install.

### Areas which could experience regressions

- Glob matching in build and lint tooling, which is the only path to this package.
- The docusaurus build.

### Screenshot/Video

No UI change, so there is nothing to show.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
