### PR TITLE
[CI Test] check test run

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,12 +9,12 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "head"
+          "tag": "v2.16-3646cbe4548ba517a54f3ec818da6e0100987618-head"
         },
         "rancher-agent": {
           "namespace": "rancher",
           "name": "rancher-agent",
-          "tag": "head"
+          "tag": "v2.16-3646cbe4548ba517a54f3ec818da6e0100987618-head"
         },
         "runtime-rancher-version": "2.15.0",
         "helm": {

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -5,7 +5,7 @@
 # ----------------------- Input
 # ---------------------------------
 
-USE_LOCAL_BRANCH_METADATA=false # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+USE_LOCAL_BRANCH_METADATA=true # [EXPERIMENT] use this branch's pinned branches-metadata.json (pre-08-14 Rancher head) to isolate the e2e regression. Revert to false before merge.
 KUBE_TYPE=${KUBE_TYPE:-K3S} # K3S or K3D
 OVERRIDE_UIS=${OVERRIDE_UIS:-true} # use UI bits supplied externally (e.g. by CI) rather than the built in UI bits
 TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}


### PR DESCRIPTION
EXPERIMENT (do not merge). Pins the e2e Rancher backend image+agent to v2.16-3646cbe4...-head (built 2026-08-14 09:51, the last head build before v2.16-5d1a1a2f...-head at 13:30 which coincides with master e2e jumping from ~3/18 to ~10/18 failing shards). Uses this branch's local branches-metadata.json (USE_LOCAL_BRANCH_METADATA=true). If e2e recovers with current dashboard code, the failures are a Rancher head regression, not dashboard code.