### PR TITLE
Make the @generic and @globalSettings e2e specs deterministic

### DIFF
--- a/cypress/e2e/po/pages/about.po.ts
+++ b/cypress/e2e/po/pages/about.po.ts
@@ -32,6 +32,10 @@ export default class AboutPagePo extends PagePo {
     return this.links(value).invoke('prop', 'href');
   }
 
+  /**
+   * No longer used by about.spec.ts, which asserts the rendered link instead of following it to the
+   * external site. Kept because this page object ships in the published @rancher/cypress package.
+   */
   clickVersionLink(value: string) {
     this.links(value)
       .then((el) => {

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -32,18 +32,25 @@ describe('About Page', { testIsolation: true, tags: ['@generic', '@adminUser', '
     diagnosticsPo.waitForPage();
   }));
 
-  qase(1520, it('can View release notes', () => {
+  qase(1520, it('renders a link to the release notes', () => {
     aboutPage.goTo();
     aboutPage.waitForPage();
     cy.getRancherVersion().then((version) => {
       const isPrime = version.RancherPrime === 'true';
-      const expectedOrigin = isPrime ? 'https://documentation.suse.com' : 'https://github.com';
-      const expectedUrlPattern = isPrime ? '/cloudnative/rancher-manager/.+/en/release-notes' : '/rancher/rancher/releases/tag/';
+      // Assert the link the dashboard renders instead of following it to the external site. The
+      // site's availability and its redirects are not ours: following it lands on
+      // chrome-error://chromewebdata/ when the runner cannot reach github.com, and for a dev build
+      // the dashboard links to `releases/latest` (see getReleaseNotesURL in shell/utils/version.js)
+      // so the old `/releases/tag/` expectation only held while github.com chose to redirect.
+      //
+      // The community pattern accepts both shapes rather than deriving which one to expect. That is
+      // deliberate: picking the shape here would restate `isDevBuild` in the test, and
+      // shell/utils/__tests__/version.test.ts already covers every dev/release/prime branch of
+      // getReleaseNotesURL exhaustively, so the choice is not left untested.
+      const expectedUrlPattern = isPrime ? '/cloudnative/rancher-manager/.+/en/release-notes' : '/rancher/rancher/releases/(latest|tag/v.+)';
 
-      aboutPage.clickVersionLink('View release notes');
-      cy.origin(expectedOrigin, { args: { expectedUrlPattern } }, ({ expectedUrlPattern }) => {
-        cy.url().should('match', new RegExp(expectedUrlPattern));
-      });
+      aboutPage.links('View release notes').should('have.attr', 'target');
+      aboutPage.getLinkDestination('View release notes').should('match', new RegExp(expectedUrlPattern));
     });
   }));
 
@@ -52,6 +59,15 @@ describe('About Page', { testIsolation: true, tags: ['@generic', '@adminUser', '
       aboutPage.goTo();
       aboutPage.waitForPage();
     });
+
+    // These links are static hrefs rendered by shell/pages/about.vue, so the href and the `target`
+    // that opens it in a new tab are the whole of the dashboard's behaviour here. Loading
+    // github.com from a CI runner is not, and when it fails the assertion sees
+    // chrome-error://chromewebdata/ on every retry.
+    const checkVersionLink = (label: string, expectedUrl: string) => {
+      aboutPage.links(label).should('have.attr', 'target');
+      aboutPage.getLinkDestination(label).should('include', expectedUrl);
+    };
 
     qase(1506, it('can see rancher version', () => {
       // Check Rancher version
@@ -62,32 +78,20 @@ describe('About Page', { testIsolation: true, tags: ['@generic', '@adminUser', '
       });
     }));
 
-    qase(1504, it('can navigate to /rancher/rancher', () => {
-      aboutPage.clickVersionLink('Rancher');
-      cy.origin('https://github.com', () => {
-        cy.url().should('include', 'https://github.com/rancher/rancher');
-      });
+    qase(1504, it('renders a link to /rancher/rancher', () => {
+      checkVersionLink('Rancher', 'https://github.com/rancher/rancher');
     }));
 
-    qase(1507, it('can navigate to /rancher/dashboard', () => {
-      aboutPage.clickVersionLink('Dashboard');
-      cy.origin('https://github.com', () => {
-        cy.url().should('include', 'https://github.com/rancher/dashboard');
-      });
+    qase(1507, it('renders a link to /rancher/dashboard', () => {
+      checkVersionLink('Dashboard', 'https://github.com/rancher/dashboard');
     }));
 
-    qase(1508, it('can navigate to /rancher/helm', () => {
-      aboutPage.clickVersionLink('Helm');
-      cy.origin('https://github.com', () => {
-        cy.url().should('include', 'https://github.com/rancher/helm');
-      });
+    qase(1508, it('renders a link to /rancher/helm', () => {
+      checkVersionLink('Helm', 'https://github.com/rancher/helm');
     }));
 
-    qase(1505, it('can navigate to /rancher/machine', () => {
-      aboutPage.clickVersionLink('Machine');
-      cy.origin('https://github.com', () => {
-        cy.url().should('include', 'https://github.com/rancher/machine');
-      });
+    qase(1505, it('renders a link to /rancher/machine', () => {
+      checkVersionLink('Machine', 'https://github.com/rancher/machine');
     }));
   });
 

--- a/cypress/e2e/tests/pages/generic/home-links.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home-links.spec.ts
@@ -1,9 +1,46 @@
-import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '@/cypress/support/utils/exception-utils';
+import { RANCHER_PAGE_EXCEPTIONS, SUSE_PAGE_EXCEPTIONS, catchTargetPageException } from '@/cypress/support/utils/exception-utils';
 import { qase } from '@/cypress/support/qase';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
+// Hosts serving the third party scripts on the suse.com pages, taken from the CI stack traces:
+// siteintercept.qualtrics.com (jobs 94098082984, 94166365373) and cdn.vector.co (jobs 94244991845,
+// 94090691278).
+const SUSE_PAGE_HOSTS = ['suse.com', 'qualtrics.com', 'vector.co'];
+
 describe('Home Page Support Links', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
   const homePage = new HomePagePo();
+
+  /**
+   * The suse.com pages this spec clicks through to run two third party scripts that reject
+   * asynchronously and late. `catchTargetPageException` handles the ones that arrive through the
+   * `cy.origin` bridge during a test, but not the ones that arrive after the test body, in an
+   * `after each` hook - and a failing hook is not retried, it skips the rest of the spec (CI jobs
+   * 94098082984 and 94166365373 both died that way, 5 passing / 1 failing, no second attempt).
+   *
+   * Those arrive in the primary context, so they need a handler here as well. Both placements are
+   * required, not one or the other: under this repo's `chromeWebSecurity: false`
+   * (cypress/base-config.ts) neither alone suppresses the late rejection.
+   *
+   * Unlike the `cy.origin` scoped handler, which structurally cannot see dashboard pages, this one
+   * runs on our own origin for the whole spec. So it matches on two things: the message must be one
+   * of `SUSE_PAGE_EXCEPTIONS` (never the wider `RANCHER_PAGE_EXCEPTIONS` list) AND the throwing
+   * frame must belong to one of `SUSE_PAGE_HOSTS`. Without that second test it would also swallow a
+   * dashboard error that happened to contain one of the strings.
+   *
+   * The host test is fail closed: a future third party script served from a host not listed above
+   * would not be matched and this spec would fail the way it does today. If a CI run shows an
+   * `after each` hook failure here again, drop the host test and match on the message alone - that
+   * is the weaker but more permissive form, and it still fixes the failures we have seen.
+   */
+  before(() => {
+    Cypress.on('uncaught:exception', (err) => {
+      const fromThirdParty = SUSE_PAGE_HOSTS.some((host) => (err.stack || '').includes(host));
+
+      if (fromThirdParty && SUSE_PAGE_EXCEPTIONS.some((message) => err.message.includes(message))) {
+        return false;
+      }
+    });
+  });
 
   // Click the support links and verify user lands on the correct page
   beforeEach(() => {
@@ -49,11 +86,18 @@ describe('Home Page Support Links', { tags: ['@generic', '@adminUser', '@standar
   }));
 
   qase(1478, it('can click on File an Issue link', () => {
+    // Pin the destination here rather than in the assertion after the click. github.com decides
+    // whether an anonymous visitor gets the new issue form or is bounced to /login, and it stopped
+    // bouncing them, so the old `github.com/login` assertion is now wrong - and it would also have
+    // been satisfied by any other authenticated github URL the link might wrongly point at.
+    homePage.supportLinks().eq(3).should('have.attr', 'href')
+      .and('include', 'github.com/rancher/dashboard/issues/new');
+
     // click File an Issue link
     homePage.clickSupportLink(3, true);
 
     cy.origin('https://github.com', () => {
-      cy.url().should('include', 'github.com/login');
+      cy.url().should('include', 'github.com/');
     });
   }));
 

--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -207,8 +207,13 @@ describe('Feature Flags', { testIsolation: false }, () => {
       featureFlagsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       featureFlagsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
       cy.getRancherResource('v1', 'management.cattle.io.features').then((resp: Cypress.Response<any>) => {
-        // We filter out fleet and ui-sql-cache feature flags
-        const featureCount = resp.body.count - 2;
+        // Apply the same by name filter the list view uses (see hideFeatureFlags in
+        // shell/list/management.cattle.io.feature.vue) instead of subtracting a fixed number.
+        // `count - 2` assumes both hidden flags exist in the backend under test, so it is off by
+        // one against any Rancher build that ships only one of them (ui-sql-cache is on its way
+        // out, see rancher/rancher#53996). That is the "Found 28, expected 27" failure.
+        const hiddenFeatureFlags = ['fleet', 'ui-sql-cache'];
+        const featureCount = resp.body.data.filter((flag: any) => !hiddenFeatureFlags.includes(flag.metadata.name)).length;
 
         featureFlagsPage.list().resourceTable().sortableTable().checkRowCount(false, featureCount);
       });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,6 +18,16 @@ const { register: registerCypressGrep } = require('@cypress/grep');
 registerCypressGrep();
 addCustomCommand();
 
+/**
+ * A lazily loaded route chunk that fails to fetch leaves the app unmounted - vue-router aborts the
+ * navigation and nothing re-renders - and the app never recovers on its own. Specs that run with
+ * `testIsolation: false` get no fresh page between tests or between retry attempts, so that one
+ * failure then fails every remaining test in the file (a single `Loading chunk 2172 failed` in
+ * global-settings/settings.spec.ts produced 47 downstream `[data-testid="side-menu"]` failures).
+ * Set when a chunk of ours fails so the next test starts from a freshly loaded app.
+ */
+let reloadAppBeforeNextTest = false;
+
 // TODO handle redirection errors better?
 // we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here
 Cypress.on('uncaught:exception', (err, runnable) => {
@@ -25,6 +35,36 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   if (err.message.includes('navigation guard')) {
     return false;
   }
+
+  // Deliberately not returning false, so this attempt still fails and is still reported. With
+  // `retries.runMode: 2` a recovered retry will usually pass and the job go green, but the failed
+  // attempt is printed by the retry logger below, so an unexplained ChunkLoadError stays visible in
+  // the CI output instead of being erased.
+  //
+  // webpack puts the failing URL in the message ("Loading chunk 2172 failed.\n(error:
+  // https://.../dashboard/js/2172.b25e9f35.js)"), and Cypress keeps the original text when it wraps
+  // it. Require `/dashboard/js/` so this only ever reacts to our own lazy chunks and never to an
+  // identically worded error from a third party bundle - the suse.com pages this suite visits serve
+  // their own webpack `.chunk.js` files. That path is Rancher's publicPath and covers every chunk
+  // error observed in CI; a consumer serving the bundle from elsewhere gets no recovery rather than
+  // a wrong one.
+  if (err.message.includes('/dashboard/js/') && (err.name === 'ChunkLoadError' || err.message.includes('Loading chunk'))) {
+    reloadAppBeforeNextTest = true;
+  }
+});
+
+beforeEach(() => {
+  // Only specs that opt out of test isolation need this. With `testIsolation: true` Cypress resets
+  // the page itself and the retry recovers unaided (proved by the two about.spec.ts chunk jobs),
+  // so gating here keeps the visit out of every other spec - including the `setup` specs and the
+  // downstream suites that consume this file through the published @rancher/cypress package.
+  if (reloadAppBeforeNextTest && Cypress.config('testIsolation') === false) {
+    // Reload the app rather than retry the failed request, so the next test is not run against the
+    // dead page the chunk failure left behind. See `reloadAppBeforeNextTest` above.
+    cy.visit('/');
+  }
+
+  reloadAppBeforeNextTest = false;
 });
 
 require('cypress-terminal-report/src/installLogsCollector')({

--- a/cypress/support/utils/exception-utils.ts
+++ b/cypress/support/utils/exception-utils.ts
@@ -1,9 +1,33 @@
 
+/**
+ * Messages thrown by the third party scripts the suse.com pages load. Their own list because
+ * generic/home-links.spec.ts has to match them in a primary context handler too, where matching the
+ * whole `RANCHER_PAGE_EXCEPTIONS` list would be far broader than the evidence supports.
+ *
+ * Neither string appears anywhere in `shell/`, `pkg/` or `creators/`, so neither can hide a
+ * dashboard error.
+ */
+export const SUSE_PAGE_EXCEPTIONS = [
+  // Thrown asynchronously by the third party visitor pixel suse.com serves (every frame is in
+  // cdn.vector.co/pixel.js), not by the dashboard. Without it the `Rancher Prime link` test in
+  // generic/home-links.spec.ts fails whenever that script cannot resolve a visitor id, which is
+  // entirely suse.com's business.
+  'No visitor ID available',
+  // `Cannot read properties of undefined (reading 'targetingResponse')`, thrown asynchronously by
+  // the Qualtrics site intercept survey suse.com serves (every frame is in
+  // siteintercept.qualtrics.com, Q_BRANDID=www.suse.com). It lands late, in the `after each` hook
+  // of the `Rancher Prime link` test, which took out the rest of that spec in CI jobs 94098082984
+  // and 94166365373. Matched on the property name alone so it survives Chrome rewording the
+  // TypeError; `targetingResponse` is a Qualtrics API field.
+  'targetingResponse'
+];
+
 export const RANCHER_PAGE_EXCEPTIONS = [
   'TenantFeatures',
   'DomainData',
   'ResizeObserver loop',
-  'cross origin page'
+  'cross origin page',
+  ...SUSE_PAGE_EXCEPTIONS
 ];
 
 /**
@@ -21,7 +45,24 @@ export const catchTargetPageException = (
       { args: { catchExceptions } },
       ({ catchExceptions }) => {
         // This is a repeat of `below`... can't serialise and pass in to cy.origin
-        cy.on('uncaught:exception', (e) => {
+        //
+        // `Cypress.on` rather than `cy.on` on purpose. `cy.on` is torn down when the test body
+        // ends, and it only covers the `cy.origin` block it was registered in - so it misses a
+        // rejection that arrives from a later block, which is what this spec's callers do (register
+        // here, click, then assert inside a second `cy.origin`). Registered inside `cy.origin` this
+        // handler is scoped to the third party origin and to `catchExceptions`, so it can never
+        // see, let alone swallow, an error from a dashboard page. Note that guarantee is structural
+        // and belongs to THIS handler only - the primary context handler in
+        // generic/home-links.spec.ts does run on dashboard pages, which is why it checks the
+        // throwing frame's host as well as the message.
+        //
+        // This covers rejections that arrive through the `cy.origin` bridge. Ones that arrive after
+        // the test body, in a hook, do not come through it - see the primary context handler in
+        // generic/home-links.spec.ts, which is needed as well.
+        //
+        // Note this handler lives for the rest of the spec, so calling `catchTargetPageException`
+        // with the same origin in N tests registers N handlers on that origin.
+        Cypress.on('uncaught:exception', (e) => {
           if (catchExceptions.filter((m) => e.message.indexOf(m) >= 0).length) {
             return false;
           }


### PR DESCRIPTION
### Summary
No linked issue. This targets the `@generic, @globalSettings` e2e shard, which is currently the single largest source of red CI on unrelated PRs.

I surveyed every failed `Tests` workflow run on PRs over a three day window: **42 failed runs across 19 branches**, and pulled the logs for all **83 failed e2e jobs**. Failures are heavily concentrated:

| Failed jobs | Shard |
|---|---|
| 24 | `e2e-test (admin, @adminUser, @generic, @globalSettings)` |
| 23 | `e2e-test (standard_user, @standardUser, @generic, @globalSettings)` |
| 14 | `e2e-test (admin, @adminUser, @explorer2)` |
| 7 | `@navigation, @extensions` |
| 7 | `@charts` |

Those two `@generic, @globalSettings` jobs account for over half of all red runs. Four distinct causes, all one class of defect: **the assertion is coupled to state the dashboard does not control.** This PR fixes those four. It does not touch the other shards.

### Occurred changes and/or fixed issues

**1. `feature-flags.spec.ts` - hardcoded flag count** (41 jobs / 17 branches, the single biggest contributor)

`AssertionError: Too many elements found. Found '28', expected '27'`. The test did `resp.body.count - 2`, hardcoding that both hidden flags exist. `ui-sql-cache` is on its way out (rancher/rancher#53996), so against a backend shipping only one of them the subtraction is off by one. Now applies the same by name filter the list view uses, so it stays correct either way:

```ts
const hiddenFeatureFlags = ['fleet', 'ui-sql-cache'];
const featureCount = resp.body.data.filter((flag) => !hiddenFeatureFlags.includes(flag.metadata.name)).length;
```

Verified identical to `hideFeatureFlags` in `shell/list/management.cattle.io.feature.vue:7-10`, same names and same field.

**2. `home-links.spec.ts` - third party scripts on the live suse.com pages** (34 jobs / 16 branches)

Two suse.com scripts reject asynchronously: the `cdn.vector.co` visitor pixel (`No visitor ID available`) and the Qualtrics site intercept survey (`targetingResponse`). The Qualtrics one lands **late, in the `after each` hook**, and a failing hook is not retried - it skips the rest of the spec. Jobs 94098082984 and 94166365373 both died that way at `5 passing / 1 failing`, with no second attempt, so the retry budget that rescues the other 9 jobs was unavailable.

Both handler placements are required. Under this repo's `chromeWebSecurity: false` (`cypress/base-config.ts:113`), neither alone suppresses the late rejection - measured, see below.

Also: the `github.com/login` assertion was stale. GitHub stopped bouncing anonymous visitors to `/login`. The href is now pinned before the click, which is strictly stronger - the old assertion would also have been satisfied by any other authenticated github URL the link might wrongly point at.

**3. ChunkLoadError cascade**

A failed lazy route chunk leaves the app unmounted, and with `testIsolation: false` nothing reloads it - not between tests, not between retry attempts. One `Loading chunk 2172 failed` in the first test of `settings.spec.ts` produced **47 downstream `[data-testid="side-menu"]` failures** in job 94166522929. The two `testIsolation: true` chunk jobs recovered on retry unaided, which is the control case.

The failing attempt is **still reported** - this is a recovery, not a suppression. Gated on `/dashboard/js/` so it can only ever react to our own chunks, and on `testIsolation === false` so it stays out of every other spec and out of the published `@rancher/cypress` package's consumers.

**4. `about.spec.ts` - same two patterns.**

### Technical notes summary

The Cypress semantics here were **measured, not reasoned about**, under Chrome for Testing 150.0.7871.124 (the CI major) with the repo's `chromeWebSecurity: false` and its own `before:browser:launch` flags:

| handler placement | result |
|---|---|
| `cy.on` inside `cy.origin` (current code) | FAILS, with bare third party page frames - CI's exact hook stack shape |
| `Cypress.on` inside `cy.origin` alone | FAILS |
| primary context handler alone | FAILS |
| **both (this PR)** | **2 passing** |

`cy.on` is torn down when the test body ends and only covers the `cy.origin` block it was registered in, so it misses a rejection arriving from a later block - which is what these tests do (register, click, then assert inside a second `cy.origin`).

The primary context handler runs on our own origin, so it matches on **two** things: the message must be one of the two known strings (never the wider `RANCHER_PAGE_EXCEPTIONS` list) **and** the throwing frame must belong to `suse.com`, `qualtrics.com` or `vector.co`. Without the host test it would also swallow a dashboard error that happened to contain one of those strings. Both strings grep to zero in `shell/`, `pkg/` and `creators/`.

The host test is **fail closed**: a future third party script on an unlisted host would not be matched and this spec would fail the way it does today. That fallback is written into the code comment so whoever hits it does not have to re-derive this.

**On the dependency upgrade theory** - worth recording, since it was the starting hypothesis and it is wrong. The PR failure rate was already ~75% in early July (74 fail / 24 pass), *before* the Cypress 15.19, webpack-dev-server 5.2.6 and babel/postcss bumps landed. And `scripts/e2e-k3s-start.sh:242-252` shows CI `kubectl cp`s a production `dist` into the Rancher pod, so there is no webpack-dev-server in the serving path at all. The 4 chunk errors span 4 unrelated branches, 2 chunk ids and 3 content hashes. Ruled out for this cohort.

### Areas or cases that should be tested

**This is the point of opening the PR.** These five specs have never been run against a real Rancher - all the evidence above is Cypress semantics on synthetic fixtures plus CI log analysis. Local verification was eslint (exit 0) and `tsc -p cypress/tsconfig.json` (unchanged: 3 pre-existing `cypress/template` TS2307 errors, present on master).

Signals to watch on the first runs:
- `generic/home-links.spec.ts` reporting **6 passing with no `"after each" hook` line**. This is the highest value signal and needs 2-3 runs before the hook fix can be called good, because the failure is intermittent.
- `global-settings/feature-flags.spec.ts` no longer reporting `Too many elements found`.
- Both `@generic, @globalSettings` jobs green, admin and standard_user.
- If a ChunkLoadError appears again, the useful detail is whether the *following* test in the same spec passes.

### Areas which could experience regressions

- `cypress/support/e2e.ts` and `cypress/support/utils/exception-utils.ts` ship in the published `@rancher/cypress` package, so both changes reach downstream extension consumers. The chunk `beforeEach` is gated on `testIsolation === false` to keep it inert for everyone else; `SUSE_PAGE_EXCEPTIONS` is new exported surface.
- `catchTargetPageException`'s `cy.origin` branch now uses `Cypress.on`, so the handler outlives the test body. Blast radius is 3 call sites, all in `home-links.spec.ts`. It stays scoped to the third party origin and cannot see dashboard pages.
- **Coverage deliberately traded, disclosed rather than buried:** `about.spec.ts` and the `File an Issue` test no longer navigate to the live external sites, so "GitHub serves this URL" is no longer covered. What the dashboard actually controls - the rendered `href` and `target` - is still asserted, and the test titles were renamed to say what they now do. `getReleaseNotesURL`'s dev/release/prime branches remain covered exhaustively by `shell/utils/__tests__/version.test.ts`.
- The host match is a substring test on `err.stack`, so a dashboard error whose stack merely *mentions* one of those three hosts would still be swallowed. Much narrower than message only, not airtight. A stricter form means parsing frame origins, which seemed like more machinery than this warrants.

### Screenshot/Video
n/a, e2e test changes only. No product code is touched.

### Relationship to #18623

@marcelofukumoto's #18623 covers overlapping ground at 60 file scope and has been open since 4 Aug. This is deliberately narrow and independent, and it converges on that PR's approach where that approach is right. Two places where it may be worth comparing notes:

- #18623 returns `false` on ChunkLoadError, which erases the failure from the run. This treats it as a recovery and lets the attempt fail, so an unexplained chunk error stays visible in CI output.
- #18623's release notes assertion on `/releases/tag/` would deterministically fail on a dev build, where `getReleaseNotesURL` renders `releases/latest`.

Happy to fold this into #18623 instead if that is preferred.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
<!-- The cohort spans both the @adminUser and @standardUser variants of this shard; both are expected to go green. -->
