### PR TITLE
Show inline error for unknown resource type or resource id

### DIFF
--- a/shell/components/ResourceDetail/__tests__/index.test.ts
+++ b/shell/components/ResourceDetail/__tests__/index.test.ts
@@ -1,0 +1,145 @@
+import { shallowMount } from '@vue/test-utils';
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+jest.mock('@shell/mixins/create-edit-view/impl', () => ({
+  __esModule: true,
+  default:    {
+    computed: {
+      doneRoute() {
+        return null;
+      },
+      doneParams() {
+        return {};
+      },
+    },
+  },
+}));
+
+jest.mock('@shell/composables/resourceDetail', () => ({ useResourceDetailPageProvider: jest.fn() }));
+
+type StoreOpts = {
+  schema?: any;
+  findError?: any;
+};
+
+const createStore = ({ schema, findError }: StoreOpts) => {
+  const dispatch = jest.fn((action: string) => {
+    if (action.endsWith('/find')) {
+      if (findError) {
+        return Promise.reject(findError);
+      }
+
+      return Promise.resolve({});
+    }
+    if (action.endsWith('/clone') || action.endsWith('/cleanForDetail')) {
+      return Promise.resolve({});
+    }
+
+    return Promise.resolve();
+  });
+
+  return {
+    getters: {
+      'i18n/t':                   (key: string, args: any) => `${ key }-${ JSON.stringify(args ?? {}) }`,
+      currentStore:               () => 'cluster',
+      'cluster/schemaFor':        () => schema,
+      'cluster/all':              () => [],
+      'type-map/hasCustomDetail': () => false,
+      'type-map/hasCustomEdit':   () => false,
+      'type-map/importDetail':    () => null,
+      'type-map/importEdit':      () => null,
+      'type-map/optionsFor':      () => ({}),
+    },
+    dispatch,
+  };
+};
+
+const createWrapper = (store: any) => {
+  // Start with pending: true so the initial render is the Loading stub (the
+  // real component doesn't guard `value.name` because the Nuxt `fetch()`
+  // hook is what populates `value` — under the test harness we drive that
+  // by hand).
+  const fetchState = { pending: true };
+
+  const wrapper = shallowMount(ResourceDetail as any, {
+    global: {
+      mocks: {
+        $store:      store,
+        $route:      { params: { resource: 'bogus-resource-type', id: 'bogus-id' }, query: {} },
+        $fetchState: fetchState,
+        t:           (key: string, args: any) => `${ key }-${ JSON.stringify(args ?? {}) }`,
+      },
+      stubs: {
+        FailWhale:    true,
+        Masthead:     true,
+        Loading:      true,
+        ResourceYaml: true,
+        Banner:       true,
+        IconMessage:  true,
+        DetailTop:    true,
+      },
+      directives: {
+        'ui-context': () => {},
+        shortkey:     () => {},
+        'clean-html': () => {},
+      },
+    },
+  });
+
+  return { wrapper, fetchState };
+};
+
+const runFetch = async(wrapper: any, fetchState: any) => {
+  await (wrapper.vm.$options as any).fetch.call(wrapper.vm);
+  fetchState.pending = false;
+  wrapper.vm.$forceUpdate();
+  await wrapper.vm.$nextTick();
+};
+
+describe('component: ResourceDetail', () => {
+  it('renders the in-context FailWhale (not the details) when the resource type has no schema', async() => {
+    const store = createStore({ schema: undefined });
+    const { wrapper, fetchState } = createWrapper(store);
+
+    await runFetch(wrapper, fetchState);
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeInstanceOf(Error);
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'Masthead' }).exists()).toBe(false);
+    // Must NOT redirect to the global fail-whale page
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  it('renders the in-context FailWhale when the resource is not found (404)', async() => {
+    const store = createStore({ schema: { id: 'bogus-resource-type' }, findError: { status: 404 } });
+    const { wrapper, fetchState } = createWrapper(store);
+
+    await runFetch(wrapper, fetchState);
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeInstanceOf(Error);
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'Masthead' }).exists()).toBe(false);
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  it('renders the in-context FailWhale when the resource is forbidden (403)', async() => {
+    const store = createStore({ schema: { id: 'bogus-resource-type' }, findError: { status: 403 } });
+    const { wrapper, fetchState } = createWrapper(store);
+
+    await runFetch(wrapper, fetchState);
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeInstanceOf(Error);
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(true);
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  it('does not set resourceNotFoundError when the resource is found', async() => {
+    const store = createStore({ schema: { id: 'bogus-resource-type' } });
+    const { wrapper, fetchState } = createWrapper(store);
+
+    await runFetch(wrapper, fetchState);
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeNull();
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+});

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -14,6 +14,7 @@ import { clone, diff } from '@shell/utils/object';
 import IconMessage from '@shell/components/IconMessage';
 import { stringify } from '@shell/utils/error';
 import { Banner } from '@components/Banner';
+import FailWhale from '@shell/components/FailWhale';
 import { useResourceDetailPageProvider } from '@shell/composables/resourceDetail';
 
 function modeFor(route) {
@@ -48,7 +49,8 @@ export default {
     ResourceYaml,
     Masthead,
     IconMessage,
-    Banner
+    Banner,
+    FailWhale,
   },
 
   mixins: [CreateEditView],
@@ -138,6 +140,15 @@ export default {
     const schema = store.getters[`${ inStore }/schemaFor`](resourceType);
     let model, initialModel, liveModel, yaml;
 
+    // If the resource type (e.g. CRD) is gone, render the error in-context (in
+    // place of the details) rather than redirecting to the global fail-whale
+    // page, so the side menu and cluster context are retained.
+    if ( !schema && realMode !== _CREATE && realMode !== _IMPORT ) {
+      this.resourceNotFoundError = new Error(this.t('nav.failWhale.resourceNotFound', { resource: resourceType }, true));
+
+      return;
+    }
+
     if ( realMode === _CREATE || realMode === _IMPORT ) {
       if ( !namespace ) {
         namespace = store.getters['defaultNamespace'];
@@ -181,7 +192,13 @@ export default {
         });
       } catch (e) {
         if (e.status === 404 || e.status === 403) {
-          store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceIdNotFound', { resource: resourceType, fqid }, true)));
+          // Render the error in-context (in place of the details) rather than
+          // redirecting to the global fail-whale page, so the side menu and
+          // cluster context are retained (e.g. after the resource has been
+          // deleted but the user still has a preference/URL pointing at it).
+          this.resourceNotFoundError = new Error(this.t('nav.failWhale.resourceIdNotFound', { resource: resourceType, fqid }, true));
+
+          return;
         }
         console.info(`Could not find '${ resourceType }' with id '${ id }''`, e); // eslint-disable-line no-console
         liveModel = {};
@@ -251,20 +268,24 @@ export default {
       resourceSubtype: null,
 
       // Set by fetch
-      hasCustomDetail: null,
-      hasCustomEdit:   null,
-      resourceType:    null,
-      asYaml:          null,
-      yaml:            null,
-      liveModel:       null,
-      initialModel:    null,
-      mode:            null,
-      as:              null,
-      value:           null,
-      model:           null,
-      notFound:        null,
-      canViewYaml:     null,
-      errors:          []
+      hasCustomDetail:       null,
+      hasCustomEdit:         null,
+      resourceType:          null,
+      asYaml:                null,
+      yaml:                  null,
+      liveModel:             null,
+      initialModel:          null,
+      mode:                  null,
+      as:                    null,
+      value:                 null,
+      model:                 null,
+      notFound:              null,
+      canViewYaml:           null,
+      errors:                [],
+      // When set, the resource type or the specific resource could not be
+      // found. The error is rendered in-context (in place of the details)
+      // instead of redirecting to the fail-whale page.
+      resourceNotFoundError: null,
     };
   },
 
@@ -411,6 +432,10 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending || notFound" />
+  <FailWhale
+    v-else-if="resourceNotFoundError"
+    :error="resourceNotFoundError"
+  />
   <component
     :is="showComponent"
     v-else-if="isFullPageOverride"


### PR DESCRIPTION
### Summary
Fixes #11345

Note, this is similar to https://github.com/rancher/dashboard/pull/18509, but for the resource detail view rather than the list view.

### Occurred changes and/or fixed issues
When navigating to a resource whose type (schema) or specific id cannot be found, the details page previously redirected to the global fail-whale page, which loses the side menu and cluster context.

`ResourceDetail` now renders the error in-context (in place of the details) via `FailWhale`, so the side menu and cluster context are retained. This covers:

- Resource type not found (no schema for the requested resource) — e.g. a CRD that has been removed.
- Specific resource id not found (`find` returns 404 or 403) — e.g. a resource that was deleted, or which the current user no longer has access to.

### Technical notes summary
- In [shell/components/ResourceDetail/index.vue](shell/components/ResourceDetail/index.vue):
  - Added a `resourceNotFoundError` data property, set when either the schema is missing or `find` throws with `status === 404 || status === 403`.
  - The template renders `<FailWhale :error="resourceNotFoundError" />` in-context when this is set, instead of falling through to the existing detail/edit/YAML rendering.
  - Uses the existing `nav.failWhale.resourceNotFound` / `nav.failWhale.resourceIdNotFound` i18n keys.
- Create/Import modes are unaffected (the missing-schema branch is skipped for `_CREATE`/`_IMPORT`).

### Areas or cases that should be tested
- Navigate to a resource type that does not exist (e.g. a URL for a CRD that has been removed) and confirm the inline error is shown and the side menu / cluster context remain.
- Navigate to a resource id that does not exist (deleted resource) and confirm the inline error is shown.
- As a user without permission to a specific resource (403), confirm the inline error is shown rather than a redirect.
- Confirm normal detail, edit, create, clone, stage and import flows for existing resource types/ids still work.
- Tested locally in Chrome.

Example: For a resource:

- Create a secret and open the detail view for that secret
- Delete the secret from the CLI using kubectl
- Refresh the browser

Example: for a resource type:

- Create a CRD (e.g. use the cronjob one from the k8s docs
- Go to the list page for this CRD
- Delete the CRD from the CLI using kubectl
- Refresh the browser

### Areas which could experience regressions
- All resource detail / edit / create pages (they share `ResourceDetail`).
- YAML view for existing resources.
- Fail-whale rendering for genuinely unresolvable navigation targets.

### Screenshot/Video

Refresh after resource deleted:

<img width="1275" height="806" alt="image" src="https://github.com/user-attachments/assets/405f5c84-d2ed-4810-9880-6f16e3f9c609" />

Refresh after CRD deleted:

<img width="1266" height="742" alt="image" src="https://github.com/user-attachments/assets/3d894f2b-4461-46bd-87dc-925865cb0a63" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
