### PR TITLE
Fix scroll bar always shows on growl

### DIFF
--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -206,7 +206,7 @@ export default {
 
           // Limit size of message and scroll just the message, not the entire growl, so that the title and icon are always visible
           max-height: 200px;
-          overflow-y: scroll;
+          overflow-y: auto;
 
           &.has-title {
             margin-top: 5px;


### PR DESCRIPTION
### Summary
Fixes #18319

Not this is not usually seen on a Mac (scroll bar is only shown when you scroll), but can be seen easily on Chrome on Linux.

### Occurred changes and/or fixed issues
The growl notification message area was always displaying a vertical scrollbar, even when the message content did not exceed the `max-height` (200px). The scrollbar now only appears when the message actually overflows.

### Technical notes summary
In [shell/components/GrowlManager.vue](shell/components/GrowlManager.vue), changed the message container's `overflow-y` from `scroll` to `auto` so the scrollbar is only rendered when needed.

This is an obvious fix.

### Areas or cases that should be tested
- Trigger a short growl notification and confirm no scrollbar is shown.
- Trigger a growl notification with a long message that exceeds 200px and confirm the message area scrolls (with a scrollbar) while the title and icon remain visible.
- Verify in both light and dark mode.
- Tested locally in Chrome.

### Areas which could experience regressions
- Growl notification rendering (all growl types: success, info, warning, error).

### Screenshot/Video

Where scroll should not be shown:

<img width="475" height="201" alt="image" src="https://github.com/user-attachments/assets/fd10809f-f6b9-4402-a11d-fe3f50d139d5" />

Where scroll is still needed:

<img width="436" height="314" alt="image" src="https://github.com/user-attachments/assets/b064c842-740d-4bc0-a42a-706b6051d03b" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
