### PR TITLE
[JIRA][12458] Show Cluster and Project Members to users with the Manage Project Members role

### DIFF
--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -13,6 +13,7 @@ import { canViewProjectMembershipEditor } from '@shell/components/form/Members/P
 import { allHash } from '@shell/utils/promise';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { RcButton } from '@components/RcButton';
+import { fetchProjectMembershipPermissions } from '@shell/utils/project-permissions';
 
 /**
  * Explorer members page.
@@ -73,7 +74,10 @@ export default {
     }
 
     this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT })
-      .then((projects) => (this['projects'] = projects));
+      .then((projects) => {
+        this['projects'] = projects;
+        this.loadProjectMembershipPermissions();
+      });
 
     const hydration = {
       normanPrincipals:  this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
@@ -103,6 +107,10 @@ export default {
       normanClusterRoleTemplateBindings: [],
       projectRoleTemplateBindings:       [],
       projects:                          [],
+      // SURE-8995: per-project member-management capabilities ({ create, remove }),
+      // keyed by mgmt project id. Populated from the projects' `resourcePermissions`
+      // (steve `?checkPermissions=`) in fetch().
+      projectMembershipPermissions:      {},
       VIRTUAL_TYPES,
       projectRoleTemplateColumns:        [
         STATE,
@@ -241,6 +249,27 @@ export default {
     },
   },
   methods: {
+    // SURE-8995: `canEditProjectMembers` (schema collectionMethods POST) is a
+    // GLOBAL flag - true if the user can create a binding on *any* project - so
+    // on its own it wrongly shows the Add/remove actions on every project. Read
+    // the per-project answer from each project's `resourcePermissions` instead
+    // (steve `?checkPermissions=`), so member actions only appear on projects
+    // the user can actually manage.
+    async loadProjectMembershipPermissions() {
+      if (!this.canEditProjectMembers) {
+        return; // can't create bindings anywhere - nothing to check
+      }
+
+      this.projectMembershipPermissions = await fetchProjectMembershipPermissions(this.$store);
+    },
+    canAddProjectMember(group) {
+      return !!this.projectMembershipPermissions[this.getMgmtProjectId(group)]?.create;
+    },
+    canRemoveProjectMember(row) {
+      const projectId = (row.projectId || '').replace(':', '/');
+
+      return !!this.projectMembershipPermissions[projectId]?.remove;
+    },
     getMgmtProjectId(group) {
       return group.group.key.replace(':', '/');
     },
@@ -364,7 +393,7 @@ export default {
               </div>
               <div class="right">
                 <button
-                  v-if="canEditProjectMembers"
+                  v-if="canAddProjectMember(group)"
                   type="button"
                   class="btn btn-sm role-secondary mr-10 right"
                   :data-testid="`add-project-member-${getProjectLabel(group).replace(' ', '').toLowerCase()}`"
@@ -393,6 +422,7 @@ export default {
                 {{ role.nameDisplay }}
               </span>
               <i
+                v-if="canRemoveProjectMember(row)"
                 class="icon icon-close"
                 :data-testid="`role-values-close-${j}`"
                 @click="removeRole(row, role, $event)"

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -218,6 +218,12 @@ export default {
     canManageMembers() {
       return canViewClusterPermissionsEditor(this.$store);
     },
+    // SURE-8995: the page is now reachable by users with only project membership permissions. Show the
+    // Cluster Membership tab only to users who can actually access cluster role bindings (the previous
+    // gate for the whole page), so project-only users don't see an empty/irrelevant cluster tab.
+    canViewClusterMembers() {
+      return !!this.$store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING);
+    },
     canManageProjectMembers() {
       return canViewProjectMembershipEditor(this.$store);
     },
@@ -303,6 +309,7 @@ export default {
     />
     <Tabbed>
       <Tab
+        v-if="canViewClusterMembers"
         name="cluster-membership"
         :label="t('members.clusterMembership')"
       >

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -52,10 +52,17 @@ export default {
 
     const projectRoleTemplateBindingSchema = this.$store.getters['rancher/schemaFor'](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
 
+    // SURE-8995: this page is now reachable by users with only project membership
+    // permissions, who have no access to CLUSTER role bindings. The norman CRTB
+    // schema can be present while the management (steve) one is not, so guard the
+    // cluster binding load on BOTH - otherwise `management/findAll` throws
+    // "Unknown schema for type: management.cattle.io.clusterroletemplatebinding".
+    const mgmtClusterRoleTemplateBindingSchema = this.$store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING);
+
     this['normanClusterRTBSchema'] = clusterRoleTemplateBindingSchema;
     this['normanProjectRTBSchema'] = projectRoleTemplateBindingSchema;
 
-    if (clusterRoleTemplateBindingSchema) {
+    if (clusterRoleTemplateBindingSchema && mgmtClusterRoleTemplateBindingSchema) {
       Promise.all([
         this.$store.dispatch(`rancher/findAll`, { type: NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING }, { root: true }),
         this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING })
@@ -63,6 +70,8 @@ export default {
         this['normanClusterRoleTemplateBindings'] = normanBindings;
         this.loadingClusterBindings = false;
       });
+    } else {
+      this.loadingClusterBindings = false;
     }
 
     if (projectRoleTemplateBindingSchema) {

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -4,15 +4,16 @@ import ResourceTable from '@shell/components/ResourceTable';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { AGE, ROLE, STATE, PRINCIPAL } from '@shell/config/table-headers';
 import { canViewClusterPermissionsEditor } from '@shell/components/form/Members/ClusterPermissionsEditor.vue';
+import { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor.vue';
 import Banner from '@components/Banner/Banner.vue';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import SortableTable from '@shell/components/SortableTable';
 import { mapGetters } from 'vuex';
-import { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor.vue';
 import { allHash } from '@shell/utils/promise';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { RcButton } from '@components/RcButton';
+import Loading from '@shell/components/Loading';
 import { fetchProjectMembershipPermissions } from '@shell/utils/project-permissions';
 
 /**
@@ -24,6 +25,7 @@ export default {
 
   components: {
     Banner,
+    Loading,
     Masthead,
     ResourceTable,
     Tabbed,
@@ -52,15 +54,11 @@ export default {
 
     const projectRoleTemplateBindingSchema = this.$store.getters['rancher/schemaFor'](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
 
-    // SURE-8995: this page is now reachable by users with only project membership
-    // permissions, who have no access to CLUSTER role bindings. The norman CRTB
-    // schema can be present while the management (steve) one is not, so guard the
-    // cluster binding load on BOTH - otherwise `management/findAll` throws
-    // "Unknown schema for type: management.cattle.io.clusterroletemplatebinding".
+    // The norman CRTB schema can be present while the management (steve) one is not, so guard
+    // the cluster binding load on BOTH - otherwise `management/findAll` throws "Unknown schema".
     const mgmtClusterRoleTemplateBindingSchema = this.$store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING);
 
     this['normanClusterRTBSchema'] = clusterRoleTemplateBindingSchema;
-    this['normanProjectRTBSchema'] = projectRoleTemplateBindingSchema;
 
     if (clusterRoleTemplateBindingSchema && mgmtClusterRoleTemplateBindingSchema) {
       Promise.all([
@@ -82,18 +80,16 @@ export default {
         });
     }
 
-    this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT })
-      .then((projects) => {
-        this['projects'] = projects;
-        this.loadProjectMembershipPermissions();
-      });
+    // Await projects (RBAC-filtered) before fetch resolves so the project-membership tab's `v-if`
+    // is settled before <Tabbed> reads the URL hash — otherwise a `#project-membership` deep link
+    // arrives before the tab exists and never activates.
+    if (this.$store.getters['management/schemaFor'](MANAGEMENT.PROJECT)) {
+      this['projects'] = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
+      await this.loadProjectMembershipPermissions();
+    }
 
-    // SURE-8995: a user with only membership permissions (e.g. a cluster-owner on
-    // a `user-base` global role) may not have access to the principal, user or
-    // role-template schemas. Guard each hydration dispatch on its schema so
-    // `findAll` doesn't throw "Unknown schema for type: ..." and break the whole
-    // page - the members list still renders (with reduced principal/role name
-    // resolution) for a view-only user.
+    // A view-only user may lack the principal / user / role-template schemas; guard each hydration
+    // dispatch on its schema so `findAll` doesn't throw "Unknown schema" and break the whole page.
     const hydration = {};
 
     if (this.$store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL)) {
@@ -126,13 +122,9 @@ export default {
       },
       resource:                          MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
       normanClusterRTBSchema:            null,
-      normanProjectRTBSchema:            null,
       normanClusterRoleTemplateBindings: [],
       projectRoleTemplateBindings:       [],
       projects:                          [],
-      // SURE-8995: per-project member-management capabilities ({ create, remove }),
-      // keyed by mgmt project id. Populated from the projects' `resourcePermissions`
-      // (steve `?checkPermissions=`) in fetch().
       projectMembershipPermissions:      {},
       VIRTUAL_TYPES,
       projectRoleTemplateColumns:        [
@@ -196,7 +188,9 @@ export default {
       return Object.keys(this.filteredProjects).reduce((all, projectId) => {
         const project = this.filteredProjects[projectId];
 
-        if ( !inUse.includes(projectId)) {
+        // management/findAll is RBAC-filtered, so a member-less project here is one the user can
+        // access - list it so its Add button is reachable and the first member can be added.
+        if (!inUse.includes(projectId)) {
           all.push(project);
         }
 
@@ -227,6 +221,13 @@ export default {
         const userOrGroup = userId || groupPrincipalId;
 
         if (!userOrGroup) {
+          // keep the empty-project placeholder (keyed by project) so the project still
+          // renders as a group with its Add button; the main-row slot fills the row.
+          if (!rows[projectId]) {
+            rows[projectId] = curr;
+            rows[projectId].allRoles = [];
+          }
+
           return rows;
         }
 
@@ -246,42 +247,27 @@ export default {
 
       return Object.values(userRoles);
     },
-    // SURE-8995: whether the user can MUTATE cluster members (the Add action opens
-    // the create-CRTB form, which needs the role-template + user reads to pick a
-    // role and search principals). A cluster-owner on a `user-base` global role
-    // lacks these, so the cluster Add is hidden and they get a read-only view -
-    // mirroring the project side (`canManageProjectMembers`).
+    // Can MUTATE cluster members: the Add flow needs the role-template + user reads; a user
+    // lacking them gets a read-only view.
     canManageMembers() {
       return canViewClusterPermissionsEditor(this.$store);
     },
-    // SURE-8995: the page is now reachable by users with only project membership permissions. Show the
-    // Cluster Membership tab only to users who can actually access cluster role bindings (the previous
-    // gate for the whole page), so project-only users don't see an empty/irrelevant cluster tab.
     canViewClusterMembers() {
       return !!this.$store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING);
     },
-    // SURE-8995: whether the current user can MUTATE project members from this page
-    // (add / remove). This requires the full membership editor schemas (role
-    // templates + principals), which the add flow depends on to pick a role and
-    // search principals. A cluster-owner on a `user-base` global role lacks these,
-    // so they get a read-only view (see `canViewProjectMembers`).
+    // Can operate the project member editor (Add/Remove): needs the role-template + principal reads
+    // the add dialog depends on. A user lacking them gets a read-only list.
     canManageProjectMembers() {
       return canViewProjectMembershipEditor(this.$store);
     },
-    // SURE-8995: whether to show the Project Membership tab at all. Viewing the
-    // members list only needs access to the project role bindings themselves - it
-    // must NOT require the role-template/principal reads (those only gate the
-    // add/remove actions). Otherwise a cluster-owner on a `user-base` global role -
-    // who can genuinely see and manage project members on the backend - is shown no
-    // tab. Name/role resolution degrades gracefully when those reads are absent.
+    // management/findAll is RBAC-filtered, so project visibility == access. The Norman schema can't
+    // gate this: /v3/schemas returns projectRoleTemplateBinding to every authenticated user.
     canViewProjectMembers() {
-      return !!this.$store.getters['rancher/schemaFor'](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
+      return Object.keys(this.filteredProjects).length > 0 ||
+        this.filteredProjectRoleTemplateBindings.length > 0;
     },
     isLocal() {
       return this.$store.getters['currentCluster'].isLocal;
-    },
-    canEditProjectMembers() {
-      return this.normanProjectRTBSchema?.collectionMethods.find((x) => x.toLowerCase() === 'post');
     },
     canEditClusterMembers() {
       return this.normanClusterRTBSchema?.collectionMethods.find((x) => x.toLowerCase() === 'post');
@@ -291,17 +277,9 @@ export default {
     },
   },
   methods: {
-    // SURE-8995: `canEditProjectMembers` (schema collectionMethods POST) is a
-    // GLOBAL flag - true if the user can create a binding on *any* project - so
-    // on its own it wrongly shows the Add/remove actions on every project. Read
-    // the per-project answer from each project's `resourcePermissions` instead
-    // (steve `?checkPermissions=`), so member actions only appear on projects
-    // the user can actually manage.
+    // Global schema collectionMethods only say whether the user can create on *any* project;
+    // read each project's `resourcePermissions` for the per-project answer.
     async loadProjectMembershipPermissions() {
-      if (!this.canEditProjectMembers) {
-        return; // can't create bindings anywhere - nothing to check
-      }
-
       this.projectMembershipPermissions = await fetchProjectMembershipPermissions(this.$store);
     },
     canAddProjectMember(group) {
@@ -378,7 +356,8 @@ export default {
       color="error"
       :label="t('members.localClusterWarning')"
     />
-    <Tabbed>
+    <Loading v-if="$fetchState.pending" />
+    <Tabbed v-else>
       <Tab
         v-if="canViewClusterMembers"
         name="cluster-membership"

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -88,11 +88,25 @@ export default {
         this.loadProjectMembershipPermissions();
       });
 
-    const hydration = {
-      normanPrincipals:  this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
-      mgmt:              this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER }),
-      mgmtRoleTemplates: this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }),
-    };
+    // SURE-8995: a user with only membership permissions (e.g. a cluster-owner on
+    // a `user-base` global role) may not have access to the principal, user or
+    // role-template schemas. Guard each hydration dispatch on its schema so
+    // `findAll` doesn't throw "Unknown schema for type: ..." and break the whole
+    // page - the members list still renders (with reduced principal/role name
+    // resolution) for a view-only user.
+    const hydration = {};
+
+    if (this.$store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL)) {
+      hydration.normanPrincipals = this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL });
+    }
+
+    if (this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
+      hydration.mgmt = this.$store.dispatch('management/findAll', { type: MANAGEMENT.USER });
+    }
+
+    if (this.$store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)) {
+      hydration.mgmtRoleTemplates = this.$store.dispatch('management/findAll', { type: MANAGEMENT.ROLE_TEMPLATE });
+    }
 
     await allHash(hydration);
   },
@@ -232,6 +246,11 @@ export default {
 
       return Object.values(userRoles);
     },
+    // SURE-8995: whether the user can MUTATE cluster members (the Add action opens
+    // the create-CRTB form, which needs the role-template + user reads to pick a
+    // role and search principals). A cluster-owner on a `user-base` global role
+    // lacks these, so the cluster Add is hidden and they get a read-only view -
+    // mirroring the project side (`canManageProjectMembers`).
     canManageMembers() {
       return canViewClusterPermissionsEditor(this.$store);
     },
@@ -241,8 +260,22 @@ export default {
     canViewClusterMembers() {
       return !!this.$store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING);
     },
+    // SURE-8995: whether the current user can MUTATE project members from this page
+    // (add / remove). This requires the full membership editor schemas (role
+    // templates + principals), which the add flow depends on to pick a role and
+    // search principals. A cluster-owner on a `user-base` global role lacks these,
+    // so they get a read-only view (see `canViewProjectMembers`).
     canManageProjectMembers() {
       return canViewProjectMembershipEditor(this.$store);
+    },
+    // SURE-8995: whether to show the Project Membership tab at all. Viewing the
+    // members list only needs access to the project role bindings themselves - it
+    // must NOT require the role-template/principal reads (those only gate the
+    // add/remove actions). Otherwise a cluster-owner on a `user-base` global role -
+    // who can genuinely see and manage project members on the backend - is shown no
+    // tab. Name/role resolution degrades gracefully when those reads are absent.
+    canViewProjectMembers() {
+      return !!this.$store.getters['rancher/schemaFor'](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
     },
     isLocal() {
       return this.$store.getters['currentCluster'].isLocal;
@@ -352,7 +385,7 @@ export default {
         :label="t('members.clusterMembership')"
       >
         <div
-          v-if="canEditClusterMembers"
+          v-if="canManageMembers && canEditClusterMembers"
           class="row mb-10 cluster-add"
         >
           <rc-button
@@ -377,7 +410,7 @@ export default {
         />
       </Tab>
       <Tab
-        v-if="canManageProjectMembers && !isHarvester"
+        v-if="canViewProjectMembers && !isHarvester"
         name="project-membership"
         :label="t('members.projectMembership')"
       >
@@ -402,7 +435,7 @@ export default {
               </div>
               <div class="right">
                 <button
-                  v-if="canAddProjectMember(group)"
+                  v-if="canManageProjectMembers && canAddProjectMember(group)"
                   type="button"
                   class="btn btn-sm role-secondary mr-10 right"
                   :data-testid="`add-project-member-${getProjectLabel(group).replace(' ', '').toLowerCase()}`"
@@ -431,7 +464,7 @@ export default {
                 {{ role.nameDisplay }}
               </span>
               <i
-                v-if="canRemoveProjectMember(row)"
+                v-if="canManageProjectMembers && canRemoveProjectMember(row)"
                 class="icon icon-close"
                 :data-testid="`role-values-close-${j}`"
                 @click="removeRole(row, role, $event)"

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -5,6 +5,7 @@ import Principal from '@shell/components/auth/Principal';
 import Loading from '@shell/components/Loading';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { get, set } from '@shell/utils/object';
+import { fetchProjectMembershipPermissions } from '@shell/utils/project-permissions';
 
 function normalizeId(id) {
   return id?.replace(':', '/') || id;
@@ -88,6 +89,17 @@ export default {
     }
 
     this['bindings'] = bindings;
+
+    // SURE-8995: only offer "Add" when the user can actually create a binding in
+    // THIS project. Schema methods are global, so read the per-project answer
+    // from the project's `resourcePermissions` (steve `?checkPermissions=`). Only
+    // applies when editing an existing project's members; cluster members and the
+    // create-project flow are unaffected.
+    if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId && this.mode !== _CREATE) {
+      const permissions = await fetchProjectMembershipPermissions(this.$store, this.parentId);
+
+      this['canAddMember'] = !!permissions[normalizeId(this.parentId)]?.create;
+    }
   },
 
   data() {
@@ -95,6 +107,7 @@ export default {
       schema:            this.$store.getters[`rancher/schemaFor`](this.type),
       bindings:          [],
       lastSavedBindings: [],
+      canAddMember:      true,
     };
   },
 
@@ -197,6 +210,7 @@ export default {
     </template>
     <template #add>
       <button
+        v-if="canAddMember"
         type="button"
         class="btn role-primary mt-10"
         data-testid="add-item"

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -180,6 +180,7 @@ export default {
     v-model:value="bindings"
     :mode="mode"
     :show-header="true"
+    :add-allowed="canAddMember"
   >
     <template #column-headers>
       <div class="box mb-0">
@@ -210,7 +211,6 @@ export default {
     </template>
     <template #add>
       <button
-        v-if="canAddMember"
         type="button"
         class="btn role-primary mt-10"
         data-testid="add-item"

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -17,12 +17,8 @@ export function canViewMembershipEditor(store, needsProject = false) {
     !!store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL);
 }
 
-// SURE-8995: whether the user can VIEW the membership list (read-only). Unlike
-// `canViewMembershipEditor` - which gates add/remove and therefore needs the
-// role-template + principal reads the add flow depends on - viewing only needs
-// access to the role-binding schema itself. This lets a cluster-owner on a
-// `user-base` global role, who can see project members on the backend but lacks
-// the global role-template/principal reads, still see the members list.
+// Can the user VIEW the membership list (read-only)? Unlike `canViewMembershipEditor` (which gates
+// add/remove and needs the role-template + principal reads), viewing needs only the binding schema.
 export function canViewMembershipEditorList(store, needsProject = false) {
   const bindingType = needsProject ? NORMAN.PROJECT_ROLE_TEMPLATE_BINDING : NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING;
 
@@ -79,11 +75,8 @@ export default {
     if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId) {
       Object.assign(roleBindingRequestParams, { opt: { filter: { projectId: this.parentId.split('/').join(':') }, force: true } });
     }
-    // SURE-8995: guard the principal / role-template / user hydration on their
-    // schemas so a view-only user (e.g. a cluster-owner on a `user-base` global
-    // role) doesn't hit "Unknown schema for type: ..." - the bindings still load
-    // and render read-only. Only the bindings (index 0) are consumed below; the
-    // rest hydrate the store for name/role resolution when the user can read them.
+    // Guard each hydration dispatch on its schema so a view-only user doesn't hit "Unknown schema";
+    // only the bindings (index 0) are consumed below, the rest hydrate name/role resolution.
     const userHydration = [
       this.schema ? this.$store.dispatch(`rancher/findAll`, roleBindingRequestParams) : []
     ];
@@ -117,15 +110,14 @@ export default {
 
     this['bindings'] = bindings;
 
-    // SURE-8995: only offer "Add" when the user can actually create a binding in
-    // THIS project. Schema methods are global, so read the per-project answer
-    // from the project's `resourcePermissions` (steve `?checkPermissions=`). Only
-    // applies when editing an existing project's members; cluster members and the
-    // create-project flow are unaffected.
+    // Schema methods are global, so read the per-project answer from the project's
+    // `resourcePermissions` to only offer "Add" where the user can create a binding in THIS project.
     if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId && this.mode !== _CREATE) {
       const permissions = await fetchProjectMembershipPermissions(this.$store, this.parentId);
+      const permission = permissions[normalizeId(this.parentId)];
 
-      this['canAddMember'] = !!permissions[normalizeId(this.parentId)]?.create;
+      this['canAddMember'] = !!permission?.create;
+      this['canRemoveMember'] = !!permission?.remove;
     }
   },
 
@@ -135,6 +127,7 @@ export default {
       bindings:          [],
       lastSavedBindings: [],
       canAddMember:      true,
+      canRemoveMember:   true,
     };
   },
 
@@ -176,8 +169,7 @@ export default {
       return this.mode === _VIEW;
     },
 
-    // SURE-8995: whether the user can add/remove members here. The add flow needs
-    // the role-template + principal reads (to pick a role and search principals),
+    // Can add/remove members here? The add flow needs the role-template + principal reads,
     // so when those are absent the editor is shown read-only.
     canManageMembers() {
       return canViewMembershipEditor(this.$store, this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
@@ -254,7 +246,9 @@ export default {
       </button>
     </template>
     <template #remove-button="{remove, i}">
-      <span v-if="(isCreate && i === 0) || isView || !canManageMembers" />
+      <!-- Hide Remove on an EXISTING binding (a saved row has an id) when the user lacks
+           delete permission; newly-added, unsaved rows stay removable. -->
+      <span v-if="(isCreate && i === 0) || isView || !canManageMembers || (!canRemoveMember && !!bindings[i]?.id)" />
       <button
         v-else
         type="button"

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -17,6 +17,18 @@ export function canViewMembershipEditor(store, needsProject = false) {
     !!store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL);
 }
 
+// SURE-8995: whether the user can VIEW the membership list (read-only). Unlike
+// `canViewMembershipEditor` - which gates add/remove and therefore needs the
+// role-template + principal reads the add flow depends on - viewing only needs
+// access to the role-binding schema itself. This lets a cluster-owner on a
+// `user-base` global role, who can see project members on the backend but lacks
+// the global role-template/principal reads, still see the members list.
+export function canViewMembershipEditorList(store, needsProject = false) {
+  const bindingType = needsProject ? NORMAN.PROJECT_ROLE_TEMPLATE_BINDING : NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING;
+
+  return !!store.getters['rancher/schemaFor'](bindingType);
+}
+
 export default {
   emits: ['membership-update'],
 
@@ -67,12 +79,27 @@ export default {
     if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId) {
       Object.assign(roleBindingRequestParams, { opt: { filter: { projectId: this.parentId.split('/').join(':') }, force: true } });
     }
+    // SURE-8995: guard the principal / role-template / user hydration on their
+    // schemas so a view-only user (e.g. a cluster-owner on a `user-base` global
+    // role) doesn't hit "Unknown schema for type: ..." - the bindings still load
+    // and render read-only. Only the bindings (index 0) are consumed below; the
+    // rest hydrate the store for name/role resolution when the user can read them.
     const userHydration = [
-      this.schema ? this.$store.dispatch(`rancher/findAll`, roleBindingRequestParams) : [],
-      this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
-      this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }),
-      this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER })
+      this.schema ? this.$store.dispatch(`rancher/findAll`, roleBindingRequestParams) : []
     ];
+
+    if (this.$store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL)) {
+      userHydration.push(this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }));
+    }
+
+    if (this.$store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)) {
+      userHydration.push(this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }));
+    }
+
+    if (this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
+      userHydration.push(this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER }));
+    }
+
     const [allBindings] = await Promise.all(userHydration);
 
     const bindings = allBindings
@@ -148,6 +175,13 @@ export default {
     isView() {
       return this.mode === _VIEW;
     },
+
+    // SURE-8995: whether the user can add/remove members here. The add flow needs
+    // the role-template + principal reads (to pick a role and search principals),
+    // so when those are absent the editor is shown read-only.
+    canManageMembers() {
+      return canViewMembershipEditor(this.$store, this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
+    },
   },
   watch: {
     membershipUpdate: {
@@ -180,7 +214,7 @@ export default {
     v-model:value="bindings"
     :mode="mode"
     :show-header="true"
-    :add-allowed="canAddMember"
+    :add-allowed="canAddMember && canManageMembers"
   >
     <template #column-headers>
       <div class="box mb-0">
@@ -220,7 +254,7 @@ export default {
       </button>
     </template>
     <template #remove-button="{remove, i}">
-      <span v-if="(isCreate && i === 0) || isView" />
+      <span v-if="(isCreate && i === 0) || isView || !canManageMembers" />
       <button
         v-else
         type="button"

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -7,10 +7,8 @@ export function canViewProjectMembershipEditor(store) {
   return canViewMembershipEditor(store, true);
 }
 
-// SURE-8995: read-only view gate for the project members list (see
-// `canViewMembershipEditorList`). Used to show the Members tab to users who can
-// see project members but not fully manage them (e.g. a cluster-owner on a
-// `user-base` global role).
+// Read-only view gate for the project members list (see `canViewMembershipEditorList`): shows the
+// Members tab to users who can see project members but not fully manage them.
 export function canViewProjectMembershipList(store) {
   return canViewMembershipEditorList(store, true);
 }

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -1,10 +1,18 @@
 <script>
 import { NORMAN } from '@shell/config/types';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
-import MembershipEditor, { canViewMembershipEditor } from '@shell/components/form/Members/MembershipEditor';
+import MembershipEditor, { canViewMembershipEditor, canViewMembershipEditorList } from '@shell/components/form/Members/MembershipEditor';
 
 export function canViewProjectMembershipEditor(store) {
   return canViewMembershipEditor(store, true);
+}
+
+// SURE-8995: read-only view gate for the project members list (see
+// `canViewMembershipEditorList`). Used to show the Members tab to users who can
+// see project members but not fully manage them (e.g. a cluster-owner on a
+// `user-base` global role).
+export function canViewProjectMembershipList(store) {
+  return canViewMembershipEditorList(store, true);
 }
 
 export default {

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -41,9 +41,8 @@ describe('component: MembershipEditor', () => {
           $store: {
             getters: {
               'rancher/schemaFor':    () => ({ type: 'object' }),
-              // SURE-8995: `canManageMembers` (which gates add/remove) reads the
-              // management role-template/PRTB schemas - provide them so the manage
-              // actions render for this manage-capable user.
+              // `canManageMembers` (gates add/remove) reads the management role-template/PRTB
+              // schemas - provide them so the manage actions render.
               'management/schemaFor': () => ({ type: 'object' }),
             }
           },

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -38,7 +38,15 @@ describe('component: MembershipEditor', () => {
       },
       global: {
         mocks: {
-          $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
+          $store: {
+            getters: {
+              'rancher/schemaFor':    () => ({ type: 'object' }),
+              // SURE-8995: `canManageMembers` (which gates add/remove) reads the
+              // management role-template/PRTB schemas - provide them so the manage
+              // actions render for this manage-capable user.
+              'management/schemaFor': () => ({ type: 'object' }),
+            }
+          },
           $fetchState: { pending: false },
         },
         stubs: { Principal: true },

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -30,7 +30,7 @@ import {
   TYPE,
 } from '@shell/config/table-headers';
 
-import { DSL } from '@shell/store/type-map';
+import { DSL, IF_HAVE } from '@shell/store/type-map';
 import {
   STEVE_AGE_COL, STEVE_EVENT_FIRST_SEEN, STEVE_EVENT_LAST_SEEN, STEVE_EVENT_OBJECT, STEVE_EVENT_TYPE, STEVE_LIST_GROUPS, STEVE_NAMESPACE_COL, STEVE_NAME_COL, STEVE_STATE_COL,
   STEVE_WORKLOAD_HEALTH_SCALE
@@ -633,10 +633,9 @@ export function init(store) {
     exact:        false,
     'exact-path': true,
     navResources: [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING],
-    ifHaveType:   {
-      type:  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
-      store: 'management'
-    }
+    // SURE-8995: show if the user can access cluster OR project role bindings (not cluster-only), so a
+    // user with only "Manage Project Members" can reach the Cluster and Project Members page.
+    ifHave:       IF_HAVE.CLUSTER_OR_PROJECT_MEMBERS
   });
 
   virtualType({

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -633,8 +633,8 @@ export function init(store) {
     exact:        false,
     'exact-path': true,
     navResources: [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING],
-    // SURE-8995: show if the user can access cluster OR project role bindings (not cluster-only), so a
-    // user with only "Manage Project Members" can reach the Cluster and Project Members page.
+    // Show if the user can access cluster OR project role bindings, so a user with only
+    // "Manage Project Members" can reach the Cluster and Project Members page.
     ifHave:       IF_HAVE.CLUSTER_OR_PROJECT_MEMBERS
   });
 

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -13,7 +13,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { MANAGEMENT } from '@shell/config/types';
 import { NAME } from '@shell/config/product/explorer';
 import { PROJECT_ID, _VIEW, _CREATE, _EDIT } from '@shell/config/query-params';
-import ProjectMembershipEditor, { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor';
+import ProjectMembershipEditor, { canViewProjectMembershipList } from '@shell/components/form/Members/ProjectMembershipEditor';
 import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { Banner } from '@components/Banner';
@@ -55,8 +55,12 @@ export default {
   computed: {
     ...mapGetters(['currentCluster', 'isStandaloneHarvester']),
 
+    // SURE-8995: show the Members tab to anyone who can view the members list. Add
+    // and remove within the editor are separately gated on full manage rights, so a
+    // cluster-owner on a `user-base` global role gets a read-only members view
+    // instead of no tab at all.
     canViewMembers() {
-      return canViewProjectMembershipEditor(this.$store);
+      return canViewProjectMembershipList(this.$store);
     },
 
     canEditProject() {

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -55,10 +55,8 @@ export default {
   computed: {
     ...mapGetters(['currentCluster', 'isStandaloneHarvester']),
 
-    // SURE-8995: show the Members tab to anyone who can view the members list. Add
-    // and remove within the editor are separately gated on full manage rights, so a
-    // cluster-owner on a `user-base` global role gets a read-only members view
-    // instead of no tab at all.
+    // Show the Members tab to anyone who can view the list; add/remove are separately gated on
+    // full manage rights, so a view-only user gets a read-only members view instead of no tab.
     canViewMembers() {
       return canViewProjectMembershipList(this.$store);
     },

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -214,15 +214,19 @@ export const SPOOFED_API_PREFIX = '__[[spoofedapi]]__';
 const instanceMethods = {};
 
 export const IF_HAVE = {
-  V2_MONITORING:            'v2-monitoring',
-  PROJECT:                  'project',
-  NO_PROJECT:               'no-project',
-  NOT_V1_ISTIO:             'not-v1-istio',
-  MULTI_CLUSTER:            'multi-cluster',
-  NEUVECTOR_NAMESPACE:      'neuvector-namespace',
-  ADMIN:                    'admin-user',
-  MCM_DISABLED:             'mcm-disabled',
-  NOT_STANDALONE_HARVESTER: 'not-standalone-harvester',
+  V2_MONITORING:              'v2-monitoring',
+  PROJECT:                    'project',
+  NO_PROJECT:                 'no-project',
+  NOT_V1_ISTIO:               'not-v1-istio',
+  MULTI_CLUSTER:              'multi-cluster',
+  NEUVECTOR_NAMESPACE:        'neuvector-namespace',
+  ADMIN:                      'admin-user',
+  MCM_DISABLED:               'mcm-disabled',
+  NOT_STANDALONE_HARVESTER:   'not-standalone-harvester',
+  // Show if the user can access cluster OR project role template bindings. Used by the
+  // "Cluster and Project Members" nav so a user with only project-level membership permissions
+  // (e.g. Manage Project Members) can reach it, not just cluster-level ones (SURE-8995).
+  CLUSTER_OR_PROJECT_MEMBERS: 'cluster-or-project-members',
 };
 
 export function DSL(store, product, module = 'type-map') {
@@ -2055,6 +2059,13 @@ function ifHave(getters, option) {
   }
   case IF_HAVE.NOT_STANDALONE_HARVESTER: { // Not used by harvester extension...
     return !getters['isStandaloneHarvester'];
+  }
+  case IF_HAVE.CLUSTER_OR_PROJECT_MEMBERS: {
+    // SURE-8995: the Cluster and Project Members page is reachable if the user can access EITHER
+    // cluster role template bindings (cluster owner/member) OR project ones (e.g. Manage Project
+    // Members). Previously it was gated on cluster bindings alone, hiding it from project members.
+    return !!getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING) ||
+           !!getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING);
   }
   default:
     return false;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -223,9 +223,8 @@ export const IF_HAVE = {
   ADMIN:                      'admin-user',
   MCM_DISABLED:               'mcm-disabled',
   NOT_STANDALONE_HARVESTER:   'not-standalone-harvester',
-  // Show if the user can access cluster OR project role template bindings. Used by the
-  // "Cluster and Project Members" nav so a user with only project-level membership permissions
-  // (e.g. Manage Project Members) can reach it, not just cluster-level ones (SURE-8995).
+  // Show if the user can access cluster OR project role template bindings, so a project-only
+  // member can reach the "Cluster and Project Members" nav, not just cluster-level ones.
   CLUSTER_OR_PROJECT_MEMBERS: 'cluster-or-project-members',
 };
 
@@ -2061,9 +2060,7 @@ function ifHave(getters, option) {
     return !getters['isStandaloneHarvester'];
   }
   case IF_HAVE.CLUSTER_OR_PROJECT_MEMBERS: {
-    // SURE-8995: the Cluster and Project Members page is reachable if the user can access EITHER
-    // cluster role template bindings (cluster owner/member) OR project ones (e.g. Manage Project
-    // Members). Previously it was gated on cluster bindings alone, hiding it from project members.
+    // Reachable if the user can access EITHER cluster OR project role template bindings.
     return !!getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING) ||
            !!getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING);
   }

--- a/shell/utils/project-permissions.ts
+++ b/shell/utils/project-permissions.ts
@@ -1,0 +1,59 @@
+import { MANAGEMENT } from '@shell/config/types';
+
+const PROJECT_RTB = MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING;
+
+export interface ProjectMembershipPermission {
+  /** current user may create project role template bindings in this project */
+  create: boolean;
+  /** current user may delete project role template bindings in this project */
+  remove: boolean;
+}
+
+/**
+ * Determine, per project, whether the current user can manage its members.
+ *
+ * Uses steve's `?checkPermissions=` query parameter (rancher/steve#594, built
+ * for rancher#48788 / SURE-8995): the API returns a `resourcePermissions` map on
+ * each project listing the verbs the user is granted on the given resource *in
+ * that project's namespace*. This is the per-project answer that the global
+ * schema `collectionMethods` can't give, delivered on the project data itself -
+ * one request for all projects, no per-project fan-out.
+ *
+ * @param store     Vuex store
+ * @param projectId optional single mgmt project id (e.g. `local/p-abc`); when
+ *                  omitted, all projects are fetched
+ * @returns map of mgmt project id -> { create, remove }
+ */
+export async function fetchProjectMembershipPermissions(
+  store: any,
+  projectId: string | null = null
+): Promise<Record<string, ProjectMembershipPermission>> {
+  const schema = store.getters['management/schemaFor'](MANAGEMENT.PROJECT);
+  const collection = schema?.links?.collection;
+
+  if (!collection) {
+    return {};
+  }
+
+  const url = projectId ? `${ collection }/${ projectId.replace(':', '/') }?checkPermissions=${ PROJECT_RTB }` : `${ collection }?checkPermissions=${ PROJECT_RTB }`;
+
+  let res;
+
+  try {
+    res = await store.dispatch('management/request', { url });
+  } catch (e) {
+    // Fail closed: without a definitive answer, don't offer member actions.
+    // The server still enforces access regardless of what the UI shows.
+    return {};
+  }
+
+  const projects = Array.isArray(res?.data) ? res.data : (res?.id ? [res] : []);
+
+  return projects.reduce((acc: Record<string, ProjectMembershipPermission>, project: any) => {
+    const perms = project.resourcePermissions?.[PROJECT_RTB] || {};
+
+    acc[project.id] = { create: !!perms.create, remove: !!perms.delete };
+
+    return acc;
+  }, {});
+}

