### PR TITLE
Derive feature-flag row count from the UI's hidden-flag filter

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -207,8 +207,14 @@ describe('Feature Flags', { testIsolation: false }, () => {
       featureFlagsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       featureFlagsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
       cy.getRancherResource('v1', 'management.cattle.io.features').then((resp: Cypress.Response<any>) => {
-        // We filter out fleet and ui-sql-cache feature flags
-        const featureCount = resp.body.count - 2;
+        // The list view hides these flags by name (see shell/list/management.cattle.io.feature.vue).
+        // Derive the expected visible-row count by applying the SAME filter to the API response rather
+        // than subtracting a fixed number: `ui-sql-cache` is being removed from the backend
+        // (rancher/rancher#53996), so it is present in some CI backends and absent in others. A hard
+        // `count - 2` then over- or under-counts by one when only one of these flags actually exists,
+        // which is the "Found 28, expected 27" flake. Filtering by name stays correct either way.
+        const hideFeatureFlags = ['fleet', 'ui-sql-cache'];
+        const featureCount = resp.body.data.filter((f: any) => !hideFeatureFlags.includes(f.metadata.name)).length;
 
         featureFlagsPage.list().resourceTable().sortableTable().checkRowCount(false, featureCount);
       });


### PR DESCRIPTION
### Summary
Fixes #18793
<!-- No issue required: this fixes an intermittent e2e failure. -->

The `Feature Flags > List > validate feature flags table header content` test is failing with `Found 28, expected 27`. It derived the expected visible-row count as `resp.body.count - 2`,
hardcoding that the list view always hides exactly two present flags (`fleet`, `ui-sql-cache`).
`ui-sql-cache` is being removed from the backend and the store already treats
it as always-enabled, so it is absent now.

### Occurred changes and/or fixed issues
- `cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts`: compute the expected visible-row
  count by applying the same name filter the list view uses instead of subtracting a fixed number.

### Technical notes summary
The list view hides flags by name (`shell/list/management.cattle.io.feature.vue` filters out
`['fleet', 'ui-sql-cache']`). The test now applies that same filter to the API response:

```js
const hideFeatureFlags = ['fleet', 'ui-sql-cache'];
const featureCount = resp.body.data.filter((f) => !hideFeatureFlags.includes(f.metadata.name)).length;
```

So the expected count matches the rendered rows whether or not `ui-sql-cache` exists in the backend:
- both present → `length - 2` = UI count
- `ui-sql-cache` removed → `length - 1` = UI count

Test-only change; no production code is touched.

### Areas or cases that should be tested
- `global-settings/feature-flags.spec.ts` (`@globalSettings`, admin) — the List row-count assertion,
  against a backend that both includes and excludes `ui-sql-cache`.

### Areas which could experience regressions
- None expected — the change is confined to a single e2e spec's expected-count derivation.

### Screenshot/Video
N/A — e2e test-only change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
