### PR TITLE
Fix Screen reader users can't tell the "Remove" and "Add" buttons apart when a form has more than one Key-Value or Array list on it

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -159,7 +159,9 @@ generic:
     key: Key for row {index}
     value: Value for row {index}
     remove: remove row {index}
+    keyValueRemove: Remove Key-Value pair in row {index}
     addKeyValue: Add a new Key-Value row
+    addBtnAriaLabel: "{label} in a Key-Value input"
     readKeyValue: read  Key-Values from file
     genericAddRow: Add a new row
     arrayList: Array list input
@@ -3271,7 +3273,10 @@ fleet:
       description1: The root folder is used by default. Fleet will scan recursively all folders and subfolders to find fleet.yaml files.
       description2: You can provide multiple different directories. You can also add subpaths to specify different YAML config file paths.
       ariaLabel: Enter paths for Git Repo
+      inputAriaLabel: Enter path {index} for Git Repo
+      removeBtn: Remove Path {index}
       placeholder: e.g. /directory/in/your/repo
+      addBtnAriaLabel: Add Path for Git Repo
       addLabel: Add Path
       enableBundles: Manually specify config files subpaths (Fleet won't scan subfolders recursively to find fleet.yaml files)
       subpaths:

--- a/shell/components/fleet/FleetGitRepoPaths.vue
+++ b/shell/components/fleet/FleetGitRepoPaths.vue
@@ -319,6 +319,7 @@ export default {
     :initial-empty-row="false"
     :a11y-label="t('fleet.gitRepo.paths.ariaLabel')"
     :add-label="t('fleet.gitRepo.paths.addLabel')"
+    :add-btn-aria-label="t('fleet.gitRepo.paths.addBtnAriaLabel')"
     :add-icon="'icon-plus'"
     :add-class="'btn-sm role-secondary'"
     :protip="t('fleet.gitRepo.paths.tooltip', {}, true)"
@@ -337,6 +338,7 @@ export default {
               v-if="!isView"
               size="small"
               variant="link"
+              :aria-label="t('fleet.gitRepo.paths.removeBtn', { index: i + 1 }, true)"
               @click="removePaths(i)"
             >
               <i class="icon icon-x" />
@@ -351,6 +353,7 @@ export default {
             data-testid="main-path"
             class="mt-5"
             :value="row.value"
+            :aria-label="t('fleet.gitRepo.paths.inputAriaLabel', { index: i + 1 }, true)"
             :placeholder="t('fleet.gitRepo.paths.placeholder')"
             :disabled="isView"
             @input="updatePath(i, $event)"

--- a/shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts
+++ b/shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts
@@ -1,6 +1,13 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
-import { _EDIT } from '@shell/config/query-params';
+import { createStore } from 'vuex';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
 import FleetGitRepoPaths, { Subpath, getRelevantPrefixes } from '@shell/components/fleet/FleetGitRepoPaths.vue';
+import { getters, state, mutations } from '@shell/store/i18n.js';
+
+// The i18n store imports the en-us yaml, which jest can't parse. The a11y tests below load the
+// small subset of translations they need explicitly, via `loadTranslations`.
+jest.mock('@shell/assets/translations/en-us.yaml', () => ({}));
 
 describe('fx: getRelevantPrefixes', () => {
   it('should return an empty array for an empty input array', () => {
@@ -261,5 +268,130 @@ describe('decode spec.targets to build UI source data', () => {
         { path: 'folderA' }
       ]);
     });
+  });
+});
+
+describe('a11y: unique path row labels', () => {
+  // Mirrors the `fleet.gitRepo.paths` block of shell/assets/translations/en-us.yaml, so the
+  // assertions below check the strings a screen reader would actually announce.
+  const TRANSLATIONS = {
+    fleet: {
+      gitRepo: {
+        paths: {
+          ariaLabel:       'Enter paths for Git Repo',
+          inputAriaLabel:  'Enter path {index} for Git Repo',
+          removeBtn:       'Remove Path {index}',
+          addBtnAriaLabel: 'Add Path for Git Repo',
+          addLabel:        'Add Path',
+          index:           'Path {index}',
+        }
+      }
+    }
+  };
+
+  const store = createStore({
+    state,
+    getters: { 'i18n/t': getters.t },
+    mutations,
+  });
+
+  store.commit('loadTranslations', { locale: 'en-us', translations: TRANSLATIONS });
+
+  /**
+   * Resolves against the real i18n store getter (so `{index}` is interpolated), falling back to
+   * the `%key%` form used by the global test mock for untranslated keys.
+   */
+  const t = jest.fn((key: string, args?: Record<string, unknown>) => {
+    return store.getters['i18n/t'](key, args) ?? `%${ key }%`;
+  });
+
+  /**
+   * The component builds its rows in `mounted`, and ArrayList only picks them up through its
+   * `value` watcher, so the rows are rendered a couple of ticks after mount.
+   */
+  const mountPaths = async(paths: string[], mode: string = _EDIT) => {
+    const wrapper = mount(FleetGitRepoPaths, {
+      props: {
+        value:   { paths, bundles: [] as Subpath[] },
+        mode,
+        touched: {}
+      },
+      global: { mocks: { t } },
+    });
+
+    await nextTick();
+    await nextTick();
+
+    return wrapper;
+  };
+
+  type PathsWrapper = Awaited<ReturnType<typeof mountPaths>>;
+
+  const removeButtonLabels = (wrapper: PathsWrapper) => wrapper
+    .findAll('.header button')
+    .map((btn) => btn.attributes('aria-label'));
+
+  const inputLabels = (wrapper: PathsWrapper) => wrapper
+    .findAll('[data-testid="main-path"]')
+    .map((input) => input.attributes('aria-label'));
+
+  beforeEach(() => t.mockClear());
+
+  it('should give each path row remove button a label naming the path and its position', async() => {
+    const wrapper = await mountPaths(['path1', 'path2', 'path3']);
+
+    expect(removeButtonLabels(wrapper)).toStrictEqual([
+      'Remove Path 1',
+      'Remove Path 2',
+      'Remove Path 3',
+    ]);
+  });
+
+  it('should keep the remove button labels unique across path rows', async() => {
+    const wrapper = await mountPaths(['path1', 'path2', 'path3']);
+    const labels = removeButtonLabels(wrapper);
+
+    expect(new Set(labels).size).toStrictEqual(labels.length);
+  });
+
+  it('should re-index the remove button labels after a path is removed', async() => {
+    const wrapper = await mountPaths(['path1', 'path2', 'path3']);
+
+    await wrapper.findAll('.header button')[0].trigger('click');
+
+    expect(removeButtonLabels(wrapper)).toStrictEqual([
+      'Remove Path 1',
+      'Remove Path 2',
+    ]);
+  });
+
+  it('should not render the remove buttons in view mode', async() => {
+    const wrapper = await mountPaths(['path1', 'path2'], _VIEW);
+
+    expect(removeButtonLabels(wrapper)).toStrictEqual([]);
+  });
+
+  it('should give each path input a label naming its position', async() => {
+    const wrapper = await mountPaths(['path1', 'path2']);
+
+    expect(inputLabels(wrapper)).toStrictEqual([
+      'Enter path 1 for Git Repo',
+      'Enter path 2 for Git Repo',
+    ]);
+  });
+
+  it('should label the add button with the path specific text while keeping the visible label', async() => {
+    const wrapper = await mountPaths(['path1']);
+    const addButton = wrapper.find('[data-testid="array-list-button"]');
+
+    expect(addButton.attributes('aria-label')).toStrictEqual('Add Path for Git Repo');
+    expect(addButton.text()).toStrictEqual('Add Path');
+  });
+
+  it('should pass the add button aria-label down to the ArrayList', async() => {
+    const wrapper = await mountPaths(['path1']);
+    const arrayList = wrapper.findComponent({ name: 'ArrayList' });
+
+    expect(arrayList.props('addBtnAriaLabel')).toStrictEqual('Add Path for Git Repo');
   });
 });

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -65,6 +65,10 @@ export default {
       type:    String,
       default: '',
     },
+    addBtnAriaLabel: {
+      type:    String,
+      default: '',
+    },
     addAllowed: {
       type:    Boolean,
       default: true,
@@ -481,7 +485,7 @@ export default {
             :class="[addClass]"
             :disabled="loading || disableAdd"
             :data-testid="`${componentTestid}-button`"
-            :aria-label="_addLabel"
+            :aria-label="addBtnAriaLabel || _addLabel"
             role="button"
             @click="add()"
           >

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -285,6 +285,9 @@ export default {
     _addLabel() {
       return this.addLabel || this.t('generic.add');
     },
+    _addBtnAriaLabel() {
+      return this.addLabel ? this.t('generic.ariaLabel.addBtnAriaLabel', { label: this.addLabel }) : this.t('generic.ariaLabel.addKeyValue');
+    },
 
     isView() {
       return this.mode === _VIEW;
@@ -893,7 +896,7 @@ export default {
                   type="button"
                   role="button"
                   :disabled="isView || disabled"
-                  :aria-label="t('generic.ariaLabel.remove', {index: i+1})"
+                  :aria-label="t('generic.ariaLabel.keyValueRemove', {index: i+1})"
                   class="btn role-link"
                   @click="remove(i)"
                 >
@@ -924,7 +927,7 @@ export default {
           :class="[addClass]"
           data-testid="add_row_item_button"
           :disabled="loading || disabled || (keyOptions && filteredKeyOptions.length === 0)"
-          :aria-label="t('generic.ariaLabel.addKeyValue')"
+          :aria-label="_addBtnAriaLabel"
           @click="add()"
         >
           <i
@@ -940,7 +943,7 @@ export default {
           :class="[addClass]"
           data-testid="add_row_item_button"
           :disabled="loading || disabled || (keyOptions && filteredKeyOptions.length === 0)"
-          :aria-label="t('generic.ariaLabel.addKeyValue')"
+          :aria-label="_addBtnAriaLabel"
           @click="add()"
         >
           <i

--- a/shell/components/form/__tests__/ArrayList.test.ts
+++ b/shell/components/form/__tests__/ArrayList.test.ts
@@ -263,4 +263,52 @@ describe('the ArrayList', () => {
       expect(wrapper.find('[data-testid="array-list-remove-item-1"]').exists()).toBe(true);
     });
   });
+
+  describe('addBtnAriaLabel', () => {
+    const mountArrayList = (props: Record<string, unknown> = {}) => mount(ArrayList, {
+      props: {
+        value: ['string 0'],
+        mode:  _EDIT,
+        ...props,
+      } as any,
+    });
+
+    const addButton = (wrapper: ReturnType<typeof mountArrayList>) => wrapper.find('[data-testid="array-list-button"]');
+
+    it('should label the add button with addBtnAriaLabel when one is given', () => {
+      const wrapper = mountArrayList({ addLabel: 'Add Path', addBtnAriaLabel: 'Add Path for Git Repo' });
+
+      expect(addButton(wrapper).attributes('aria-label')).toStrictEqual('Add Path for Git Repo');
+    });
+
+    it('should keep the visible add button text as addLabel, independent of the aria-label', () => {
+      const wrapper = mountArrayList({ addLabel: 'Add Path', addBtnAriaLabel: 'Add Path for Git Repo' });
+
+      expect(addButton(wrapper).text()).toStrictEqual('Add Path');
+      expect(addButton(wrapper).attributes('aria-label')).toStrictEqual('Add Path for Git Repo');
+    });
+
+    it.each([
+      ['no addBtnAriaLabel and an addLabel', { addLabel: 'Add Path' }, 'Add Path'],
+      ['an empty addBtnAriaLabel', { addLabel: 'Add Path', addBtnAriaLabel: '' }, 'Add Path'],
+      ['neither label', {}, '%generic.ariaLabel.genericAddRow%'],
+      ['no addLabel but an addBtnAriaLabel', { addBtnAriaLabel: 'Add Path for Git Repo' }, 'Add Path for Git Repo'],
+    ])('should fall back to the add label with %s', (_: string, props: Record<string, unknown>, expected: string) => {
+      const wrapper = mountArrayList(props);
+
+      expect(addButton(wrapper).attributes('aria-label')).toStrictEqual(expected);
+    });
+
+    it('should give two lists on the same page distinct add button labels', () => {
+      const paths = mountArrayList({ addLabel: 'Add', addBtnAriaLabel: 'Add Path for Git Repo' });
+      const other = mountArrayList({ addLabel: 'Add', addBtnAriaLabel: 'Add a new resource' });
+
+      const pathsAdd = addButton(paths).attributes('aria-label');
+      const otherAdd = addButton(other).attributes('aria-label');
+
+      expect(pathsAdd).toStrictEqual('Add Path for Git Repo');
+      expect(otherAdd).toStrictEqual('Add a new resource');
+      expect(pathsAdd).not.toStrictEqual(otherAdd);
+    });
+  });
 });

--- a/shell/components/form/__tests__/KeyValue.test.ts
+++ b/shell/components/form/__tests__/KeyValue.test.ts
@@ -1,6 +1,12 @@
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
 import KeyValue from '@shell/components/form/KeyValue.vue';
+import { getters, state, mutations } from '@shell/store/i18n.js';
+
+// The i18n store imports the en-us yaml, which jest can't parse. The tests below load the small
+// subset of translations they need explicitly, via `loadTranslations`.
+jest.mock('@shell/assets/translations/en-us.yaml', () => ({}));
 
 describe('component: KeyValue', () => {
   it.skip('(Vue3 Skip) should display a not encoded value', () => {
@@ -274,7 +280,7 @@ describe('component: KeyValue', () => {
     expect(valueGroup.attributes('role')).toBe('gridcell');
     expect(firstKeyInput.attributes('aria-label')).toBe('%generic.ariaLabel.key%');
     expect(firstValueInput.attributes('aria-label')).toBe('%generic.ariaLabel.value%');
-    expect(rowRemove.attributes('aria-label')).toBe('%generic.ariaLabel.remove%');
+    expect(rowRemove.attributes('aria-label')).toBe('%generic.ariaLabel.keyValueRemove%');
     expect(rowAdd.attributes('aria-label')).toBe('%generic.ariaLabel.addKeyValue%');
     expect(readKeyValueFromFile.attributes('aria-label')).toBe('%generic.ariaLabel.readKeyValue%');
   });
@@ -341,6 +347,185 @@ describe('component: KeyValue', () => {
 
       expect(textarea.exists()).toBe(true);
       expect(textarea.attributes('disabled')).toBeDefined();
+    });
+  });
+
+  describe('a11y: unique add/remove button labels', () => {
+    // Mirrors the `generic.ariaLabel` block of shell/assets/translations/en-us.yaml, so the
+    // assertions below check the strings a screen reader would actually announce.
+    const TRANSLATIONS = {
+      generic: {
+        add:       'Add',
+        remove:    'Remove',
+        ariaLabel: {
+          keyValue:        'Key-Value input',
+          key:             'Key for row {index}',
+          value:           'Value for row {index}',
+          remove:          'remove row {index}',
+          keyValueRemove:  'Remove Key-Value pair in row {index}',
+          addKeyValue:     'Add a new Key-Value row',
+          addBtnAriaLabel: '{label} in a Key-Value input',
+        }
+      }
+    };
+
+    const store = createStore({
+      state,
+      getters: { 'i18n/t': getters.t },
+      mutations,
+    });
+
+    store.commit('loadTranslations', { locale: 'en-us', translations: TRANSLATIONS });
+
+    /**
+     * Resolves against the real i18n store getter (so `{index}`/`{label}` are interpolated),
+     * falling back to the `%key%` form used by the global test mock for untranslated keys.
+     */
+    const t = jest.fn((key: string, args?: Record<string, unknown>) => {
+      return store.getters['i18n/t'](key, args) ?? `%${ key }%`;
+    });
+
+    const mountKV = (props: Record<string, unknown> = {}) => mount(KeyValue, {
+      props: {
+        mode:           'edit',
+        valueMultiline: false,
+        ...props,
+      } as any,
+      global: {
+        mocks: { t },
+        stubs: { CodeMirror: true },
+      },
+    });
+
+    beforeEach(() => t.mockClear());
+
+    describe('remove buttons', () => {
+      it('should give each row remove button a label naming the Key-Value pair and its row', () => {
+        const wrapper = mountKV({
+          value: {
+            k1: 'v1', k2: 'v2', k3: 'v3'
+          },
+          asMap: true
+        });
+
+        const labels = wrapper
+          .findAll('[data-testid^="remove-column-"] button')
+          .map((btn) => btn.attributes('aria-label'));
+
+        expect(labels).toStrictEqual([
+          'Remove Key-Value pair in row 1',
+          'Remove Key-Value pair in row 2',
+          'Remove Key-Value pair in row 3',
+        ]);
+      });
+
+      it('should keep the remove button labels unique within the component', () => {
+        const wrapper = mountKV({ value: { k1: 'v1', k2: 'v2' }, asMap: true });
+
+        const labels = wrapper
+          .findAll('[data-testid^="remove-column-"] button')
+          .map((btn) => btn.attributes('aria-label'));
+
+        expect(new Set(labels).size).toStrictEqual(labels.length);
+      });
+
+      it('should request the key-value specific remove translation, not the generic one', () => {
+        mountKV({ value: { k1: 'v1' }, asMap: true });
+
+        expect(t).toHaveBeenCalledWith('generic.ariaLabel.keyValueRemove', { index: 1 });
+        expect(t).not.toHaveBeenCalledWith('generic.ariaLabel.remove', { index: 1 });
+      });
+
+      it('should re-index the remove button labels after a row is removed', async() => {
+        const wrapper = mountKV({
+          value: {
+            k1: 'v1', k2: 'v2', k3: 'v3'
+          },
+          asMap: true
+        });
+
+        await wrapper.find('[data-testid="remove-column-0"] button').trigger('click');
+        await nextTick();
+
+        const labels = wrapper
+          .findAll('[data-testid^="remove-column-"] button')
+          .map((btn) => btn.attributes('aria-label'));
+
+        expect(labels).toStrictEqual([
+          'Remove Key-Value pair in row 1',
+          'Remove Key-Value pair in row 2',
+        ]);
+      });
+    });
+
+    describe('add button', () => {
+      it.each([
+        ['plain button', false],
+        ['RcButton', true],
+      ])('should fall back to the generic key-value label when no addLabel is given (%s)', (_: string, useRcButton: boolean) => {
+        const wrapper = mountKV({
+          value: { k: 'v' }, asMap: true, useRcButton
+        });
+
+        const addButton = wrapper.find('[data-testid="add_row_item_button"]');
+
+        expect(addButton.attributes('aria-label')).toStrictEqual('Add a new Key-Value row');
+      });
+
+      it.each([
+        ['plain button', false],
+        ['RcButton', true],
+      ])('should build the label from addLabel so it describes what is being added (%s)', (_: string, useRcButton: boolean) => {
+        const wrapper = mountKV({
+          value: { k: 'v' }, asMap: true, addLabel: 'Add Label', useRcButton
+        });
+
+        const addButton = wrapper.find('[data-testid="add_row_item_button"]');
+
+        expect(addButton.attributes('aria-label')).toStrictEqual('Add Label in a Key-Value input');
+        expect(t).toHaveBeenCalledWith('generic.ariaLabel.addBtnAriaLabel', { label: 'Add Label' });
+      });
+
+      it('should give two Key-Value inputs on the same page distinct add button labels', () => {
+        // Reproduces the reported issue: Labels and Annotations on the same form
+        const labels = mountKV({
+          value: { k: 'v' }, asMap: true, addLabel: 'Add Label'
+        });
+        const annotations = mountKV({
+          value: { k: 'v' }, asMap: true, addLabel: 'Add Annotation'
+        });
+
+        const labelsAdd = labels.find('[data-testid="add_row_item_button"]').attributes('aria-label');
+        const annotationsAdd = annotations.find('[data-testid="add_row_item_button"]').attributes('aria-label');
+
+        expect(labelsAdd).toStrictEqual('Add Label in a Key-Value input');
+        expect(annotationsAdd).toStrictEqual('Add Annotation in a Key-Value input');
+        expect(labelsAdd).not.toStrictEqual(annotationsAdd);
+      });
+
+      it.each([
+        ['undefined addLabel', undefined, 'Add a new Key-Value row'],
+        ['empty addLabel', '', 'Add a new Key-Value row'],
+        ['addLabel with no visible text change', 'Add', 'Add in a Key-Value input'],
+        ['addLabel with special characters', 'Add "Path"', 'Add "Path" in a Key-Value input'],
+      ])('_addBtnAriaLabel: %s', (_: string, addLabel: string | undefined, expected: string) => {
+        const wrapper = mountKV({
+          value: { k: 'v' }, asMap: true, addLabel
+        });
+
+        expect((wrapper.vm as any)._addBtnAriaLabel).toStrictEqual(expected);
+      });
+
+      it('should keep the visible add button text independent of the aria-label', () => {
+        const wrapper = mountKV({
+          value: { k: 'v' }, asMap: true, addLabel: 'Add Label'
+        });
+
+        const addButton = wrapper.find('[data-testid="add_row_item_button"]');
+
+        expect(addButton.text()).toStrictEqual('Add Label');
+        expect(addButton.attributes('aria-label')).toStrictEqual('Add Label in a Key-Value input');
+      });
     });
   });
 

--- a/shell/edit/auditlog.cattle.io.auditpolicy/__tests__/__snapshots__/Filters.test.ts.snap
+++ b/shell/edit/auditlog.cattle.io.auditpolicy/__tests__/__snapshots__/Filters.test.ts.snap
@@ -11,6 +11,7 @@ exports[`component: Filters rendering & initial state should render with default
       <array-list-stub
         a11ylabel=""
         addallowed="true"
+        addbtnarialabel=""
         addclass=""
         adddisabled="false"
         addicon=""


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18835

Screen reader users can't tell the "Remove" and "Add" buttons apart when a form has more than one Key-Value or Array list on it. Every remove button announced the same generic "remove row N", and every add button announced either a generic "Add a new Key-Value row" or just the visible label, so on a page like **Repository: Create** (Labels + Annotations) or **Git Repo: Add Repository** (Paths) the buttons were indistinguishable out of context.

### Occurred changes and/or fixed issues
- Key-Value remove buttons now announce what they remove and which row: "Remove Key-Value pair in row 1"
- Key-Value add buttons now include the field they belong to: "Add Label in a Key-Value input", "Add Annotation in a Key-Value input"
- Array list gained an optional `addBtnAriaLabel` prop, so a consumer can give its add button a specific accessible name without changing the visible button text
- Git Repo paths: the add button announces "Add Path for Git Repo", each row's icon-only remove button announces "Remove Path 1", "Remove Path 2", …, and each path input announces "Enter path 1 for Git Repo"
- New unit tests covering all of the above

### Technical notes summary
The visible text on these buttons is unchanged — this is purely about the accessible name.

`KeyValue` picks its add button label based on whether the consumer passed an `addLabel`: if it did, the label is wrapped ("<addLabel> in a Key-Value input"); if not, it falls back to the existing generic string. Its remove button moved to a new translation key so it can say what kind of thing it removes rather than just "row N".

`ArrayList` is used in a lot of places, so instead of changing its default it takes a new optional `addBtnAriaLabel` prop and falls back to the current behaviour when nothing is passed. Only the Git Repo paths list opts in for now. That list renders its own rows through the `columns` slot, so its remove button and path input are labelled in `FleetGitRepoPaths` directly.

All the new accessible names keep the visible label as a prefix ("Add Path" → "Add Path for Git Repo"), which is what WCAG 2.5.3 *Label in Name* asks for and keeps voice-control users able to say "click Add Path".

### Areas or cases that should be tested
Tested locally in Chrome — reviewer please use a different browser, ideally with a screen reader (NVDA on Windows / Firefox is what the finding was raised against).

**Repository: Create** (`Cluster → Apps → Repositories → Create`, Labels & Annotations tab)
1. Add a couple of Labels and a couple of Annotations
2. Tab to the remove buttons — each should announce "Remove Key-Value pair in row N"
3. Tab to the two add buttons — they should announce "Add Label in a Key-Value input" and "Add Annotation in a Key-Value input", while still reading "Add Label" / "Add Annotation" on screen

**Git Repo: Add Repository** (`Continuous Delivery → Git Repos → Create`, Paths section)
1. Activate "Add Path" a few times
2. The add button should announce "Add Path for Git Repo" and still display "Add Path"
3. Each row's X button should announce "Remove Path 1", "Remove Path 2", … and the labels should re-number after removing a row
4. Each path input should announce "Enter path N for Git Repo"
5. Tick "Manually specify config files subpaths" and check the subpaths Key-Value add/remove buttons too

**Anything else using Key-Value or Array list** — labels/annotations on any resource, env vars, config maps, secrets, node taints. Nothing visible should change; the only difference is what a screen reader reads out.

### Areas which could experience regressions
- Every consumer of `shell/components/form/KeyValue.vue` — the remove button now reads a different translation key, and the add button's `aria-label` changes whenever an `addLabel` is passed. No visible text or behaviour changes, but the surface is wide.
- Every consumer of `shell/components/form/ArrayList.vue` — the new prop defaults to empty, so any list that doesn't pass it keeps its current accessible name.
- `FleetGitRepoPaths` — the Paths section markup was touched (attributes only, no structure), so worth a quick check that the Git Repo create/edit form and the paths ↔ bundles round-trip still behave.
- Any e2e test asserting on the old `aria-label` values of these buttons.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