--- a/shell/utils/project-permissions.ts
+++ b/shell/utils/project-permissions.ts
@@ -12,12 +12,10 @@ export interface ProjectMembershipPermission {
 /**
  * Determine, per project, whether the current user can manage its members.
  *
- * Uses steve's `?checkPermissions=` query parameter (rancher/steve#594, built
- * for rancher#48788 / SURE-8995): the API returns a `resourcePermissions` map on
- * each project listing the verbs the user is granted on the given resource *in
- * that project's namespace*. This is the per-project answer that the global
- * schema `collectionMethods` can't give, delivered on the project data itself -
- * one request for all projects, no per-project fan-out.
+ * Uses steve's `?checkPermissions=` query parameter: the API returns a
+ * `resourcePermissions` map on each project listing the verbs the user is granted
+ * on the given resource *in that project's namespace* — the per-project answer the
+ * global schema `collectionMethods` can't give, in one request for all projects.
  *
  * @param store     Vuex store
  * @param projectId optional single mgmt project id (e.g. `local/p-abc`); when
@@ -32,6 +30,9 @@ export async function fetchProjectMembershipPermissions(
   const collection = schema?.links?.collection;
 
   if (!collection) {
+    // eslint-disable-next-line no-console
+    console.warn('management.cattle.io.project schema has no collection link; cannot check per-project member permissions — hiding member actions (fail-closed).');
+
     return {};
   }
 
@@ -42,8 +43,10 @@ export async function fetchProjectMembershipPermissions(
   try {
     res = await store.dispatch('management/request', { url });
   } catch (e) {
-    // Fail closed: without a definitive answer, don't offer member actions.
-    // The server still enforces access regardless of what the UI shows.
+    // Fail closed (the server still enforces access); log it so a false-deny isn't silent.
+    // eslint-disable-next-line no-console
+    console.warn(`project membership permission check failed for ${ projectId || 'all projects' } — hiding member actions (fail-closed):`, e);
+
     return {};
   }
 


### PR DESCRIPTION
### Summary
Fixes #12458 (SURE-8995)

The **Cluster and Project Members** nav was gated on cluster (CRTB) access, so a **Project Member** with the **Manage Project Members** role couldn't reach it. This PR:
- Opens the page to users with **cluster OR project** role-binding access (was CRTB-only).
- Gates the per-project **Add**/**✕** on each project's real `resourcePermissions` (steve `?checkPermissions=`, rancher/steve#594) instead of the global `collectionMethods`, so actions only show where the user can actually manage.
- Gives a **read-only** members view to users who can read the bindings but lack the global role-template/principal reads the editor needs (e.g. a **cluster-owner** on a **User-Base** global role) — previously they got no tab and `Unknown schema` errors. Those reads now gate only Add/remove; hydration is guarded per schema.

### Technical notes
- `store/type-map.js` + `config/product/explorer.js` — new `IF_HAVE.CLUSTER_OR_PROJECT_MEMBERS` for the nav gate (CRTB **or** PRTB).
- `utils/project-permissions.ts` *(new)* — per-project `{ create, remove }` from `resourcePermissions` in one request.
- `ExplorerMembers.vue`, `Members/MembershipEditor.vue`, `Members/ProjectMembershipEditor.vue`, `edit/management.cattle.io.project.vue` — split **view** (binding schema) from **manage** (role-template + principal) gates; guard hydration so limited users don't hit `Unknown schema`.

### Testing
1. **Manage-on-A / View-on-B** user (Standard User): Project tab only; Add/✕ on A, hidden on B; same in Edit Project → Members.
2. **Cluster-only** user: Cluster tab only, no errors.
3. **User-Base + cluster-owner**: both tabs + Edit Project editor **read-only** (no Add/✕), no `Unknown schema`; names may not fully resolve (expected).
4. **Admin**: both tabs, all actions — no regression.

Verified end-to-end on a live 2.15 backend in Chromium; unit tests updated. Reviewer: please try another browser + light/dark + a11y.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
