### PR TITLE
Drop `@jest/globals` imports from shell tests

### DIFF
--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 1100
+# Total errors: 1037
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
 pkg/aks/components/Config.vue: error TS2532: Object is possibly 'undefined'.
@@ -113,69 +113,8 @@ pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@she
 pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 pkg/rancher-prime/pages/registration.composable.ts: error TS2339: Property 'message' does not exist on type '{}'.
 scripts/__tests__/cypress.test.ts: error TS2307: Cannot find module '@/scripts/cypress' or its corresponding type declarations.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2339: Property 'linkFor' does not exist on type '{}'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2339: Property 'linkFor' does not exist on type '{}'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '(type: string, id: string) => any' is not assignable to parameter of type 'UnknownFunction'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'never[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'never[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ cleanForSave: Mock<any>; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ cleanForSave: Mock<any>; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ data: { metadata: { name: string; }; }[]; pagination: { page: number; pageSize: number; total: number; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ data: { metadata: { name: string; }; }[]; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; labels: { app: string; }; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; labels: { app: string; }; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; namespace: string; }; spec: { data: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; namespace: string; }; spec: { replicas: number; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; namespace: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; data: { key: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; status: { conditions: never[]; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ metadata: { resourceVersion: string; name: string; namespace: string; }; type: string; data: { key: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2345: Argument of type '{ type: string; metadata: { name: string; namespace: string; }; }' is not assignable to parameter of type 'never'.
 shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2352: Conversion of type 'ActionFindPageTransientResponse<ResourceInstance<Record<string, any>>>' to type 'any[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2352: Conversion of type 'ActionFindPageTransientResponse<ResourceInstance<Record<string, any>>>' to type 'any[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2558: Expected 0-1 type arguments, but got 2.
-shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2558: Expected 0-1 type arguments, but got 2.
-shell/apis/shell/__tests__/notifications.test.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type 'never[]' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ data: never[]; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ data: string[]; paging: { next: null; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ data: string[]; paging: { next: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ items: string[]; links: { pages: { next: null; }; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ items: string[]; links: { pages: { next: string; }; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ items: string[]; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ items: string[]; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ items: string[]; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ metadata: { name: string; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ save: Mock<UnknownFunction>; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ save: Mock<UnknownFunction>; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ spec: { routes: never[]; }; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ spec: { routes: { domain: string; }[]; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ spec: { routes: { domain: string; }[]; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ spec: { routes: { domain: string; }[]; }; }[]' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ spec: {}; }[]' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ status: number; message: string; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{ status: number; }' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{}' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/proxy.test.ts: error TS2345: Argument of type '{}' is not assignable to parameter of type 'never'.
-shell/apis/shell/__tests__/slide-in.test.ts: error TS2554: Expected 1 arguments, but got 0.
 shell/apis/shell/__tests__/system.test.ts: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/apis/shell/__tests__/system.test.ts: error TS2724: '"@shell/config/version"' has no exported member named 'getKubeVersionData'. Did you mean 'getVersionData'?
 shell/apis/shell/index.ts: error TS2459: Module '"@shell/apis/intf/shell"' declares 'ProxyApi' locally, but it is not exported.
@@ -905,8 +844,6 @@ shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'podsByN
 shell/plugins/steve/__tests__/mutations.test.ts: error TS2339: Property 'podsByNamespace' does not exist on type '{ types: { pod: any; }; ctx?: undefined; type?: undefined; data?: undefined; } | { ctx: { rootGetters: { 'type-map/optionsFor': (type: string) => {}; }; getters: { classify: (resource: any) => typeof Resource; cleanResource: (existing: Resource, resource: any) => any; keyFieldForType: () => string; }; }; type: strin...'.
 shell/plugins/steve/__tests__/mutations.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/plugins/steve/__tests__/resource-utils.test.ts: error TS2554: Expected 1-2 arguments, but got 0.
-shell/plugins/steve/__tests__/steve-class-resource-api.test.ts: error TS2558: Expected 0-1 type arguments, but got 2.
-shell/plugins/steve/__tests__/steve-class-resource-api.test.ts: error TS2578: Unused '@ts-expect-error' directive.
 shell/plugins/steve/__tests__/steve-pagination-utils.test.ts: error TS2341: Property 'convertPaginationParams' is private and only accessible within class 'StevePaginationUtils'.
 shell/plugins/steve/__tests__/steve-pagination-utils.test.ts: error TS2445: Property 'combineNsProjectFilterResults' is protected and only accessible within class 'NamespaceProjectFilters' and its subclasses.
 shell/plugins/steve/__tests__/steve-pagination-utils.test.ts: error TS2445: Property 'createFiltersFromNamespaceProjectFilterResult' is protected and only accessible within class 'NamespaceProjectFilters' and its subclasses.

--- a/shell/apis/resources/__tests__/resources-api-class.test.ts
+++ b/shell/apis/resources/__tests__/resources-api-class.test.ts
@@ -1,6 +1,3 @@
-import {
-  describe, it, expect, jest, beforeEach, afterEach
-} from '@jest/globals';
 import { ResourcesApiClassImpl } from '../resources-api-class';
 import { Store } from 'vuex';
 
@@ -11,15 +8,15 @@ describe.each(['cluster', 'management'] as const)('resourcesApiClassImpl with st
   let mockSchemaFor: jest.Mock;
   let mockPaginationEnabled: jest.Mock;
   let mockUrlFor: jest.Mock;
-  let consoleErrorSpy: any;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    mockDispatch = jest.fn() as any;
-    mockSchemaFor = jest.fn() as any;
-    mockPaginationEnabled = jest.fn() as any;
-    mockUrlFor = jest.fn() as any;
+    mockDispatch = jest.fn();
+    mockSchemaFor = jest.fn();
+    mockPaginationEnabled = jest.fn();
+    mockUrlFor = jest.fn();
     mockUrlFor.mockImplementation((type: string, id: string) => {
       const schema = mockSchemaFor(type);
 
@@ -697,7 +694,7 @@ describe.each(['cluster', 'management'] as const)('resourcesApiClassImpl with st
         data:     { key: 'value' },
       };
       const cleanedData = { ...inputData };
-      const mockModel = { cleanForSave: jest.fn<any, any[]>().mockReturnValue(cleanedData) };
+      const mockModel = { cleanForSave: jest.fn().mockReturnValue(cleanedData) };
       const mockResponse = { ...inputData, metadata: { ...inputData.metadata, resourceVersion: '2' } };
 
       mockSchemaFor.mockReturnValue({
@@ -738,7 +735,7 @@ describe.each(['cluster', 'management'] as const)('resourcesApiClassImpl with st
 
     it('should throw error and log when request fails', async() => {
       // Arrange
-      const mockModel = { cleanForSave: jest.fn<any, any[]>().mockReturnValue({}) };
+      const mockModel = { cleanForSave: jest.fn().mockReturnValue({}) };
 
       mockSchemaFor.mockReturnValue({
         attributes: { namespaced: false },

--- a/shell/apis/shell/__tests__/modal.test.ts
+++ b/shell/apis/shell/__tests__/modal.test.ts
@@ -1,8 +1,5 @@
 // modal.test.ts
 
-import {
-  describe, it, expect, jest, beforeEach
-} from '@jest/globals';
 import { ModalApiImpl } from '../modal'; // Adjust path as needed
 import { Store } from 'vuex';
 
@@ -16,7 +13,7 @@ describe('modalApiImpl', () => {
 
   beforeEach(() => {
     // 1. Arrange: Create a mock commit function
-    mockCommit = jest.fn() as any;
+    mockCommit = jest.fn();
 
     // Create a mock store object
     mockStore = { commit: mockCommit } as any;

--- a/shell/apis/shell/__tests__/notifications.test.ts
+++ b/shell/apis/shell/__tests__/notifications.test.ts
@@ -1,8 +1,5 @@
 // notifications.test.ts
 
-import {
-  describe, it, expect, jest, beforeEach
-} from '@jest/globals';
 import { NotificationApiImpl } from '../notifications';
 import { Store } from 'vuex';
 import { NotificationLevel } from '@shell/types/notifications'; // Assuming this path
@@ -14,7 +11,7 @@ describe('notificationApiImpl', () => {
 
   beforeEach(() => {
     // 1. Arrange
-    mockDispatch = jest.fn() as any;
+    mockDispatch = jest.fn();
     mockStore = { dispatch: mockDispatch } as any;
 
     // 2. Arrange

--- a/shell/apis/shell/__tests__/proxy.test.ts
+++ b/shell/apis/shell/__tests__/proxy.test.ts
@@ -1,8 +1,5 @@
 // proxy.test.ts
 
-import {
-  describe, it, expect, jest, beforeEach
-} from '@jest/globals';
 import { ProxyApiImpl, createDepaginator } from '../proxy';
 import { Store } from 'vuex';
 
@@ -14,7 +11,7 @@ describe('proxyApiImpl', () => {
   let proxyApi: ProxyApiImpl;
 
   beforeEach(() => {
-    mockDispatch = jest.fn() as any;
+    mockDispatch = jest.fn();
     mockStore = { dispatch: mockDispatch } as any;
     proxyApi = new ProxyApiImpl(mockStore);
   });

--- a/shell/apis/shell/__tests__/slide-in.test.ts
+++ b/shell/apis/shell/__tests__/slide-in.test.ts
@@ -1,8 +1,5 @@
 // slide-in.test.ts
 
-import {
-  describe, it, expect, jest, beforeEach
-} from '@jest/globals';
 import { SlideInApiImpl } from '../slide-in'; // Adjust path as needed
 import { Store } from 'vuex';
 
@@ -16,7 +13,7 @@ describe('slideInApiImpl', () => {
 
   beforeEach(() => {
     // 1. Arrange
-    mockCommit = jest.fn() as any;
+    mockCommit = jest.fn();
     mockStore = { commit: mockCommit } as any;
 
     // 2. Arrange

--- a/shell/apis/shell/__tests__/system.test.ts
+++ b/shell/apis/shell/__tests__/system.test.ts
@@ -1,8 +1,5 @@
 // system.test.ts
 
-import {
-  describe, it, expect, jest, beforeEach
-} from '@jest/globals';
 import { SystemApiImpl } from '../system';
 import { Store } from 'vuex';
 
@@ -48,7 +45,7 @@ describe('systemApiImpl', () => {
     mockIsPrerelease.mockClear();
 
     // Arrange: Mock the store
-    mockGetter = jest.fn() as any;
+    mockGetter = jest.fn();
     mockStore = {
       getters: { 'management/byId': mockGetter },
       $config: { dashboardVersion: 'v2.9-test' }

--- a/shell/plugins/steve/__tests__/steve-class-resource-api.test.ts
+++ b/shell/plugins/steve/__tests__/steve-class-resource-api.test.ts
@@ -1,10 +1,7 @@
-import {
-  describe, it, expect, jest, beforeEach, afterEach
-} from '@jest/globals';
 import Steve from '@shell/plugins/steve/steve-class.js';
 
 describe('class: Steve — ResourceInstanceApi methods', () => {
-  let consoleErrorSpy: any;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -15,11 +12,10 @@ describe('class: Steve — ResourceInstanceApi methods', () => {
   });
 
   function createSteveModel(overrides: Record<string, any> = {}) {
-    const dispatch = jest.fn<any, any[]>();
+    const dispatch = jest.fn();
 
     dispatch.mockResolvedValue(undefined);
 
-    // @ts-expect-error - JS class without TS declarations
     const model = new Steve({
       type:     'configmap',
       id:       'default/my-config',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves type-check errors related to importing `describe`/`it`/`expect`/`jest`/`beforeEach` from `@jest/globals` by deleting the import statements and the associated workarounds. 

Fixes #18590
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Drop `@jest/globals` imports from shell tests and fix type errors
- Update the baseline

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The import was referencing stricter typings from `jest-mock`. Deleting the import restores the jest globals. With this change, `describe`, `it`, `expect`, `jest` and `beforeEach` are all in scope.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI should pass all gates.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Any regressions associated with this change should be raised by test failures in CI.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
