### PR TITLE
Fix lingering a11y issues with Tabbed + Tab components

### DIFF
--- a/cypress/e2e/po/components/certificates.po.ts
+++ b/cypress/e2e/po/components/certificates.po.ts
@@ -7,11 +7,11 @@ export default class CertificatesPo extends ComponentPo {
   }
 
   expiredBanner() {
-    return new ComponentPo('#cluster-certs .banner.error');
+    return new ComponentPo('[data-testid="tab-panel-cluster-certs"] .banner.error');
   }
 
   expiringBanner() {
-    return new ComponentPo('#cluster-certs .banner.warning');
+    return new ComponentPo('[data-testid="tab-panel-cluster-certs"] .banner.warning');
   }
 
   list() {

--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -17,8 +17,12 @@ export default class TabbedPo extends ComponentPo {
     return this.self().get(`[data-testid="btn-${ name }"]`).click();
   }
 
+  /**
+   * The tablist can also hold presentational list items (the add/remove footer, `tab-row-extras`
+   * slot content), so scope this to actual tabs.
+   */
   allTabs(componentTestId = this.componentId) {
-    return this.self().get(`[data-testid="${ componentTestId }-block"] > li`);
+    return this.self().get(`[data-testid="${ componentTestId }-block"] > li.tab`);
   }
 
   assertTabIsActive(selector: string) {

--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -23,8 +23,12 @@ export default class TabbedPo extends ComponentPo {
     return this.self().get(`[data-testid="btn-${ name }"]`).click();
   }
 
+  /**
+   * The tablist `<ul>` only holds `<li role="presentation">` tab wrappers; controls and extras
+   * are rendered as siblings outside the `<ul>`, so `> li.tab` safely scopes to actual tabs.
+   */
   allTabs(componentTestId = this.componentId) {
-    return this.self().get(`[data-testid="${ componentTestId }-block"] > li`);
+    return this.self().get(`[data-testid="${ componentTestId }-block"] > li.tab`);
   }
 
   assertTabIsActive(selector: string) {

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -47,7 +47,7 @@ export default abstract class ClusterManagerDetailPagePo extends BaseDetailPageP
   }
 
   poolsList(tabId: 'machine' | 'node') {
-    return new MachinePoolsListPo(this.self().find(`#${ tabId }-pools [data-testid="sortable-table-list-container"]`));
+    return new MachinePoolsListPo(this.self().find(`[data-testid="tab-panel-${ tabId }-pools"] [data-testid="sortable-table-list-container"]`));
   }
 
   conditionsList() {

--- a/cypress/e2e/po/edit/resource-detail.po.ts
+++ b/cypress/e2e/po/edit/resource-detail.po.ts
@@ -49,7 +49,7 @@ export default class ResourceDetailPo extends ComponentPo {
    * @returns the list of the tab
    */
   tabbedList(tabId: string, index?: number) {
-    const baseSelector = `#${ tabId } [data-testid="sortable-table-list-container"]`;
+    const baseSelector = `[data-testid="tab-panel-${ tabId }"] [data-testid="sortable-table-list-container"]`;
     const selector = tabId === 'related' ? `${ baseSelector }:nth-of-type(${ index })` : baseSelector;
 
     return new ResourceTablePo(selector);

--- a/cypress/e2e/po/edit/services.po.ts
+++ b/cypress/e2e/po/edit/services.po.ts
@@ -54,7 +54,7 @@ export default class ServicesCreateEditPo extends PagePo {
   }
 
   externalNameInput() {
-    return new LabeledInputPo('#define-external-name .labeled-input input');
+    return new LabeledInputPo('[data-testid="tab-panel-define-external-name"] .labeled-input input');
   }
 
   ipAddressesTab() {
@@ -62,7 +62,7 @@ export default class ServicesCreateEditPo extends PagePo {
   }
 
   ipAddressList() {
-    return new ArrayListPo('section#ips');
+    return new ArrayListPo('[data-testid="tab-panel-ips"]');
   }
 
   lablesAnnotationsTab() {
@@ -70,7 +70,7 @@ export default class ServicesCreateEditPo extends PagePo {
   }
 
   lablesAnnotationsKeyValue() {
-    return new KeyValuePo('section#labels-and-annotations');
+    return new KeyValuePo('[data-testid="tab-panel-labels-and-annotations"]');
   }
 
   errorBanner() {

--- a/cypress/e2e/po/other-products/logging/logging-clusterflow.po.ts
+++ b/cypress/e2e/po/other-products/logging/logging-clusterflow.po.ts
@@ -49,7 +49,7 @@ export class LoggingClusterFlowCreateEditPagePo extends BaseDetailPagePo {
   }
 
   outputSelector() {
-    return new LabeledSelectPo('section#outputs .labeled-select');
+    return new LabeledSelectPo('[data-testid="tab-panel-outputs"] .labeled-select');
   }
 
   ruleItem(index: number) {
@@ -57,7 +57,7 @@ export class LoggingClusterFlowCreateEditPagePo extends BaseDetailPagePo {
   }
 
   matchesList() {
-    return new ArrayListPo('section#match .array-list-grouped');
+    return new ArrayListPo('[data-testid="tab-panel-match"] .array-list-grouped');
   }
 
   /**
@@ -100,7 +100,7 @@ export class LoggingClusterFlowDetailPagePo extends BaseDetailPagePo {
   }
 
   outputSelector() {
-    return new LabeledSelectPo('section#outputs .labeled-select');
+    return new LabeledSelectPo('[data-testid="tab-panel-outputs"] .labeled-select');
   }
 
   ruleItem(index: number) {

--- a/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
@@ -70,11 +70,11 @@ export default class ClusterDashboardPagePo extends PagePo {
   }
 
   eventsList() {
-    return new ResourceTablePo('#cluster-events [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-cluster-events"] [data-testid="sortable-table-list-container"]');
   }
 
   certificatesList() {
-    return new ResourceTablePo('#cluster-certs [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-cluster-certs"] [data-testid="sortable-table-list-container"]');
   }
 
   clusterActionsHeader() {

--- a/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
@@ -83,6 +83,6 @@ export default class ClusterProjectMembersPo extends PagePo {
   }
 
   projectTable() {
-    return new SortableTablePo('#project-membership [data-testid="sortable-table-list-container"]');
+    return new SortableTablePo('[data-testid="tab-panel-project-membership"] [data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/explorer/ingress.po.ts
+++ b/cypress/e2e/po/pages/explorer/ingress.po.ts
@@ -50,7 +50,7 @@ export class IngressCreateEditPo extends BaseDetailPagePo {
   }
 
   rulesList() {
-    return new ArrayListPo('section#rules .array-list-grouped');
+    return new ArrayListPo('[data-testid="tab-panel-rules"] .array-list-grouped');
   }
 
   setRuleRequestHostValue(arrayListIndex: number, value: string) {
@@ -84,7 +84,7 @@ export class IngressCreateEditPo extends BaseDetailPagePo {
   }
 
   certificatesList() {
-    return new ArrayListPo('section#certificates .array-list-grouped');
+    return new ArrayListPo('[data-testid="tab-panel-certificates"] .array-list-grouped');
   }
 
   setSecretNameValueByLabel(arrayListIndex: number, value: string, parentIndex?: number) {
@@ -121,7 +121,7 @@ export class IngressDetailPagePo extends BaseDetailPagePo {
    * @returns the list of the tab
    */
   list(tabId: 'rules' | 'events' | 'related', index?: number) {
-    const baseSelector = `#${ tabId } [data-testid="sortable-table-list-container"]`;
+    const baseSelector = `[data-testid="tab-panel-${ tabId }"] [data-testid="sortable-table-list-container"]`;
     const selector = tabId === 'related' ? `${ baseSelector }:nth-of-type(${ index })` : baseSelector;
 
     return new ResourceTablePo(selector);

--- a/cypress/e2e/po/pages/explorer/network-policy.po.ts
+++ b/cypress/e2e/po/pages/explorer/network-policy.po.ts
@@ -62,7 +62,7 @@ export class NetworkPolicyCreateEditPagePo extends BaseDetailPagePo {
   }
 
   ingressRuleItem(index: number) {
-    return new ArrayListPo('section #rule-ingress0', this.self()).arrayListItem(index);
+    return new ArrayListPo('[data-testid="tab-panel-rule-ingress0"]', this.self()).arrayListItem(index);
   }
 
   ingressRuleItemPortInput(index: number) {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
@@ -230,7 +230,7 @@ export class FleetGitRepoDetailsPo extends BaseDetailPagePo {
   }
 
   bundlesList() {
-    return new ResourceTablePo('#bundles [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-bundles"] [data-testid="sortable-table-list-container"]');
   }
 
   showConfig() {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.bundle.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.bundle.po.ts
@@ -63,14 +63,14 @@ export class FleetBundleDetailsPo extends BaseDetailPagePo {
   }
 
   resourcesList() {
-    return new ResourceTablePo('#resources [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-resources"] [data-testid="sortable-table-list-container"]');
   }
 
   conditionsList() {
-    return new ResourceTablePo('#conditions [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-conditions"] [data-testid="sortable-table-list-container"]');
   }
 
   eventsList() {
-    return new ResourceTablePo('#events [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-events"] [data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
@@ -59,7 +59,7 @@ export class FleetClusterDetailsPo extends BaseDetailPagePo {
   }
 
   appBundlesList() {
-    return new ResourceTablePo('#applications [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-applications"] [data-testid="sortable-table-list-container"]');
   }
 
   addAppButton() {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.clustergroup.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.clustergroup.po.ts
@@ -64,6 +64,6 @@ export class FleetClusterGroupDetailsPo extends BaseDetailPagePo {
   }
 
   clusterList() {
-    return new ResourceTablePo('#clusters [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-clusters"] [data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.fleetworkspace.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.fleetworkspace.po.ts
@@ -48,11 +48,11 @@ export class FleetWorkspaceCreateEditPo extends BaseDetailPagePo {
   }
 
   allowTargetNsTabList() {
-    return new ArrayListPo('section#allowedtargetnamespaces');
+    return new ArrayListPo('[data-testid="tab-panel-allowedtargetnamespaces"]');
   }
 
   lablesAnnotationsKeyValue() {
-    return new KeyValuePo('section#labels');
+    return new KeyValuePo('[data-testid="tab-panel-labels"]');
   }
 
   defaultOciRegistry() {
@@ -78,10 +78,10 @@ export class FleetWorkspaceDetailsPo extends BaseDetailPagePo {
   }
 
   recentEventsList() {
-    return new ResourceTablePo('#events [data-testid="sortable-table-list-container"]');
+    return new ResourceTablePo('[data-testid="tab-panel-events"] [data-testid="sortable-table-list-container"]');
   }
 
   relatedResourcesList(index: number) {
-    return new ResourceTablePo(`#related div:nth-of-type(${ index })[data-testid="sortable-table-list-container"]`);
+    return new ResourceTablePo(`[data-testid="tab-panel-related"] div:nth-of-type(${ index })[data-testid="sortable-table-list-container"]`);
   }
 }

--- a/cypress/e2e/po/pages/users-and-auth/roles.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/roles.po.ts
@@ -65,11 +65,11 @@ export default class RolesPo extends ClusterPage {
    * @returns
    */
   list(tabIdSelector: 'GLOBAL' | 'CLUSTER' | 'NAMESPACE') {
-    return new RoleListPo(`#${ tabIdSelector } [data-testid="sortable-table-list-container"]`);
+    return new RoleListPo(`[data-testid="tab-panel-${ tabIdSelector }"] [data-testid="sortable-table-list-container"]`);
   }
 
   paginatedTab(tabIdSelector: 'GLOBAL' | 'CLUSTER' | 'NAMESPACE') {
-    return new PaginationPo(`#${ tabIdSelector } div.paging`);
+    return new PaginationPo(`[data-testid="tab-panel-${ tabIdSelector }"] div.paging`);
   }
 
   tabs() {

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -65,7 +65,7 @@ describe('Charts Wizard', { testIsolation: false, tags: ['@charts', '@adminUser'
       tabbedPo.allTabs().should('have.length', 4);
       installChartPage.selectTab(tabbedPo, 'Other Demo Fields');
 
-      const labeledSelect = new LabeledSelectPo('section[id="Other Demo Fields"] [type="search"]');
+      const labeledSelect = new LabeledSelectPo('[data-testid="tab-panel-Other Demo Fields"] [type="search"]');
 
       labeledSelect.self().scrollIntoView();
       labeledSelect.toggle();

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -49,8 +49,8 @@ describe('DaemonSets', { testIsolation: false, tags: ['@explorer2', '@adminUser'
       .click();
 
     // edit daemonset
-    workloadsDaemonsetsEditPage.clickTab('#DaemonSet');
-    workloadsDaemonsetsEditPage.clickTab('#upgrading');
+    workloadsDaemonsetsEditPage.clickTab('[data-testid="btn-DaemonSet"]');
+    workloadsDaemonsetsEditPage.clickTab('[data-testid="btn-upgrading"]');
     workloadsDaemonsetsEditPage.ScalingUpgradePolicyRadioBtn().set(1);
     workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
       .click();

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -67,9 +67,9 @@ describe('DaemonSets', { testIsolation: false, tags: ['@explorer2', '@adminUser'
     // commit and the tab bar to render before clicking a tab (gating on the list loading indicator
     // above isn't enough - the race is the edit form mounting).
     workloadsDaemonsetsEditPage.waitForPage();
-    workloadsDaemonsetsEditPage.waitForTab('#DaemonSet', LONG_TIMEOUT_OPT);
-    workloadsDaemonsetsEditPage.clickTab('#DaemonSet');
-    workloadsDaemonsetsEditPage.clickTab('#upgrading');
+    workloadsDaemonsetsEditPage.waitForTab('[data-testid="btn-DaemonSet"]', LONG_TIMEOUT_OPT);
+    workloadsDaemonsetsEditPage.clickTab('[data-testid="btn-DaemonSet"]');
+    workloadsDaemonsetsEditPage.clickTab('[data-testid="btn-upgrading"]');
     workloadsDaemonsetsEditPage.ScalingUpgradePolicyRadioBtn().set(1);
     workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
       .click();

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -194,10 +194,10 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
 
       // open the pod tab
-      deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
+      deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('[data-testid="btn-pod"]');
 
       // open the pod storage tab
-      deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage-pod');
+      deploymentEditConfigPage.podTabs().clickTabWithSelector('[data-testid="btn-storage-pod"]');
 
       // check that there is a component rendered for each workload volume and that that component has rendered some information about the volume
       deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().value()
@@ -209,7 +209,7 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().set('name: test-vol-changed\nprojected:\n    defaultMode: 420');
 
       // verify that the list of volumes in the container tab has updated
-      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('[data-testid="btn-storage"]');
       deploymentEditConfigPage.containerStorage().addVolumeButton().toggle();
       deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('contain', 'test-vol-changed (projected)');
       deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('not.contain', 'test-vol (projected)');
@@ -229,7 +229,7 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentsListPage.goTo();
       deploymentsListPage.waitForPage();
       deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
-      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('[data-testid="btn-storage"]');
 
       deploymentEditConfigPage.containerStorage().addVolume('test-vol1');
 
@@ -247,7 +247,7 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentsListPage.goTo();
       deploymentsListPage.waitForPage();
       deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
-      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('[data-testid="btn-storage"]');
       deploymentEditConfigPage.containerStorage().removeVolume(0);
       deploymentEditConfigPage.resourceDetail().cruResource().saveOrCreate().click();
 
@@ -264,7 +264,7 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentsCreatePage.goTo();
       deploymentsCreatePage.waitForPage();
 
-      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#container-0');
+      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('[data-testid="btn-container-0"]');
 
       deploymentsCreatePage.addEnvironmentVariable();
       deploymentsCreatePage.addEnvironmentVariable();
@@ -291,10 +291,10 @@ describe('Deployments', { testIsolation: false, tags: ['@explorer2', '@adminUser
       deploymentsCreatePage.waitForPage();
 
       // open the pod tab
-      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#pod');
+      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('[data-testid="btn-pod"]');
 
       // open the pod storage tab
-      deploymentsCreatePage.podTabs().clickTabWithSelector('li#storage-pod');
+      deploymentsCreatePage.podTabs().clickTabWithSelector('[data-testid="btn-storage-pod"]');
 
       deploymentsCreatePage.podStorage().addVolumeButton().toggle();
       deploymentsCreatePage.podStorage().addVolumeButton().getOptions().should('contain', 'CSI');

--- a/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
@@ -97,8 +97,8 @@ describe('Workloads', { tags: ['@adminUser'] }, () => {
         deploymentsListPage.goToEditConfigPage(nodeSchedulingDeploymentId);
 
         // Navigate to Pod tab > Node Scheduling tab
-        deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
-        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#nodeScheduling-pod');
+        deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('[data-testid="btn-pod"]');
+        deploymentEditConfigPage.podTabs().clickTabWithSelector('[data-testid="btn-nodeScheduling-pod"]');
 
         const nodeScheduling = new NodeSchedulingPo();
 

--- a/cypress/e2e/tests/pages/extensions/extension-compatibility.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extension-compatibility.spec.ts
@@ -249,8 +249,7 @@ describe('Extension Compatibility', { tags: ['@extensionsCompatibility', '@admin
       .should('exist')
       .scrollIntoView()
       .click({ force: true });
-    // Content lives in `section#<name>` (the tab nav `<li>` shares the same id, so scope to section).
-    cy.get(`section#${ tabName }`, MEDIUM_TIMEOUT_OPT).should('be.visible').and('contain', 'THIS IS A DEMO TAB');
+    cy.get(`[data-testid="tab-panel-${ tabName }"]`, MEDIUM_TIMEOUT_OPT).should('be.visible').and('contain', 'THIS IS A DEMO TAB');
   };
 
   /**

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -288,7 +288,7 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
 
         createRKE2ClusterPage.nameNsDescription().name().set('abc');
 
-        createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
+        createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
 
         createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeEnabled();
 
@@ -367,7 +367,7 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
 
         // waitForPage defaults to 4s which can race the edit page load under load
         editCreatedClusterPage().waitForPage('mode=edit', 'basic', LONG_TIMEOUT_OPT);
-        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
+        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
         editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
           .set(customAddonConfig);
         editCreatedClusterPage().save();
@@ -386,7 +386,7 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click({ force: true });
 
         editCreatedClusterPage().waitForPage('mode=edit', 'basic', LONG_TIMEOUT_OPT);
-        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
+        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
         editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
           .value()
           .should('include', customAddonConfig);

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -494,7 +494,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     createRKE2ClusterPage.ipv6ConfirmationDialog().find('[data-testid="ipv6-dialog-cancel"]').click();
 
     // verify that setting stack preference to 'IPv6' clears the warning
-    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('#networking');
+    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-networking"]');
     createRKE2ClusterPage.networkTab().stackPreference().toggle();
     createRKE2ClusterPage.networkTab().stackPreference().clickOptionWithLabel('IPv6');
     createRKE2ClusterPage.create();
@@ -611,7 +611,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     createRKE2ClusterPage.ipv6ConfirmationDialog().find('[data-testid="ipv6-dialog-cancel"]').click();
 
     // verify that setting stack pref to dual does not remove the stack preference warning
-    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('#networking');
+    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-networking"]');
     createRKE2ClusterPage.networkTab().stackPreference().toggle();
     createRKE2ClusterPage.networkTab().stackPreference().clickOptionWithLabel('Dual');
     createRKE2ClusterPage.create();

--- a/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
+++ b/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
@@ -40,7 +40,7 @@ describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
     });
 
     it('Clearing a registry auth item on the UI (Cluster Edit Config) should retain its authentication ID', () => {
-      editCluster.clickTab('#registry');
+      editCluster.clickTab('[data-testid="btn-registry"]');
       editCluster.registryAuthenticationItems().closeArrayListItem(0);
 
       // registries is populated in fake-cluster -> "generateProvClusterObj" -> "spec.rkeConfig.registries"

--- a/cypress/e2e/tests/pages/manager/registries.spec.ts
+++ b/cypress/e2e/tests/pages/manager/registries.spec.ts
@@ -51,7 +51,7 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     createCustomClusterPage.selectCustom(0);
 
     // navigate to Registries tab
-    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
+    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-registry"]');
     // enable registry (checkbox is on by default in Prime; only set when not Prime)
     cy.getRancherVersion().then((version) => {
       if (version.RancherPrime !== 'true') {
@@ -86,7 +86,7 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     // cluster name
     createCustomClusterPage.nameNsDescription().name().set(this.clusterName);
     // navigate to Registries tab
-    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
+    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-registry"]');
     // enable registry (checkbox is on by default in Prime; only set when not Prime)
     cy.getRancherVersion().then((version) => {
       if (version.RancherPrime !== 'true') {
@@ -156,7 +156,7 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     // cluster name
     createCustomClusterPage.nameNsDescription().name().set(this.clusterName2);
     // navigate to Registries tab
-    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
+    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-registry"]');
     // enable registry (checkbox is on by default in Prime; only set when not Prime)
     cy.getRancherVersion().then((version) => {
       if (version.RancherPrime !== 'true') {

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -164,14 +164,24 @@ export default {
 };
 </script>
 
+<!--
+  Two things worth knowing about the panel below:
+
+  - it has no aria-hidden. v-show already keeps the inactive panels out of the accessibility tree,
+    and aria-hidden on a focusable (tabindex="0") element is a violation in its own right.
+  - this note sits outside the <template> on purpose. A comment at the template root turns the
+    component into a fragment, which silently breaks attribute fallthrough for the consumers that
+    pass a class straight to <Tab> (ConfigTab, YamlTab).
+-->
 <template>
   <section
     v-show="active"
     :id="name"
     ref="tab-summarized-container"
-    :aria-hidden="!active"
+    class="tab-panel"
     role="tabpanel"
     :aria-labelledby="`tab-${name}`"
+    tabindex="0"
   >
     <div
       v-if="shouldShowHeader"
@@ -192,6 +202,11 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+.tab-panel:focus-visible {
+  @include focus-outline;
+  outline-offset: -2px;
+}
+
 .tab-header {
   display: flex;
   justify-content: space-between;

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -181,6 +181,7 @@ export default {
     class="tab-panel"
     role="tabpanel"
     :aria-labelledby="`tab-${instanceUid}-${name}`"
+    :data-testid="`tab-panel-${name}`"
     tabindex="0"
   >
     <div

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -8,7 +8,7 @@ import { useI18n } from '@shell/composables/useI18n';
 export default {
   name: 'Tab',
 
-  inject: ['addTab', 'removeTab', 'sideTabs', 'select'],
+  inject: ['addTab', 'removeTab', 'sideTabs', 'select', 'instanceUid'],
 
   emits: ['active'],
 
@@ -176,11 +176,11 @@ export default {
 <template>
   <section
     v-show="active"
-    :id="name"
+    :id="`${instanceUid}-${name}`"
     ref="tab-summarized-container"
     class="tab-panel"
     role="tabpanel"
-    :aria-labelledby="`tab-${name}`"
+    :aria-labelledby="`tab-${instanceUid}-${name}`"
     tabindex="0"
   >
     <div

--- a/shell/components/Tabbed/__tests__/index.test.ts
+++ b/shell/components/Tabbed/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { mount, VueWrapper } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 
@@ -19,12 +20,34 @@ const defaultGlobalMountOptions = {
   }
 };
 
+const OneTab = defineComponent({
+  components: { Tab },
+  template:   '<Tab name="tab1" label="Tab 1" />',
+});
+
+const TwoTabs = defineComponent({
+  components: { Tab },
+  template:   `
+    <Tab name="tab1" label="Tab 1" />
+    <Tab name="tab2" label="Tab 2" />
+  `,
+});
+
+const ThreeTabs = defineComponent({
+  components: { Tab },
+  template:   `
+    <Tab name="tab1" label="Tab 1" />
+    <Tab name="tab2" label="Tab 2" />
+    <Tab name="tab3" label="Tab 3" />
+  `,
+});
+
 describe('component: Tabbed', () => {
   const findTabNav = (wrapper: VueWrapper<any>) => wrapper.find('[data-testid="tabbed-block"]');
 
   it('should display tab navigation for a single tab when hideSingleTab is false (default)', async() => {
     const wrapper = mount(Tabbed, {
-      slots:  { default: { components: { Tab }, template: '<Tab name="tab1" label="Tab 1" />' } },
+      slots:  { default: OneTab },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -35,15 +58,7 @@ describe('component: Tabbed', () => {
 
   it('should display tab navigation for multiple tabs when hideSingleTab is false (default)', async() => {
     const wrapper = mount(Tabbed, {
-      slots: {
-        default: {
-          components: { Tab },
-          template:   `
-            <Tab name="tab1" label="Tab 1" />
-            <Tab name="tab2" label="Tab 2" />
-          `,
-        },
-      },
+      slots:  { default: TwoTabs },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -55,7 +70,7 @@ describe('component: Tabbed', () => {
   it('should NOT display tab navigation for a single tab when hideSingleTab is true', async() => {
     const wrapper = mount(Tabbed, {
       props:  { hideSingleTab: true },
-      slots:  { default: { components: { Tab }, template: '<Tab name="tab1" label="Tab 1" />' } },
+      slots:  { default: OneTab },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -66,21 +81,192 @@ describe('component: Tabbed', () => {
 
   it('should display tab navigation for multiple tabs when hideSingleTab is true', async() => {
     const wrapper = mount(Tabbed, {
-      props: { hideSingleTab: true },
-      slots: {
-        default: {
-          components: { Tab },
-          template:   `
-            <Tab name="tab1" label="Tab 1" />
-            <Tab name="tab2" label="Tab 2" />
-          `,
-        },
-      },
+      props:  { hideSingleTab: true },
+      slots:  { default: TwoTabs },
       global: { ...defaultGlobalMountOptions },
     });
 
     await wrapper.vm.$nextTick();
 
     expect(findTabNav(wrapper).exists()).toBe(true);
+  });
+});
+
+const mountTabs = async(props: Record<string, unknown> = {}, attachTo?: HTMLElement): Promise<VueWrapper<any>> => {
+  const wrapper = mount(Tabbed, {
+    props,
+    slots:  { default: ThreeTabs },
+    global: { ...defaultGlobalMountOptions },
+    attachTo,
+  });
+
+  // one tick for the tabs to register themselves, one for the resulting default selection
+  await wrapper.vm.$nextTick();
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+const tabsOf = (wrapper: VueWrapper<any>) => wrapper.findAll('[role="tab"]');
+
+const selectedIndex = (wrapper: VueWrapper<any>) => tabsOf(wrapper).findIndex((tab) => tab.attributes('aria-selected') === 'true');
+
+describe('component: Tabbed, ARIA structure', () => {
+  it('should keep the tablist out of the tab sequence and declare its orientation', async() => {
+    const wrapper = await mountTabs();
+    const tablist = wrapper.find('[role="tablist"]');
+
+    expect(tablist.attributes('tabindex')).toBeUndefined();
+    expect(tablist.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('should declare a side tablist as vertical', async() => {
+    const wrapper = await mountTabs({ sideTabs: true });
+
+    expect(wrapper.find('[role="tablist"]').attributes('aria-orientation')).toBe('vertical');
+  });
+
+  it('should not render duplicate ids', async() => {
+    const wrapper = await mountTabs();
+    const ids = wrapper.findAll('[id]').map((el) => el.attributes('id'));
+
+    expect(ids).toStrictEqual([...new Set(ids)]);
+  });
+
+  it('should point each tab at its own tab panel, and at nothing else', async() => {
+    const wrapper = await mountTabs();
+    const tabs = tabsOf(wrapper);
+
+    expect(tabs).toHaveLength(3);
+
+    tabs.forEach((tab) => {
+      const panels = wrapper.findAll(`#${ tab.attributes('aria-controls') }`);
+
+      expect(panels).toHaveLength(1);
+      expect(panels[0].attributes('role')).toBe('tabpanel');
+      expect(panels[0].attributes('aria-labelledby')).toBe(tab.attributes('id'));
+    });
+  });
+
+  it('should point every tab at an external panel when one is supplied', async() => {
+    const wrapper = await mountTabs({ externalPanelId: 'some-external-panel' });
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-controls'))).toStrictEqual([
+      'some-external-panel',
+      'some-external-panel',
+      'some-external-panel',
+    ]);
+  });
+
+  it('should strip the list semantics from the tab items so the tablist only owns tabs', async() => {
+    const wrapper = await mountTabs();
+    const items = wrapper.findAll('[data-testid="tabbed-block"] > li');
+
+    expect(items).toHaveLength(3);
+
+    items.forEach((item) => {
+      expect(item.attributes('role')).toBe('presentation');
+    });
+  });
+
+  it('should apply a roving tabindex so only the active tab is reachable with Tab', async() => {
+    const wrapper = await mountTabs();
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('tabindex'))).toStrictEqual(['0', '-1', '-1']);
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-selected'))).toStrictEqual(['true', 'false', 'false']);
+  });
+
+  it('should move the roving tabindex with the selection', async() => {
+    const wrapper = await mountTabs();
+
+    wrapper.vm.select('tab3');
+    await wrapper.vm.$nextTick();
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('tabindex'))).toStrictEqual(['-1', '-1', '0']);
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-selected'))).toStrictEqual(['false', 'false', 'true']);
+  });
+
+  it('should make every tab panel focusable and free of aria-hidden', async() => {
+    const wrapper = await mountTabs();
+    const panels = wrapper.findAll('[role="tabpanel"]');
+
+    expect(panels).toHaveLength(3);
+
+    panels.forEach((panel) => {
+      expect(panel.attributes('tabindex')).toBe('0');
+      expect(panel.attributes('aria-hidden')).toBeUndefined();
+    });
+  });
+});
+
+describe('component: Tabbed, keyboard navigation', () => {
+  it.each([
+    ['ArrowRight', 0, 1],
+    ['ArrowRight', 2, 0],
+    ['ArrowLeft', 1, 0],
+    ['ArrowLeft', 0, 2],
+    ['ArrowDown', 0, 1],
+    ['ArrowUp', 0, 2],
+    ['Home', 2, 0],
+    ['End', 0, 2],
+  ])('should move the selection with %s from index %i to index %i', async(key, from, to) => {
+    const wrapper = await mountTabs();
+
+    wrapper.vm.select(`tab${ (from as number) + 1 }`);
+    await wrapper.vm.$nextTick();
+
+    await tabsOf(wrapper)[from as number].trigger('keydown', { key });
+
+    expect(selectedIndex(wrapper)).toBe(to);
+  });
+
+  it.each([['Enter'], [' ']])('should activate the focused tab on %s', async(key) => {
+    const wrapper = await mountTabs();
+
+    await tabsOf(wrapper)[1].trigger('keydown', { key });
+
+    expect(selectedIndex(wrapper)).toBe(1);
+  });
+
+  it('should move DOM focus along with the selection, so focus is never stranded on an unreachable tab', async() => {
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    const wrapper = await mountTabs({}, container);
+
+    await tabsOf(wrapper)[0].trigger('keydown', { key: 'ArrowRight' });
+    await wrapper.vm.$nextTick();
+
+    expect(document.activeElement?.id).toBe('tab-tab2');
+
+    wrapper.unmount();
+    container.remove();
+  });
+});
+
+describe('component: Tabbed, side tab add/remove controls', () => {
+  const mountWithControls = () => mountTabs({ sideTabs: true, showTabsAddRemove: true });
+
+  it('should render the controls as a presentational list item, not as a list nested in the tablist', async() => {
+    const wrapper = await mountWithControls();
+    const footer = wrapper.find('.tab-list-footer');
+
+    expect(footer.element.tagName).toBe('LI');
+    expect(footer.attributes('role')).toBe('presentation');
+    expect(wrapper.find('[data-testid="tabbed-block"]').findAll('ul')).toHaveLength(0);
+  });
+
+  it('should emit addTab and removeTab with the index of the active tab', async() => {
+    const wrapper = await mountWithControls();
+
+    wrapper.vm.select('tab2');
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="tab-list-add"]').trigger('click');
+    await wrapper.find('[data-testid="tab-list-remove"]').trigger('click');
+
+    expect(wrapper.emitted('addTab')).toStrictEqual([[1]]);
+    expect(wrapper.emitted('removeTab')).toStrictEqual([[1]]);
   });
 });

--- a/shell/components/Tabbed/__tests__/index.test.ts
+++ b/shell/components/Tabbed/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { mount, VueWrapper } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 
@@ -19,12 +20,34 @@ const defaultGlobalMountOptions = {
   }
 };
 
+const OneTab = defineComponent({
+  components: { Tab },
+  template:   '<Tab name="tab1" label="Tab 1" />',
+});
+
+const TwoTabs = defineComponent({
+  components: { Tab },
+  template:   `
+    <Tab name="tab1" label="Tab 1" />
+    <Tab name="tab2" label="Tab 2" />
+  `,
+});
+
+const ThreeTabs = defineComponent({
+  components: { Tab },
+  template:   `
+    <Tab name="tab1" label="Tab 1" />
+    <Tab name="tab2" label="Tab 2" />
+    <Tab name="tab3" label="Tab 3" />
+  `,
+});
+
 describe('component: Tabbed', () => {
   const findTabNav = (wrapper: VueWrapper<any>) => wrapper.find('[data-testid="tabbed-block"]');
 
   it('should display tab navigation for a single tab when hideSingleTab is false (default)', async() => {
     const wrapper = mount(Tabbed, {
-      slots:  { default: { components: { Tab }, template: '<Tab name="tab1" label="Tab 1" />' } },
+      slots:  { default: OneTab },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -35,15 +58,7 @@ describe('component: Tabbed', () => {
 
   it('should display tab navigation for multiple tabs when hideSingleTab is false (default)', async() => {
     const wrapper = mount(Tabbed, {
-      slots: {
-        default: {
-          components: { Tab },
-          template:   `
-            <Tab name="tab1" label="Tab 1" />
-            <Tab name="tab2" label="Tab 2" />
-          `,
-        },
-      },
+      slots:  { default: TwoTabs },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -55,7 +70,7 @@ describe('component: Tabbed', () => {
   it('should NOT display tab navigation for a single tab when hideSingleTab is true', async() => {
     const wrapper = mount(Tabbed, {
       props:  { hideSingleTab: true },
-      slots:  { default: { components: { Tab }, template: '<Tab name="tab1" label="Tab 1" />' } },
+      slots:  { default: OneTab },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -66,16 +81,8 @@ describe('component: Tabbed', () => {
 
   it('should display tab navigation for multiple tabs when hideSingleTab is true', async() => {
     const wrapper = mount(Tabbed, {
-      props: { hideSingleTab: true },
-      slots: {
-        default: {
-          components: { Tab },
-          template:   `
-            <Tab name="tab1" label="Tab 1" />
-            <Tab name="tab2" label="Tab 2" />
-          `,
-        },
-      },
+      props:  { hideSingleTab: true },
+      slots:  { default: TwoTabs },
       global: { ...defaultGlobalMountOptions },
     });
 
@@ -157,5 +164,184 @@ describe('component: Tabbed', () => {
       expect(wrapper.find('.tab.disabled').exists()).toBe(true);
       expect(findTabNav(wrapper).element.children).toHaveLength(0);
     });
+  });
+});
+
+const mountTabs = async(props: Record<string, unknown> = {}, attachTo?: HTMLElement): Promise<VueWrapper<any>> => {
+  const wrapper = mount(Tabbed, {
+    props,
+    slots:  { default: ThreeTabs },
+    global: { ...defaultGlobalMountOptions },
+    attachTo,
+  });
+
+  // one tick for the tabs to register themselves, one for the resulting default selection
+  await wrapper.vm.$nextTick();
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+const tabsOf = (wrapper: VueWrapper<any>) => wrapper.findAll('[role="tab"]');
+
+const selectedIndex = (wrapper: VueWrapper<any>) => tabsOf(wrapper).findIndex((tab) => tab.attributes('aria-selected') === 'true');
+
+describe('component: Tabbed, ARIA structure', () => {
+  it('should keep the tablist out of the tab sequence and declare its orientation', async() => {
+    const wrapper = await mountTabs();
+    const tablist = wrapper.find('[role="tablist"]');
+
+    expect(tablist.attributes('tabindex')).toBeUndefined();
+    expect(tablist.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('should declare a side tablist as vertical', async() => {
+    const wrapper = await mountTabs({ sideTabs: true });
+
+    expect(wrapper.find('[role="tablist"]').attributes('aria-orientation')).toBe('vertical');
+  });
+
+  it('should not render duplicate ids', async() => {
+    const wrapper = await mountTabs();
+    const ids = wrapper.findAll('[id]').map((el) => el.attributes('id'));
+
+    expect(ids).toStrictEqual([...new Set(ids)]);
+  });
+
+  it('should point each tab at its own tab panel, and at nothing else', async() => {
+    const wrapper = await mountTabs();
+    const tabs = tabsOf(wrapper);
+
+    expect(tabs).toHaveLength(3);
+
+    tabs.forEach((tab) => {
+      const panels = wrapper.findAll(`#${ tab.attributes('aria-controls') }`);
+
+      expect(panels).toHaveLength(1);
+      expect(panels[0].attributes('role')).toBe('tabpanel');
+      expect(panels[0].attributes('aria-labelledby')).toBe(tab.attributes('id'));
+    });
+  });
+
+  it('should point every tab at an external panel when one is supplied', async() => {
+    const wrapper = await mountTabs({ externalPanelId: 'some-external-panel' });
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-controls'))).toStrictEqual([
+      'some-external-panel',
+      'some-external-panel',
+      'some-external-panel',
+    ]);
+  });
+
+  it('should strip the list semantics from the tab items so the tablist only owns tabs', async() => {
+    const wrapper = await mountTabs();
+    const items = wrapper.findAll('[data-testid="tabbed-block"] > li');
+
+    expect(items).toHaveLength(3);
+
+    items.forEach((item) => {
+      expect(item.attributes('role')).toBe('presentation');
+    });
+  });
+
+  it('should apply a roving tabindex so only the active tab is reachable with Tab', async() => {
+    const wrapper = await mountTabs();
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('tabindex'))).toStrictEqual(['0', '-1', '-1']);
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-selected'))).toStrictEqual(['true', 'false', 'false']);
+  });
+
+  it('should move the roving tabindex with the selection', async() => {
+    const wrapper = await mountTabs();
+
+    wrapper.vm.select('tab3');
+    await wrapper.vm.$nextTick();
+
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('tabindex'))).toStrictEqual(['-1', '-1', '0']);
+    expect(tabsOf(wrapper).map((tab) => tab.attributes('aria-selected'))).toStrictEqual(['false', 'false', 'true']);
+  });
+
+  it('should make every tab panel focusable and free of aria-hidden', async() => {
+    const wrapper = await mountTabs();
+    const panels = wrapper.findAll('[role="tabpanel"]');
+
+    expect(panels).toHaveLength(3);
+
+    panels.forEach((panel) => {
+      expect(panel.attributes('tabindex')).toBe('0');
+      expect(panel.attributes('aria-hidden')).toBeUndefined();
+    });
+  });
+});
+
+describe('component: Tabbed, keyboard navigation', () => {
+  it.each([
+    ['ArrowRight', 0, 1],
+    ['ArrowRight', 2, 0],
+    ['ArrowLeft', 1, 0],
+    ['ArrowLeft', 0, 2],
+    ['ArrowDown', 0, 1],
+    ['ArrowUp', 0, 2],
+    ['Home', 2, 0],
+    ['End', 0, 2],
+  ])('should move the selection with %s from index %i to index %i', async(key, from, to) => {
+    const wrapper = await mountTabs();
+
+    wrapper.vm.select(`tab${ (from as number) + 1 }`);
+    await wrapper.vm.$nextTick();
+
+    await tabsOf(wrapper)[from as number].trigger('keydown', { key });
+
+    expect(selectedIndex(wrapper)).toBe(to);
+  });
+
+  it.each([['Enter'], [' ']])('should activate the focused tab on %s', async(key) => {
+    const wrapper = await mountTabs();
+
+    await tabsOf(wrapper)[1].trigger('keydown', { key });
+
+    expect(selectedIndex(wrapper)).toBe(1);
+  });
+
+  it('should move DOM focus along with the selection, so focus is never stranded on an unreachable tab', async() => {
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    const wrapper = await mountTabs({}, container);
+
+    await tabsOf(wrapper)[0].trigger('keydown', { key: 'ArrowRight' });
+    await wrapper.vm.$nextTick();
+
+    expect(document.activeElement?.id).toBe('tab-tab2');
+
+    wrapper.unmount();
+    container.remove();
+  });
+});
+
+describe('component: Tabbed, side tab add/remove controls', () => {
+  const mountWithControls = () => mountTabs({ sideTabs: true, showTabsAddRemove: true });
+
+  it('should render the add/remove controls outside the tablist, not nested inside it', async() => {
+    const wrapper = await mountWithControls();
+    const footer = wrapper.find('.tab-list-footer');
+
+    expect(footer.element.tagName).toBe('DIV');
+    expect(footer.attributes('role')).toBe('presentation');
+    expect(wrapper.find('[data-testid="tabbed-block"]').find('.tab-list-footer').exists()).toBe(false);
+  });
+
+  it('should emit addTab and removeTab with the index of the active tab', async() => {
+    const wrapper = await mountWithControls();
+
+    wrapper.vm.select('tab2');
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="tab-list-add"]').trigger('click');
+    await wrapper.find('[data-testid="tab-list-remove"]').trigger('click');
+
+    expect(wrapper.emitted('addTab')).toStrictEqual([[1]]);
+    expect(wrapper.emitted('removeTab')).toStrictEqual([[1]]);
   });
 });

--- a/shell/components/Tabbed/__tests__/index.test.ts
+++ b/shell/components/Tabbed/__tests__/index.test.ts
@@ -272,6 +272,41 @@ describe('component: Tabbed, ARIA structure', () => {
       expect(panel.attributes('aria-hidden')).toBeUndefined();
     });
   });
+
+  it('should not produce duplicate ids when two Tabbed instances share the same tab names', async() => {
+    // Both instances must live in the same Vue app — useId() guarantees uniqueness within an app,
+    // matching how Tabbed instances coexist in the real single-page application.
+    const DoubleTabbedFixture = defineComponent({
+      components: { Tabbed, Tab },
+      template:   `
+        <div>
+          <Tabbed>
+            <Tab name="tab1" label="Tab 1" />
+            <Tab name="tab2" label="Tab 2" />
+          </Tabbed>
+          <Tabbed>
+            <Tab name="tab1" label="Tab 1" />
+            <Tab name="tab2" label="Tab 2" />
+          </Tabbed>
+        </div>
+      `,
+    });
+
+    const wrapper = mount(DoubleTabbedFixture, {
+      global: {
+        ...defaultGlobalMountOptions,
+        components: { ...defaultGlobalMountOptions.components, Tabbed },
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const ids = wrapper.findAll('[id]').map((el) => el.attributes('id') as string);
+
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toStrictEqual([...new Set(ids)]);
+  });
 });
 
 describe('component: Tabbed, keyboard navigation', () => {
@@ -313,7 +348,9 @@ describe('component: Tabbed, keyboard navigation', () => {
     await tabsOf(wrapper)[0].trigger('keydown', { key: 'ArrowRight' });
     await wrapper.vm.$nextTick();
 
-    expect(document.activeElement?.id).toBe('tab-tab2');
+    const expectedId = wrapper.vm.tabButtonId('tab2');
+
+    expect(document.activeElement?.id).toBe(expectedId);
 
     wrapper.unmount();
     container.remove();

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -106,6 +106,19 @@ export default {
     title: {
       type:    String,
       default: null,
+    },
+
+    /**
+     * id of a tab panel that lives OUTSIDE of this component.
+     *
+     * Normally each Tab renders its own `role="tabpanel"` and the tab's `aria-controls` points at it.
+     * Some consumers (e.g. `tabsOnly` usages) render the tab content themselves, elsewhere in the page.
+     * In that case pass the id of that container here so the tabs stay programmatically associated
+     * with the content they actually control.
+     */
+    externalPanelId: {
+      type:    String,
+      default: null,
     }
   },
 
@@ -288,18 +301,15 @@ export default {
 
     selectNext(direction) {
       const { sortedTabs } = this;
+
+      if (!sortedTabs.length) {
+        return;
+      }
+
       const currentIdx = sortedTabs.findIndex((x) => x.active);
       const nextIdx = getCyclicalIdx(currentIdx, direction, sortedTabs.length);
-      const nextName = sortedTabs[nextIdx].name;
 
-      this.select(nextName);
-
-      this.$nextTick(() => {
-        this.$refs.tablist.removeAttribute('tabindex');
-        if (this.tabRefs[nextName]) {
-          this.tabRefs[nextName].focus();
-        }
-      });
+      this.selectAndFocus(sortedTabs[nextIdx].name);
 
       function getCyclicalIdx(currentIdx, direction, tabsLength) {
         const nxt = currentIdx + direction;
@@ -312,6 +322,35 @@ export default {
           return nxt;
         }
       }
+    },
+
+    /**
+     * Home/End keyboard support, as per the ARIA authoring practices for tabs
+     */
+    selectEdge(edge) {
+      const { sortedTabs } = this;
+
+      if (!sortedTabs.length) {
+        return;
+      }
+
+      const tab = edge === 'first' ? sortedTabs[0] : sortedTabs[sortedTabs.length - 1];
+
+      this.selectAndFocus(tab.name);
+    },
+
+    /**
+     * Move both selection and keyboard focus to a tab.
+     *
+     * Focus has to follow selection because the tabs use a roving tabindex - only the active tab is
+     * reachable with `tabindex="0"`, so leaving focus behind would strand it on an unreachable element.
+     */
+    selectAndFocus(name) {
+      this.select(name);
+
+      this.$nextTick(() => {
+        this.tabRefs[name]?.focus();
+      });
     },
 
     tabAddClicked() {
@@ -347,31 +386,35 @@ export default {
       class="tabs"
       :class="{'clearfix':!sideTabs, 'vertical': sideTabs, 'horizontal': !sideTabs, 'remove-borders': removeBorders}"
       :data-testid="`${componentTestid}-block`"
-      tabindex="0"
-      @keydown.right.prevent="selectNext(1)"
-      @keydown.left.prevent="selectNext(-1)"
-      @keydown.down.prevent="selectNext(1)"
-      @keydown.up.prevent="selectNext(-1)"
+      :aria-orientation="sideTabs ? 'vertical' : 'horizontal'"
     >
       <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
       <li
         v-for="tab in sortedTabs"
-        :id="tab.name"
         :key="tab.name"
         :data-testid="tab.name"
+        role="presentation"
         :class="{tab: true, active: tab.active, disabled: tab.disabled, error: (tab.error)}"
       >
         <a
           :id="`tab-${tab.name}`"
           :ref="(el) => { if (el) tabRefs[tab.name] = el; }"
           :data-testid="`btn-${tab.name}`"
-          :aria-controls="tab.name"
-          :aria-selected="tab.active"
+          :aria-controls="externalPanelId || tab.name"
+          :aria-selected="!!tab.active"
+          :aria-disabled="tab.disabled ? 'true' : undefined"
           :aria-label="tab.labelDisplay || ''"
           role="tab"
           :tabindex="tab.active ? '0' : '-1'"
           @click.prevent="select(tab.name, $event)"
-          @keyup.enter.space="select(tab.name, $event)"
+          @keydown.enter.prevent="select(tab.name, $event)"
+          @keydown.space.prevent="select(tab.name, $event)"
+          @keydown.right.prevent="selectNext(1)"
+          @keydown.left.prevent="selectNext(-1)"
+          @keydown.down.prevent="selectNext(1)"
+          @keydown.up.prevent="selectNext(-1)"
+          @keydown.home.prevent="selectEdge('first')"
+          @keydown.end.prevent="selectEdge('last')"
         >
           <i
             v-if="tab.labelIcon"
@@ -394,17 +437,20 @@ export default {
       <li
         v-if="sideTabs && !sortedTabs.length"
         class="tab disabled"
+        role="presentation"
       >
         <a
           href="#"
           @click.prevent
         >(None)</a>
       </li>
-      <ul
+      <!-- A tablist may only own tabs, so the add/remove controls go in a presentational item -->
+      <li
         v-if="sideTabs && showTabsAddRemove"
         class="tab-list-footer"
+        role="presentation"
       >
-        <li>
+        <div class="tab-list-footer-controls">
           <button
             type="button"
             class="btn bg-transparent"
@@ -424,8 +470,8 @@ export default {
           >
             <i class="icon icon-minus" />
           </button>
-        </li>
-      </ul>
+        </div>
+      </li>
       <slot name="tab-row-extras" />
     </ul>
     <div
@@ -473,15 +519,6 @@ export default {
   margin: 0;
   padding: 0;
 
-  &:focus-visible {
-    outline: none;
-
-    .tab.active {
-      @include focus-outline;
-      outline-offset: -2px;
-    }
-  }
-
   &.horizontal {
     border: solid thin var(--border);
     border-bottom: 0;
@@ -508,10 +545,6 @@ export default {
     }
   }
 
-  &:focus .tab.active a span {
-    text-decoration: underline;
-  }
-
   .tab {
     position: relative;
     float: left;
@@ -525,6 +558,17 @@ export default {
 
       &:hover {
         text-decoration: none;
+        span {
+          text-decoration: underline;
+        }
+      }
+
+      // The tab itself is the focusable element now (roving tabindex), so the focus ring lives here
+      // rather than on the tablist.
+      &:focus-visible {
+        @include focus-outline;
+        outline-offset: -2px;
+
         span {
           text-decoration: underline;
         }
@@ -658,7 +702,7 @@ export default {
       margin-top: auto;
       z-index: z-index('default');
 
-      li {
+      .tab-list-footer-controls {
         display: flex;
         flex: 1;
 

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -106,6 +106,19 @@ export default {
     title: {
       type:    String,
       default: null,
+    },
+
+    /**
+     * id of a tab panel that lives OUTSIDE of this component.
+     *
+     * Normally each Tab renders its own `role="tabpanel"` and the tab's `aria-controls` points at it.
+     * Some consumers (e.g. `tabsOnly` usages) render the tab content themselves, elsewhere in the page.
+     * In that case pass the id of that container here so the tabs stay programmatically associated
+     * with the content they actually control.
+     */
+    externalPanelId: {
+      type:    String,
+      default: null,
     }
   },
 
@@ -288,18 +301,15 @@ export default {
 
     selectNext(direction) {
       const { sortedTabs } = this;
+
+      if (!sortedTabs.length) {
+        return;
+      }
+
       const currentIdx = sortedTabs.findIndex((x) => x.active);
       const nextIdx = getCyclicalIdx(currentIdx, direction, sortedTabs.length);
-      const nextName = sortedTabs[nextIdx].name;
 
-      this.select(nextName);
-
-      this.$nextTick(() => {
-        this.$refs.tablist.removeAttribute('tabindex');
-        if (this.tabRefs[nextName]) {
-          this.tabRefs[nextName].focus();
-        }
-      });
+      this.selectAndFocus(sortedTabs[nextIdx].name);
 
       function getCyclicalIdx(currentIdx, direction, tabsLength) {
         const nxt = currentIdx + direction;
@@ -312,6 +322,35 @@ export default {
           return nxt;
         }
       }
+    },
+
+    /**
+     * Home/End keyboard support, as per the ARIA authoring practices for tabs
+     */
+    selectEdge(edge) {
+      const { sortedTabs } = this;
+
+      if (!sortedTabs.length) {
+        return;
+      }
+
+      const tab = edge === 'first' ? sortedTabs[0] : sortedTabs[sortedTabs.length - 1];
+
+      this.selectAndFocus(tab.name);
+    },
+
+    /**
+     * Move both selection and keyboard focus to a tab.
+     *
+     * Focus has to follow selection because the tabs use a roving tabindex - only the active tab is
+     * reachable with `tabindex="0"`, so leaving focus behind would strand it on an unreachable element.
+     */
+    selectAndFocus(name) {
+      this.select(name);
+
+      this.$nextTick(() => {
+        this.tabRefs[name]?.focus();
+      });
     },
 
     tabAddClicked() {
@@ -350,16 +389,11 @@ export default {
         role="tablist"
         class="tab-list"
         :data-testid="`${componentTestid}-block`"
-        tabindex="0"
-        @keydown.right.prevent="selectNext(1)"
-        @keydown.left.prevent="selectNext(-1)"
-        @keydown.down.prevent="selectNext(1)"
-        @keydown.up.prevent="selectNext(-1)"
+        :aria-orientation="sideTabs ? 'vertical' : 'horizontal'"
       >
         <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
         <li
           v-for="tab in sortedTabs"
-          :id="tab.name"
           :key="tab.name"
           :data-testid="tab.name"
           role="presentation"
@@ -369,13 +403,21 @@ export default {
             :id="`tab-${tab.name}`"
             :ref="(el) => { if (el) tabRefs[tab.name] = el; }"
             :data-testid="`btn-${tab.name}`"
-            :aria-controls="tab.name"
-            :aria-selected="tab.active"
+            :aria-controls="externalPanelId || tab.name"
+            :aria-selected="!!tab.active"
+            :aria-disabled="tab.disabled ? 'true' : undefined"
             :aria-label="tab.labelDisplay || ''"
             role="tab"
             :tabindex="tab.active ? '0' : '-1'"
             @click.prevent="select(tab.name, $event)"
-            @keyup.enter.space="select(tab.name, $event)"
+            @keydown.enter.prevent="select(tab.name, $event)"
+            @keydown.space.prevent="select(tab.name, $event)"
+            @keydown.right.prevent="selectNext(1)"
+            @keydown.left.prevent="selectNext(-1)"
+            @keydown.down.prevent="selectNext(1)"
+            @keydown.up.prevent="selectNext(-1)"
+            @keydown.home.prevent="selectEdge('first')"
+            @keydown.end.prevent="selectEdge('last')"
           >
             <i
               v-if="tab.labelIcon"
@@ -399,17 +441,20 @@ export default {
       <div
         v-if="sideTabs && !sortedTabs.length"
         class="tab disabled"
+        role="presentation"
       >
         <a
           href="#"
           @click.prevent
         >(None)</a>
       </div>
-      <ul
+      <!-- A tablist may only own tabs, so the add/remove controls go outside the ul -->
+      <div
         v-if="sideTabs && showTabsAddRemove"
         class="tab-list-footer"
+        role="presentation"
       >
-        <li>
+        <div class="tab-list-footer-controls">
           <button
             type="button"
             class="btn bg-transparent"
@@ -429,8 +474,8 @@ export default {
           >
             <i class="icon icon-minus" />
           </button>
-        </li>
-      </ul>
+        </div>
+      </div>
       <slot name="tab-row-extras" />
     </div>
     <div
@@ -480,19 +525,6 @@ export default {
     padding: 0;
     display: flex;
     flex-direction: inherit;
-
-    &:focus-visible {
-      outline: none;
-
-      .tab.active {
-        @include focus-outline;
-        outline-offset: -2px;
-      }
-    }
-
-    &:focus .tab.active a span {
-      text-decoration: underline;
-    }
   }
 
   &.horizontal {
@@ -534,6 +566,17 @@ export default {
 
       &:hover {
         text-decoration: none;
+        span {
+          text-decoration: underline;
+        }
+      }
+
+      // The tab itself is the focusable element now (roving tabindex), so the focus ring lives here
+      // rather than on the tablist.
+      &:focus-visible {
+        @include focus-outline;
+        outline-offset: -2px;
+
         span {
           text-decoration: underline;
         }
@@ -667,7 +710,7 @@ export default {
       margin: auto 0 0;
       z-index: z-index('default');
 
-      li {
+      .tab-list-footer-controls {
         display: flex;
         flex: 1;
 

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -7,7 +7,7 @@ import findIndex from 'lodash/findIndex';
 import { ExtensionPoint, TabLocation } from '@shell/core/types';
 import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import Tab from '@shell/components/Tabbed/Tab';
-import { computed, ref, useTemplateRef } from 'vue';
+import { computed, ref, useId, useTemplateRef } from 'vue';
 import { useIsInResourceDetailDrawer } from '@shell/components/Drawer/ResourceDetailDrawer/composables';
 import { useIsInResourceDetailPage } from '@shell/composables/resourceDetail';
 import { useIsInResourceCreatePage, useIsInResourceEditPage } from '@shell/composables/cruResource';
@@ -126,9 +126,9 @@ export default {
     const tabs = this.tabs;
 
     return {
-      select: this.select,
-
-      sideTabs: this.sideTabs,
+      select:      this.select,
+      sideTabs:    this.sideTabs,
+      instanceUid: this.instanceUid,
 
       addTab(tab) {
         const existing = findBy(tabs, 'name', tab.name);
@@ -184,6 +184,7 @@ export default {
   },
 
   setup(props) {
+    const instanceUid = useId();
     const isInResourceDetailDrawer = ref(useIsInResourceDetailDrawer());
     const isInResourceDetailPage = ref(useIsInResourceDetailPage());
     const isInResourceEditPage = ref(useIsInResourceEditPage());
@@ -196,7 +197,7 @@ export default {
     });
 
     return {
-      isInResourceDetailDrawer, isInResourceDetailPage, isInResourceEditPage, isInResourceCreatePage, summary
+      instanceUid, isInResourceDetailDrawer, isInResourceDetailPage, isInResourceEditPage, isInResourceCreatePage, summary
     };
   },
 
@@ -233,6 +234,10 @@ export default {
   },
 
   methods: {
+    tabButtonId(name) {
+      return `tab-${ this.instanceUid }-${ name }`;
+    },
+
     getInitialTabLocation() {
       if (this.isInResourceEditPage) {
         return TabLocation.RESOURCE_EDIT_PAGE;
@@ -295,7 +300,11 @@ export default {
         tab.active = (tab.name === selected.name);
       }
 
-      this.$emit('changed', { tab: selected, selectedName: selected.name });
+      this.$emit('changed', {
+        tab:          selected,
+        selectedName: selected.name,
+        tabButtonId:  this.tabButtonId(selected.name)
+      });
       this.activeTabName = selected.name;
     },
 
@@ -400,10 +409,10 @@ export default {
           :class="{tab: true, active: tab.active, disabled: tab.disabled, error: (tab.error)}"
         >
           <a
-            :id="`tab-${tab.name}`"
+            :id="tabButtonId(tab.name)"
             :ref="(el) => { if (el) tabRefs[tab.name] = el; }"
             :data-testid="`btn-${tab.name}`"
-            :aria-controls="externalPanelId || tab.name"
+            :aria-controls="externalPanelId || `${instanceUid}-${tab.name}`"
             :aria-selected="!!tab.active"
             :aria-disabled="tab.disabled ? 'true' : undefined"
             :aria-label="tab.labelDisplay || ''"

--- a/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
+++ b/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
@@ -2,19 +2,20 @@
 
 exports[`view: fleet.cattle.io.bundle should render resources when bundle deployments exist 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
-  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" tabindex="0">
+  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" aria-orientation="horizontal">
     <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
-    <li id="resources" data-testid="resources" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
+    <li data-testid="resources" role="presentation" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
         <!--v-if--><span>Resources</span>
         <!--v-if-->
         <!--v-if-->
       </a></li>
     <!--v-if-->
+    <!-- A tablist may only own tabs, so the add/remove controls go in a presentational item -->
     <!--v-if-->
   </ul>
   <div class="tab-container">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" aria-hidden="false" role="tabpanel" aria-labelledby="tab-resources" style="">
+    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="">
       <!--v-if-->
       <resource-table-stub rows="[object Object],[object Object]" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>
@@ -30,14 +31,15 @@ exports[`view: fleet.cattle.io.bundle should render the bundle detail page 1`] =
 
 exports[`view: fleet.cattle.io.bundle should render the bundle detail page with full mount 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
-  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" tabindex="0">
+  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" aria-orientation="horizontal">
     <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
     <!--v-if-->
+    <!-- A tablist may only own tabs, so the add/remove controls go in a presentational item -->
     <!--v-if-->
   </ul>
   <div class="">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" aria-hidden="true" role="tabpanel" aria-labelledby="tab-resources" style="display: none;">
+    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="display: none;">
       <!--v-if-->
       <resource-table-stub rows="" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>

--- a/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
+++ b/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
@@ -3,20 +3,21 @@
 exports[`view: fleet.cattle.io.bundle should render resources when bundle deployments exist 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
   <div class="tabs clearfix horizontal">
-    <ul role="tablist" class="tab-list" data-testid="tabbed-block" tabindex="0">
+    <ul role="tablist" class="tab-list" data-testid="tabbed-block" aria-orientation="horizontal">
       <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
-      <li id="resources" data-testid="resources" role="presentation" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
+      <li data-testid="resources" role="presentation" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
           <!--v-if--><span>Resources</span>
           <!--v-if-->
           <!--v-if-->
         </a></li>
     </ul>
     <!--v-if-->
+    <!-- A tablist may only own tabs, so the add/remove controls go outside the ul -->
     <!--v-if-->
   </div>
   <div class="tab-container">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" aria-hidden="false" role="tabpanel" aria-labelledby="tab-resources" style="">
+    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="">
       <!--v-if-->
       <resource-table-stub rows="[object Object],[object Object]" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>
@@ -33,15 +34,16 @@ exports[`view: fleet.cattle.io.bundle should render the bundle detail page 1`] =
 exports[`view: fleet.cattle.io.bundle should render the bundle detail page with full mount 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
   <div class="tabs clearfix horizontal">
-    <ul role="tablist" class="tab-list" data-testid="tabbed-block" tabindex="0">
+    <ul role="tablist" class="tab-list" data-testid="tabbed-block" aria-orientation="horizontal">
       <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
     </ul>
     <!--v-if-->
+    <!-- A tablist may only own tabs, so the add/remove controls go outside the ul -->
     <!--v-if-->
   </div>
   <div class="">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" aria-hidden="true" role="tabpanel" aria-labelledby="tab-resources" style="display: none;">
+    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="display: none;">
       <!--v-if-->
       <resource-table-stub rows="" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>

--- a/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
+++ b/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
@@ -5,7 +5,7 @@ exports[`view: fleet.cattle.io.bundle should render resources when bundle deploy
   <div class="tabs clearfix horizontal">
     <ul role="tablist" class="tab-list" data-testid="tabbed-block" aria-orientation="horizontal">
       <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
-      <li data-testid="resources" role="presentation" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
+      <li data-testid="resources" role="presentation" class="tab active"><a id="tab-v-0-resources" data-testid="btn-resources" aria-controls="v-0-resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
           <!--v-if--><span>Resources</span>
           <!--v-if-->
           <!--v-if-->
@@ -17,7 +17,7 @@ exports[`view: fleet.cattle.io.bundle should render resources when bundle deploy
   </div>
   <div class="tab-container">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="">
+    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" tabindex="0" style="">
       <!--v-if-->
       <resource-table-stub rows="[object Object],[object Object]" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>
@@ -43,7 +43,7 @@ exports[`view: fleet.cattle.io.bundle should render the bundle detail page with 
   </div>
   <div class="">
     <!-- This is where "normal" tab content goes... -->
-    <section id="resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-resources" tabindex="0" style="display: none;">
+    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" tabindex="0" style="display: none;">
       <!--v-if-->
       <resource-table-stub rows="" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>

--- a/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
+++ b/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
@@ -17,7 +17,7 @@ exports[`view: fleet.cattle.io.bundle should render resources when bundle deploy
   </div>
   <div class="tab-container">
     <!-- This is where "normal" tab content goes... -->
-    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" tabindex="0" style="">
+    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" data-testid="tab-panel-resources" tabindex="0" style="">
       <!--v-if-->
       <resource-table-stub rows="[object Object],[object Object]" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>
@@ -43,7 +43,7 @@ exports[`view: fleet.cattle.io.bundle should render the bundle detail page with 
   </div>
   <div class="">
     <!-- This is where "normal" tab content goes... -->
-    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" tabindex="0" style="display: none;">
+    <section id="v-0-resources" class="tab-panel" role="tabpanel" aria-labelledby="tab-v-0-resources" data-testid="tab-panel-resources" tabindex="0" style="display: none;">
       <!--v-if-->
       <resource-table-stub rows="" loading="false" altloading="false" keyfield="tableKey" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" search="true" tableactions="false" paginglabel="sortableTable.paging.resource" rowactions="false" groupoptions="[object Object],[object Object]" groupdefault="namespace" grouptooltip="resourceTable.groupBy.namespace" overflowx="false" overflowy="false" ignorefilter="false" hasadvancedfiltering="false" advfilterhidelabelsascols="false" advfilterpreventfilteringlabels="false" usequeryparamsforsimplefiltering="false" forceupdateliveanddelayed="0" externalpaginationenabled="false" default-sort-by="state"></resource-table-stub>
     </section>

--- a/shell/detail/helm.cattle.io.projecthelmchart.vue
+++ b/shell/detail/helm.cattle.io.projecthelmchart.vue
@@ -143,7 +143,11 @@ export default {
         />
       </Tab>
       <template #tab-row-extras>
-        <div class="tab-row-footer">
+        <!-- This slot renders inside the tablist <ul>, so it has to be an <li> and must not claim a role -->
+        <li
+          class="tab-row-footer"
+          role="presentation"
+        >
           <div
             class="resources-dropdown"
             :class="{disabled: !prometheusServiceEndpointEnabled}"
@@ -203,7 +207,7 @@ export default {
             :href="value.status.dashboardValues.alertmanagerURL"
             target="_blank"
           > {{ t('monitoring.overview.linkedList.alertManager.label') }} <i class="icon icon-external-link" /></a>
-        </div>
+        </li>
       </template>
     </Tabbed>
     <div v-else>

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -666,7 +666,11 @@ export default {
           </Tabbed>
         </Tab>
         <template #tab-row-extras>
-          <li class="tablist-controls">
+          <!-- This slot renders inside the tablist <ul>, so it must not claim a role of its own -->
+          <li
+            class="tablist-controls"
+            role="presentation"
+          >
             <button
               v-if="!isView"
               type="button"

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1424,4 +1424,40 @@ describe('page: UI plugins/Extensions', () => {
       expect(all[1]).toHaveProperty('helmError', true);
     });
   });
+
+  describe('tab panel', () => {
+    // The tabs render in `tabs-only` mode, so the card grid is the panel they control and has to be
+    // associated with them explicitly rather than just sitting next to them.
+    const mountLoaded = async() => {
+      const w = mountComponent();
+
+      await w.setData({ loading: false, activeTab: 'available' });
+
+      return w;
+    };
+
+    it('should expose the extension card grid as the tab panel', async() => {
+      const w = await mountLoaded();
+      const panel = w.find('.plugin-cards');
+
+      expect(panel.attributes('id')).toBe('extensions-tab-panel');
+      expect(panel.attributes('role')).toBe('tabpanel');
+      expect(panel.attributes('tabindex')).toBe('0');
+      expect(panel.attributes('aria-labelledby')).toBe('tab-available');
+    });
+
+    it('should tell the tabs which external panel they control', async() => {
+      const w = await mountLoaded();
+
+      expect(w.findComponent({ name: 'Tabbed' }).props('externalPanelId')).toBe('extensions-tab-panel');
+    });
+
+    it('should not label the panel before a tab has been selected', async() => {
+      const w = mountComponent();
+
+      await w.setData({ loading: false, activeTab: '' });
+
+      expect(w.find('.plugin-cards').attributes('aria-labelledby')).toBeUndefined();
+    });
+  });
 });

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1431,7 +1431,13 @@ describe('page: UI plugins/Extensions', () => {
     const mountLoaded = async() => {
       const w = mountComponent();
 
-      await w.setData({ loading: false, activeTab: 'available' });
+      // activeTabButtonId is normally set by Tabbed's @changed event; simulate it directly here
+      // since shallowMount stubs Tabbed and won't fire the real event.
+      await w.setData({
+        loading:           false,
+        activeTab:         'available',
+        activeTabButtonId: 'tab-v-0-available'
+      });
 
       return w;
     };
@@ -1443,7 +1449,7 @@ describe('page: UI plugins/Extensions', () => {
       expect(panel.attributes('id')).toBe('extensions-tab-panel');
       expect(panel.attributes('role')).toBe('tabpanel');
       expect(panel.attributes('tabindex')).toBe('0');
-      expect(panel.attributes('aria-labelledby')).toBe('tab-available');
+      expect(panel.attributes('aria-labelledby')).toBe('tab-v-0-available');
     });
 
     it('should tell the tabs which external panel they control', async() => {
@@ -1455,7 +1461,11 @@ describe('page: UI plugins/Extensions', () => {
     it('should not label the panel before a tab has been selected', async() => {
       const w = mountComponent();
 
-      await w.setData({ loading: false, activeTab: '' });
+      await w.setData({
+        loading:           false,
+        activeTab:         '',
+        activeTabButtonId: undefined
+      });
 
       expect(w.find('.plugin-cards').attributes('aria-labelledby')).toBeUndefined();
     });

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -45,6 +45,10 @@ const TABS_VALUES = {
   BUILTIN:   'builtin',
 };
 
+// id of the container holding the extension cards - the tabs render in `tabs-only` mode, so this is
+// the tab panel they control
+const EXTENSIONS_PANEL_ID = 'extensions-tab-panel';
+
 export default {
   components: {
     ActionMenu,
@@ -63,6 +67,7 @@ export default {
   data() {
     return {
       TABS_VALUES,
+      EXTENSIONS_PANEL_ID,
       kubeVersion:                    null,
       activeTab:                      '',
       installing:                     {},
@@ -1140,6 +1145,7 @@ export default {
         v-if="!loading"
         ref="tabs"
         :tabs-only="true"
+        :external-panel-id="EXTENSIONS_PANEL_ID"
         data-testid="extension-tabs"
         @changed="tabChanged"
       >
@@ -1174,10 +1180,18 @@ export default {
           :raw="true"
         />
       </div>
+      <!--
+        The tabs above are `tabs-only`, so this is the panel they control. It has to be associated
+        with them explicitly, otherwise the tab structure isn't programmatically complete.
+      -->
       <div
         v-else
+        :id="EXTENSIONS_PANEL_ID"
         class="plugin-cards"
         :class="{'v-margin': !list.length}"
+        role="tabpanel"
+        :aria-labelledby="activeTab ? `tab-${activeTab}` : undefined"
+        tabindex="0"
       >
         <IconMessage
           v-if="list.length === 0"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -70,6 +70,7 @@ export default {
       EXTENSIONS_PANEL_ID,
       kubeVersion:                    null,
       activeTab:                      '',
+      activeTabButtonId:              undefined,
       installing:                     {},
       installedFromRepo:              {},
       errors:                         {},
@@ -457,6 +458,7 @@ export default {
 
     tabChanged(f) {
       this.activeTab = f.selectedName;
+      this.activeTabButtonId = f.tabButtonId;
     },
 
     // Developer Load is in the action menu
@@ -1190,7 +1192,7 @@ export default {
         class="plugin-cards"
         :class="{'v-margin': !list.length}"
         role="tabpanel"
-        :aria-labelledby="activeTab ? `tab-${activeTab}` : undefined"
+        :aria-labelledby="activeTabButtonId || undefined"
         tabindex="0"
       >
         <IconMessage


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18839

The tabs on the Extensions page were only half-way to being a real ARIA tab structure. The tab buttons announced themselves as tabs, but the content they pointed at was not marked up as a tab panel, and the `aria-controls` on each tab did not actually resolve to that content. Screen readers therefore could not tell a user which panel a tab owns, or move them into it.

The fix is in the shared `Tabbed` / `Tab` components, so it lands everywhere tabs are used, not just on the Extensions page.

### Occurred changes and/or fixed issues
- Each tab now points at a real `role="tabpanel"` with a matching `id`, and the panel points back at its tab with `aria-labelledby`
- Fixed the underlying bug that made `aria-controls` useless: the tab `<li>` and the tab panel were both rendering with the same `id`, so `aria-controls` resolved to the list item instead of the content
- Tab IDs are now unique per `Tabbed` instance, so two components with the same tab names (e.g. two containers on the Workload edit page, both having a "General" tab) no longer produce duplicate `id` attributes in the DOM. Each tab's `aria-controls` now correctly resolves to its own panel, not a sibling instance's
- Tab panels are now reachable with the keyboard (`tabindex="0"`), so a user can tab straight from the selected tab into its content
- Every tab now reports `aria-selected` (`true` or `false`) instead of only the selected one
- The tab list itself is no longer a tab stop; the tabs are, using a roving tabindex — only the selected tab is in the tab sequence, the rest are reached with the arrow keys
- Added `Home` / `End` support, and `aria-orientation` so assistive tech knows whether the tab list is horizontal or vertical
- Removed `aria-hidden` from tab panels — it was being applied to a focusable element, which is a violation in its own right, and `v-show` already hides inactive panels from assistive tech
- The Extensions page renders its tab content outside of the `Tabbed` component, so a new `external-panel-id` prop lets a page tell the tabs which container they actually control
- The side-tab add/remove footer and the `tab-row-extras` slot are now rendered as siblings of the `<ul role="tablist">`, not inside it. A `<ul role="tablist">` may only own `role="tab"` children — having other elements inside it was causing a critical `aria-required-children` axe violation on Workload create and the Network Policy side-tab footer

### Technical notes summary
`Tabbed` renders the tab strip and `Tab` renders one panel. The two were each using the tab's name as an element `id`, which meant duplicate ids on the page and an `aria-controls` that pointed at the wrong thing. `Tab` now uses a uid-prefixed id (via Vue 3.5's `useId()`) that it shares with the tab button through `provide`/`inject`, keeping the two in sync while staying unique across multiple `Tabbed` instances on the same page.

Keyboard handling moved off the `<ul>` and onto the individual tab buttons, which is what lets each tab carry its own tabindex. Arrow keys still move between tabs, `Home`/`End` jump to the ends, and focus follows the selection automatically.

One case did not fit the shared component: the Extensions page uses `Tabbed` in `tabs-only` mode and renders the cards itself, so the tabs genuinely controlled nothing. Rather than special-casing it, a page can now hand `Tabbed` the id of the container it owns via `external-panel-id`. The `@changed` event now also carries `tabButtonId` so consumers that render an external panel can build the correct `aria-labelledby` without duplicating the ID formula.

No visual changes were intended. The one style adjustment is that the focus ring is drawn on the tab button itself rather than on the tab list, since the tab is now the focusable element.

### Areas or cases that should be tested
Tested locally in Chrome — **the reviewer should use a different browser**, ideally Firefox + NVDA since that is the combination the audit failed on.

**The reported issue**
- Extensions page (`Extensions` from the top-left menu): tab through to the "Installed / Available / Updates / All" tabs, move between them with the arrow keys, and confirm the extension cards below are announced as a tab panel belonging to the selected tab
- Continue tabbing past the tab strip and confirm focus lands in the cards area

**Tabs in general** — the change is in the shared component, so a spot check of a few different tab flavours is worth it:
- Horizontal tabs on a detail page, e.g. any cluster detail page (`Conditions`, `Related`, `Events`)
- Nested tabs, e.g. `Workloads` → edit a Deployment → the `Pod` tab and the per-container tabs inside it. This is the key case for the duplicate-ID fix — two containers both have a "General" tab, and their panels must now be independent
- Side (vertical) tabs with add/remove, e.g. RKE2 cluster create → machine pools, or EKS node groups — check the `+` / `-` buttons still work and still sit below the tab list
- The resource detail drawer (`Config` / `YAML` tabs)
- Project Helm Chart detail page, which injects the Prometheus / Grafana / Alertmanager links into the tab row

**Keyboard**
- `Tab` should enter the tab strip once, landing on the selected tab, and leave it on the next press
- `Left` / `Right` / `Up` / `Down` move between tabs and wrap around at the ends
- `Home` / `End` jump to the first / last tab
- `Enter` / `Space` activate the focused tab
- The focus ring should be visible on the tab, in both light and dark mode

### Areas which could experience regressions
- **Anything using tabs**, which is around 77 files. The shared markup changed, so this is the main risk area
- **Tab styling**, specifically the focus ring, which moved from the tab list to the tab button, and the side-tab add/remove footer, which moved from inside the `<ul>` to a sibling `<div>` outside it
- **Deep links to a tab** (`.../some-resource#storage`). The URL hash still selects the right tab via the router; the change is that the `#storage` fragment no longer resolves to a panel element by that exact id (the panel id is now uid-prefixed), so browser native scroll-to-fragment on load won't apply — but tab selection itself is unaffected
- **E2E selectors.** Several specs were selecting tabs by that now-removed `<li>` id (`li#pod`, `#registry`, `#networking`, `#rke2-calico`, `#DaemonSet`, ...). They have all been moved to the `[data-testid="btn-<name>"]` selector the rest of the suite already uses
- **Attribute fallthrough on `Tab`.** `ConfigTab` and `YamlTab` pass a class straight to `<Tab>`; this is covered by their existing tests

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
