### PR TITLE
Bump nanoid from 3.3.16 to 3.3.18 in /

### DIFF
--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -7159,9 +7159,9 @@ multicast-dns@^7.2.5:
     thunky "^1.0.2"
 
 nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 negotiator@0.6.3:
   version "0.6.3"

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
   },
   "resolutions": {
     "uuid": "11.1.1",
+    "nanoid": "3.3.18",
     "@cypress/request": "4.0.1",
     "form-data": "4.0.6",
     "cross-spawn": "7.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11460,15 +11460,10 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
-
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.3, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### Summary
Bumps [nanoid](https://github.com/ai/nanoid) from 3.3.16 to 3.3.18. This is a security fix that pins `nanoid` to `3.3.18` via a `resolutions` entry, forcing all transitive uses up to the patched version.

### Occurred changes and/or fixed issues
Updates `nanoid` to `3.3.18` across the affected manifests (`package.json` resolution, `yarn.lock`, `docusaurus/yarn.lock`). No application logic is changed — this is a dependency-only bump.

### Vulnerabilities fixed
Bumping `nanoid` to `3.3.18` resolves the following Dependabot alert(s):

- [**Dependabot #1101**](https://github.com/rancher/dashboard/security/dependabot/1101) · **HIGH** — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213: nanoid: custom generators can loop indefinitely when size is zero Vulnerable `< 3.3.17`, patched in `3.3.17`.

### Technical notes summary
Security-only dependency bump. `nanoid` is pinned via the root `package.json` `resolutions` block so every transitive dependency resolves to `3.3.18`.

### Areas or cases that should be tested
General smoke test of the dashboard. `nanoid` is a small id-generation utility used transitively; no functional behavior should change.

### Areas which could experience regressions
None expected — dependency-only change.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/4c326b95-86aa-482b-ae74-0f5dce1709c1

**Playwright checks performed** (video recorded, 1280×800):
1. **Login + styled dashboard home renders** — logged in with local credentials; landed on `/dashboard/home` with the Rancher masthead visible and body font `Lato, arial, …` (not the UA serif default), confirming the postcss-built stylesheet is applied. ✅ **PASS**
2. **Local cluster explorer renders with real data** — navigated to `c/local/explorer`; no "Error" masthead, side nav present, and cluster content (Capacity/Workloads/Nodes/Events) rendered from the proxied live `local` cluster API. ✅ **PASS**
3. **ConfigMaps resource list renders real cluster rows** — navigated to `c/local/explorer/configmap`; the SortableTable rendered **100 real ConfigMap rows** from the cluster (Name/Namespace/Age). ✅ **PASS**
4. **Resource detail YAML editor renders** — opened a ConfigMap detail → **Show Configuration → YAML** tab; the CodeMirror editor rendered the full manifest (`apiVersion: v1`, `kind`/`data`/`metadata`) with syntax highlighting, confirming the Vue-compiled code-editor component works. ✅ **PASS**

**Verdict:** **4/4 checks passed.** The dashboard built cleanly with nanoid 3.3.18 (postcss + Vue SFC compilation ran through the bumped package) and every exercised view — login, cluster explorer, resource list, and the YAML editor — renders and functions correctly against real proxied cluster data. The nanoid bump is behavior-preserving for the dashboard's usage.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

