### PR TITLE
fix issue with poor labels in table checkboxes

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6670,8 +6670,10 @@ sortableTable:
     lastPageBtn: Last page of results icon
     sortingIconDesc: Table header descending sort icon
     sortingIconAsc: Table header ascending sort icon
-  genericGroupCheckbox: Table group selection checkbox
-  genericRowCheckbox: Table row selection checkbox for item {item}
+  genericGroupCheckbox: Select all rows
+  genericRowCheckbox: Select {item}
+  genericRowCheckboxNoItem: Select row
+  selectAllResources: Select all {resource}
   tableActionsLabel: More actions - { resource }
   tableActionsImgAlt: More actions icon
   bulkActions:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6705,8 +6705,10 @@ sortableTable:
     lastPageBtn: Last page of results icon
     sortingIconDesc: Table header descending sort icon
     sortingIconAsc: Table header ascending sort icon
-  genericGroupCheckbox: Table group selection checkbox
-  genericRowCheckbox: Table row selection checkbox for item {item}
+  genericGroupCheckbox: Select all rows
+  genericRowCheckbox: Select {item}
+  genericRowCheckboxNoItem: Select row
+  selectAllResources: Select all {resource}
   expandColumnHeader: Expand
   actionsColumnHeader: Actions
   tableActionsLabel: More actions - { resource }

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -604,6 +604,14 @@ export default {
     },
 
     /**
+     * Readable, plural name of the resource being listed, used by the table to
+     * describe the select all checkbox
+     */
+    selectAllLabel() {
+      return this.parsedPagingParams.pluralLabel;
+    },
+
+    /**
      * Get the counts data by namespace for the current resource type
      */
     namespaceCounts() {
@@ -715,6 +723,7 @@ export default {
     :paging="true"
     :paging-params="parsedPagingParams"
     :paging-label="pagingLabel"
+    :select-all-label="selectAllLabel"
     :rows-per-page="rowsPerPage"
     :row-actions="rowActions"
     :table-actions="_showBulkActions"

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -74,6 +74,14 @@ export default {
       type:     Function,
       required: true,
     },
+    /**
+     * Accessible label for the select all checkbox. Supplied by SortableTable,
+     * which resolves it from the resource type where one is known.
+     */
+    selectAllLabel: {
+      type:    String,
+      default: '',
+    },
     noRows: {
       type:    Boolean,
       default: true,
@@ -231,7 +239,7 @@ export default {
           data-testid="sortable-table_check_select_all"
           :indeterminate="isIndeterminate"
           :disabled="noRows || noResults"
-          :alternate-label="t('sortableTable.genericGroupCheckbox')"
+          :alternate-label="selectAllLabel || t('sortableTable.genericGroupCheckbox')"
         />
       </th>
       <th

--- a/shell/components/SortableTable/__tests__/THead.test.ts
+++ b/shell/components/SortableTable/__tests__/THead.test.ts
@@ -1,0 +1,47 @@
+import { shallowMount } from '@vue/test-utils';
+import { Checkbox } from '@components/Form/Checkbox';
+import THead from '@shell/components/SortableTable/THead.vue';
+
+describe('component: THead', () => {
+  const requiredProps = {
+    columns:         [],
+    sortBy:          'name',
+    tableActions:    true,
+    rowActions:      false,
+    rowActionsWidth: 40,
+    howMuchSelected: 'none',
+    labelFor:        (col: { name: string }) => col.name,
+  };
+
+  const mountTHead = (props = {}) => shallowMount(THead, {
+    props:  { ...requiredProps, ...props },
+    global: { mocks: { t: (key: string) => key } },
+  });
+
+  describe('select all checkbox', () => {
+    it('should use the label provided by the parent table', () => {
+      const wrapper = mountTHead({ selectAllLabel: 'Select all Projects/Namespaces' });
+
+      const checkbox = wrapper.findComponent(Checkbox);
+
+      expect(checkbox.props('alternateLabel')).toBe('Select all Projects/Namespaces');
+    });
+
+    it.each([
+      ['no label is provided', undefined],
+      ['an empty label is provided', ''],
+    ])('should fall back to the generic label when %s', (_, selectAllLabel) => {
+      const wrapper = mountTHead({ selectAllLabel });
+
+      const checkbox = wrapper.findComponent(Checkbox);
+
+      expect(checkbox.props('alternateLabel')).toBe('sortableTable.genericGroupCheckbox');
+    });
+
+    it('should not be rendered when the table has no table actions', () => {
+      const wrapper = mountTHead({ tableActions: false, selectAllLabel: 'Select all Namespaces' });
+
+      expect(wrapper.findComponent(Checkbox).exists()).toBe(false);
+    });
+  });
+});

--- a/shell/components/SortableTable/__tests__/THead.test.ts
+++ b/shell/components/SortableTable/__tests__/THead.test.ts
@@ -122,7 +122,11 @@ describe('component: THead', () => {
 
   describe('select all checkbox', () => {
     it('should use the label provided by the parent table', () => {
-      const wrapper = mountTHead({ tableActions: true, columns: [], selectAllLabel: 'Select all Projects/Namespaces' });
+      const wrapper = mountTHead({
+        tableActions:   true,
+        columns:        [],
+        selectAllLabel: 'Select all Projects/Namespaces',
+      });
 
       const checkbox = wrapper.findComponent(Checkbox);
 
@@ -133,7 +137,11 @@ describe('component: THead', () => {
       ['no label is provided', undefined],
       ['an empty label is provided', ''],
     ])('should fall back to the generic label when %s', (_, selectAllLabel) => {
-      const wrapper = mountTHead({ tableActions: true, columns: [], selectAllLabel });
+      const wrapper = mountTHead({
+        tableActions: true,
+        columns:      [],
+        selectAllLabel,
+      });
 
       const checkbox = wrapper.findComponent(Checkbox);
 

--- a/shell/components/SortableTable/__tests__/THead.test.ts
+++ b/shell/components/SortableTable/__tests__/THead.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import jsyaml from 'js-yaml';
 import { shallowMount } from '@vue/test-utils';
+import { Checkbox } from '@components/Form/Checkbox';
 import THead from '@shell/components/SortableTable/THead.vue';
 import { NONE } from '@shell/components/SortableTable/selection';
 
@@ -117,6 +118,33 @@ describe('component: THead', () => {
       '%tableHeaders.explore%',
       '%sortableTable.actionsColumnHeader%',
     ]);
+  });
+
+  describe('select all checkbox', () => {
+    it('should use the label provided by the parent table', () => {
+      const wrapper = mountTHead({ tableActions: true, columns: [], selectAllLabel: 'Select all Projects/Namespaces' });
+
+      const checkbox = wrapper.findComponent(Checkbox);
+
+      expect(checkbox.props('alternateLabel')).toBe('Select all Projects/Namespaces');
+    });
+
+    it.each([
+      ['no label is provided', undefined],
+      ['an empty label is provided', ''],
+    ])('should fall back to the generic label when %s', (_, selectAllLabel) => {
+      const wrapper = mountTHead({ tableActions: true, columns: [], selectAllLabel });
+
+      const checkbox = wrapper.findComponent(Checkbox);
+
+      expect(checkbox.props('alternateLabel')).toBe('%sortableTable.genericGroupCheckbox%');
+    });
+
+    it('should not be rendered when the table has no table actions', () => {
+      const wrapper = mountTHead({ tableActions: false, selectAllLabel: 'Select all Namespaces' });
+
+      expect(wrapper.findComponent(Checkbox).exists()).toBe(false);
+    });
   });
 });
 

--- a/shell/components/SortableTable/__tests__/selection-labels.test.ts
+++ b/shell/components/SortableTable/__tests__/selection-labels.test.ts
@@ -1,0 +1,57 @@
+import SortableTable from '@shell/components/SortableTable/index.vue';
+
+const { computed, methods } = SortableTable as any;
+
+/**
+ * Mirrors the i18n `t` helper closely enough to assert on both the key and the
+ * interpolated values
+ */
+const t = (key: string, args?: Record<string, string>) => (args ? `${ key }-${ JSON.stringify(args) }` : key);
+
+describe('component: SortableTable, accessible selection labels', () => {
+  describe('selectAllCheckboxLabel', () => {
+    const selectAllCheckboxLabel = (context: Record<string, any>) => computed.selectAllCheckboxLabel.call({ t, ...context });
+
+    it('should use the resource name given by the page over the one from the schema', () => {
+      const label = selectAllCheckboxLabel({
+        selectAllLabel: 'Projects/Namespaces',
+        pagingParams:   { pluralLabel: 'Namespaces' },
+      });
+
+      expect(label).toBe('sortableTable.selectAllResources-{"resource":"Projects/Namespaces"}');
+    });
+
+    it('should fall back to the resource name derived from the schema', () => {
+      const label = selectAllCheckboxLabel({
+        selectAllLabel: null,
+        pagingParams:   { pluralLabel: 'Deployments' },
+      });
+
+      expect(label).toBe('sortableTable.selectAllResources-{"resource":"Deployments"}');
+    });
+
+    it.each([
+      ['there is no resource context at all', { selectAllLabel: null, pagingParams: null }],
+      ['the schema provided an empty name', { selectAllLabel: null, pagingParams: { pluralLabel: '' } }],
+      ['the schema provided no name', { selectAllLabel: null, pagingParams: {} }],
+    ])('should fall back to the generic label when %s', (_, context) => {
+      expect(selectAllCheckboxLabel(context)).toBe('sortableTable.genericGroupCheckbox');
+    });
+  });
+
+  describe('rowCheckboxLabel', () => {
+    const rowCheckboxLabel = (row: any) => methods.rowCheckboxLabel.call({ t }, row);
+
+    it('should name the row it selects', () => {
+      expect(rowCheckboxLabel({ row: { id: 'default/nginx' } })).toBe('sortableTable.genericRowCheckbox-{"item":"default/nginx"}');
+    });
+
+    it.each([
+      ['the row has no id', { row: {} }],
+      ['the row has an empty id', { row: { id: '' } }],
+      ['there is no row', undefined],
+    ])('should fall back to the generic label when %s', (_, row) => {
+      expect(rowCheckboxLabel(row)).toBe('sortableTable.genericRowCheckboxNoItem');
+    });
+  });
+});

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -265,6 +265,16 @@ export default {
     },
 
     /**
+     * Readable, plural name of the resource being listed, used for the select
+     * all checkbox label. Defaults to the name derived from the schema (via
+     * pagingParams) and falls back to a generic label when neither is known.
+     */
+    selectAllLabel: {
+      type:    String,
+      default: null,
+    },
+
+    /**
      * Allows you to override the default preference of the number of
      * items to display per page. This is used by ./paging.js if you're
      * looking for a reference.
@@ -593,6 +603,15 @@ export default {
       return !!(!this.isLoading && !this._didinit && this.rows?.length);
     },
 
+    /**
+     * Accessible label for the select all checkbox in the table header
+     */
+    selectAllCheckboxLabel() {
+      const resource = this.selectAllLabel || this.pagingParams?.pluralLabel;
+
+      return resource ? this.t('sortableTable.selectAllResources', { resource }) : this.t('sortableTable.genericGroupCheckbox');
+    },
+
     manualRefreshLoadingFinished() {
       const res = !!(!this.isLoading && this._didinit && this.rows?.length && !this.isManualRefreshLoading);
 
@@ -908,6 +927,15 @@ export default {
       }
 
       return ucFirst(col.name);
+    },
+
+    /**
+     * Accessible label for a row's selection checkbox
+     */
+    rowCheckboxLabel(row) {
+      const item = row?.row?.id;
+
+      return item ? this.t('sortableTable.genericRowCheckbox', { item }) : this.t('sortableTable.genericRowCheckboxNoItem');
     },
 
     valueFor(row, col, isLabel) {
@@ -1338,6 +1366,7 @@ export default {
       <THead
         v-if="showHeaders"
         :label-for="labelFor"
+        :select-all-label="selectAllCheckboxLabel"
         :columns="columns"
         :group="group"
         :group-options="advGroupOptions"
@@ -1466,7 +1495,7 @@ export default {
                     :data-node-id="row.key"
                     :data-testid="componentTestid + '-' + i + '-checkbox'"
                     :value="selectedRows.includes(row.row)"
-                    :alternate-label="t('sortableTable.genericRowCheckbox', { item: row && row.row ? row.row.id : '' })"
+                    :alternate-label="rowCheckboxLabel(row)"
                   />
                 </td>
                 <td


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18829

Accessibility audit finding 87 (WCAG 1.3.1, Level A) came back as "partially fixed": the table checkboxes do have accessible names, but the wording is generic boilerplate that doesn't say what is being selected. This PR replaces those labels with wording that names the resource.

### Occurred changes and/or fixed issues
- The "select all" checkbox in a table header now names the resource being listed, e.g. "Select all Deployments", "Select all API Keys", "Select all Namespaces", instead of "Table group selection checkbox"
- The resource name is worked out by `ResourceTable` from the schema, so every list view in the product picks it up with no per-page code — including server-side paginated lists via `PaginatedResourceTable`
- Tables that are not backed by a resource type (form tables such as tolerations, ingress rules, conditions) fall back to "Select all rows"
- Row checkboxes now announce "Select cattle-fleet-clusters-system" instead of "Table row selection checkbox for item cattle-fleet-clusters-system", so the part that changes per row is heard almost immediately
- Rows with no id fall back to "Select row" rather than rendering a dangling "Select "

### Technical notes summary
`SortableTable` gained an optional `selectAllLabel` prop and resolves the header checkbox label in three steps: the label the parent gave it, then the resource name it already receives for the pagination footer, then a generic fallback. `ResourceTable` fills that prop in automatically from the schema (the same `type-map/labelFor` lookup that produces "1 - 10 of 25 Deployments"), which is why no list view had to be touched individually. `THead` just renders whatever label it is handed.

The row label moved from an inline expression in the template into a small method, which is what makes the empty-id fallback possible.

Components that use `SortableTable` directly rather than through `ResourceTable` keep the generic label, and can opt in individually by passing `select-all-label`. Most of them have bulk actions turned off, so they render no select-all checkbox at all.

### Areas or cases that should be tested
Tested locally in Chrome; a reviewer should ideally use a different browser, and a screen reader (JAWS/NVDA/VoiceOver) where possible.

The two pages called out by the audit:
1. **Account and API Keys** → API Keys table → inspect the header checkbox, expect `aria-label="Select all API Keys"`; inspect a row checkbox, expect `aria-label="Select <key id>"`.
2. **Projects/Namespaces** → same two checks. Note the header reads "Select all Namespaces" — see the note in the section below.

Then a general sweep, since this touches the shared table:
3. Any standard list view (Deployments, Config Maps, Secrets, Cluster Management → Clusters) — header checkbox names the resource in plural, row checkbox names the row.
4. A server-side paginated list (a large namespace list, or any view using `PaginatedResourceTable`) — same behaviour.
5. A form table with no resource type behind it (workload create → Pod → Tolerations, or an Ingress's rules) — where a select-all checkbox exists it reads "Select all rows".
6. Toggling both checkboxes still selects/deselects as before, and the indeterminate state still works — the labels are the only change, but the header checkbox markup was touched.

### Areas which could experience regressions
- Every list view in the product renders through `SortableTable`, so bulk selection generally is the main regression surface: select all, partial selection / indeterminate state, and the bulk action bar counts.
- The header label reuses the resource name that `ResourceTable` already computes for the pagination footer. The footer itself is unchanged, but it's worth a glance that "1 - 10 of 25 Deployments" still reads correctly.
- Extensions that render their own `SortableTable` are unaffected — the new prop is optional and defaults to the previous generic wording.
- Two translation keys changed value (`sortableTable.genericGroupCheckbox`, `sortableTable.genericRowCheckbox`) and two were added. Only `en-us` defined them, so no other locale is affected, but any downstream consumer relying on the old English strings would see new text.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
