### PR TITLE
Fix Fleet Clusters jenkins failures

### DIFF
--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -23,7 +23,7 @@ const branch = 'master';
 const paths = 'qa-test-apps/nginx-app';
 const downloadsFolder = Cypress.config('downloadsFolder');
 
-describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployment into the downstream cluster', { testIsolation: 'off', tags: ['@fleet', '@adminUser', '@jenkins'] }, () => {
+describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployment into the downstream cluster', { testIsolation: 'off', tags: ['@fixfleet','@fleet', '@adminUser', '@jenkins'] }, () => {
   const region = 'us-west-1';
   const namespace = 'fleet-default';
   let removeCluster = false;

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -85,6 +85,12 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
   qase(9691, it('data is populated in fleet cluster list and detail view', () => {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
+    // Provisioning clusters can briefly render "Active" in the UI as soon as the resource
+    // is created, before the backend has finished computing its real status (it then flips
+    // back to Provisioning/Updating for several minutes). Waiting on the UI text alone can
+    // therefore produce a false positive here, so poll the underlying resource via the API
+    // until it reports a real, non-transitioning "active" state before checking the UI.
+    cy.waitForResourceState('v1', `provisioning.cattle.io.clusters/${ namespace }`, clusterName, 'active', Math.ceil(VERY_LONG_TIMEOUT_OPT.timeout / 1500));
     clusterList.list().state(clusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // create gitrepo
@@ -92,8 +98,12 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
       removeGitRepo = true;
     });
 
-    // go to fleet gitrepo and wait until git repo is in active state
-    fleetAppBundlesListPage.navTo();
+    // Go to fleet gitrepo and wait until git repo is in active state.
+    // Don't use navTo() here: it asserts the sortable table is visible as part of the navigation
+    // itself, and the session starts on the fleet-local workspace, which has no App Bundles and
+    // so renders the empty state instead of a table. Visit the list directly and switch to
+    // fleet-default (the workspace the git repo was created in) before asserting on any row.
+    fleetAppBundlesListPage.goTo();
     fleetAppBundlesListPage.waitForPage();
     headerPo.selectWorkspace(namespace);
     fleetAppBundlesListPage.resourceTableDetails(gitRepo, 1).contains('Active', LONG_TIMEOUT_OPT);
@@ -107,8 +117,14 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
 
     // check name
     fleetClusterListPage.resourceTableDetails(clusterName, 2).should('be.visible');
-    // check cluster state in fleet
-    fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Not Ready', MEDIUM_TIMEOUT_OPT);
+    // check cluster state in fleet.
+    // A freshly provisioned downstream cluster is Active in provisioning.cattle.io long before it
+    // is Active in fleet: the fleet cluster sits in "Wait Check-In" until the fleet agent deployed
+    // into the downstream cluster registers back, which can take several minutes. Don't assert on
+    // that intermediate state (whether we catch it at all is a race), and don't wait it out purely
+    // through the UI either - poll the fleet cluster resource until it really is active, then
+    // assert the list reflects it.
+    cy.waitForResourceState('v1', `fleet.cattle.io.clusters/${ namespace }`, clusterName, 'active', Math.ceil(VERY_LONG_TIMEOUT_OPT.timeout / 1500));
     fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Active', EXTRA_LONG_TIMEOUT_OPT);
     // check Git Repos ready
     fleetClusterListPage.resourceTableDetails(clusterName, 3).should('have.text', '1');
@@ -140,7 +156,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     // check target
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 5).contains('All');
     // check cluster resources
-    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('contain.text', '—');
+    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('contain.text', '1');
   }));
 
   it('check all tabs are available in the details view', () => {
@@ -269,14 +285,21 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     });
 
     // enable feature: provisioningv2-fleet-workspace-back-population
+    // Note: we don't assume the initial state of the feature flag. It may be left in the
+    // "Active" state from a previous failed run (this describe uses testIsolation: false
+    // and the QA cluster is shared). Only activate it if it's not already active, and
+    // always mark it for cleanup so the after() hook can reset the environment.
     FeatureFlagsPagePo.navTo();
     featureFlagsPage.waitForPage();
-    featureFlagsPage.list().details(feature, 0).should('include.text', 'Disabled');
-    featureFlagsPage.list().clickRowActionMenuItem(feature, 'Activate');
-    featureFlagsPage.clickCardActionButtonAndWait('Activate', feature, true, { waitForModal: true, waitForRequest: true });
-    featureFlagsPage.list().details(feature, 0).should('include.text', 'Active').then(() => {
-      disableFeature = true;
+    // Mark for cleanup up-front so a mid-test failure still triggers the after() reset.
+    disableFeature = true;
+    featureFlagsPage.list().details(feature, 0).invoke('text').then((text) => {
+      if (!text.includes('Active')) {
+        featureFlagsPage.list().clickRowActionMenuItem(feature, 'Activate');
+        featureFlagsPage.clickCardActionButtonAndWait('Activate', feature, true, { waitForModal: true, waitForRequest: true });
+      }
     });
+    featureFlagsPage.list().details(feature, 0).should('include.text', 'Active');
 
     const loadingPo = new LoadingPo('.loading-indicator');
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/2291 by stabilizing the Fleet clusters E2E spec against real AWS RKE2 downstream clusters.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Cluster Active state: Polls provisioning.cattle.io.clusters via API until the cluster is genuinely active before validating the UI.
- App Bundles navigation: Uses goTo() + waitForPage() and switches from fleet-local to fleet-default before validating App Bundles.
- Fleet cluster readiness: Removes the racy Not Ready assertion and polls fleet.cattle.io.clusters until the cluster is Active.
- Cluster resources: Corrects the expected App Bundles resource count from — to 1 because we are going to have the resource that we created.
- Feature flag handling: Makes provisioningv2-fleet-workspace-back-population activation idempotent and ensures cleanup runs even after failures.

### Screenshot
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1139" height="704" alt="Screenshot 2026-08-13 at 5 52 16 p m" src="https://github.com/user-attachments/assets/15feee42-9f0c-4747-90e2-711989fe4165" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
