### PR TITLE
Add Region field to the logging S3 output form

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4452,7 +4452,10 @@ logging:
   s3:
     keyId: Key Id from Secret
     secretKey: Secret Key from Secret
+    region: Region
+    regionTooltip: The AWS region of the bucket, such as us-east-1. Set this for AWS S3 targets, and alongside Endpoint for S3-compatible services. Pick from the list, or type a region that is not listed.
     endpoint: Endpoint
+    endpointTooltip: For S3-compatible services such as MinIO, and for AWS VPC, FIPS or GovCloud endpoints. For any other AWS S3 target, leave this empty and set Region instead, otherwise fluentd rejects the configuration.
     bucket: Bucket
     path: Path
     overwriteExistingPath: Overwrite Existing Path

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4453,9 +4453,7 @@ logging:
     keyId: Key Id from Secret
     secretKey: Secret Key from Secret
     region: Region
-    regionTooltip: The AWS region of the bucket, such as us-east-1. Set this for AWS S3 targets, and alongside Endpoint for S3-compatible services. Pick from the list, or type a region that is not listed.
     endpoint: Endpoint
-    endpointTooltip: For S3-compatible services such as MinIO, and for AWS VPC, FIPS or GovCloud endpoints. For any other AWS S3 target, leave this empty and set Region instead, otherwise fluentd rejects the configuration.
     bucket: Bucket
     path: Path
     overwriteExistingPath: Overwrite Existing Path

--- a/shell/edit/logging.banzaicloud.io.output/providers/__tests__/s3.test.ts
+++ b/shell/edit/logging.banzaicloud.io.output/providers/__tests__/s3.test.ts
@@ -1,0 +1,69 @@
+import { shallowMount, VueWrapper } from '@vue/test-utils';
+import fetchMixin from '@shell/mixins/fetch.client.js';
+import S3 from '@shell/edit/logging.banzaicloud.io.output/providers/s3.vue';
+
+const REGIONS = ['us-east-1', 'eu-west-1'];
+
+// The app registers this mixin globally in shell/initialize/entry.js, it is what runs fetch()
+const mountS3 = (value: Record<string, string>) => shallowMount(S3, {
+  props: {
+    mode: 'edit', namespace: 'whatever', value
+  },
+  global: {
+    mixins: [fetchMixin],
+    mocks:  {
+      $store: {
+        dispatch: (action: string) => {
+          if (action !== 'aws/defaultRegions') {
+            throw new Error(`unexpected dispatch: ${ action }`);
+          }
+
+          return Promise.resolve([...REGIONS]);
+        }
+      }
+    }
+  }
+});
+
+describe('component: S3', () => {
+  it('should display a region select showing the configured s3_region', () => {
+    const value = { s3_region: 'us-east-1' };
+    const wrapper = mountS3(value);
+
+    const region = wrapper.find('[data-testid="s3-region"]');
+
+    expect(region.exists()).toBe(true);
+    expect(region.attributes('value')).toBe(value.s3_region);
+  });
+
+  it('should write the region select back to s3_region', async() => {
+    const value = {};
+    const wrapper = mountS3(value);
+
+    const region = wrapper.findComponent('[data-testid="s3-region"]') as VueWrapper<any, any>;
+
+    await region.vm.$emit('update:value', 'eu-west-1');
+
+    expect(value).toStrictEqual({ s3_region: 'eu-west-1' });
+  });
+
+  it('should populate the region select with the known AWS regions', async() => {
+    const wrapper = mountS3({});
+
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.findComponent('[data-testid="s3-region"]') as VueWrapper<any, any>;
+
+    expect(region.props('options')).toStrictEqual(REGIONS);
+  });
+
+  it('should keep an existing region that is not a known AWS region as an option', async() => {
+    const wrapper = mountS3({ s3_region: 'minio-local' });
+
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.findComponent('[data-testid="s3-region"]') as VueWrapper<any, any>;
+
+    expect(region.props('options')).toStrictEqual(['minio-local', ...REGIONS]);
+  });
+});

--- a/shell/edit/logging.banzaicloud.io.output/providers/s3.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/s3.vue
@@ -1,11 +1,12 @@
 <script>
 import { Checkbox } from '@components/Form/Checkbox';
 import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
 import SecretSelector from '@shell/components/form/SecretSelector';
 
 export default {
   components: {
-    Checkbox, LabeledInput, SecretSelector
+    Checkbox, LabeledInput, LabeledSelect, SecretSelector
   },
   props: {
     value: {
@@ -27,6 +28,20 @@ export default {
       required: true
     }
   },
+
+  async fetch() {
+    const regions = await this.$store.dispatch('aws/defaultRegions');
+    const current = this.value.s3_region;
+
+    // An Output can point at an S3-compatible service with a region that AWS
+    // does not know about, so keep it as an option instead of showing nothing.
+    this.knownRegions = current && !regions.includes(current) ? [current, ...regions] : regions;
+  },
+
+  data() {
+    return { knownRegions: [] };
+  },
+
   computed: {
     overwrite: {
       get() {
@@ -49,13 +64,29 @@ export default {
     </div>
     <div class="row mb-10">
       <div class="col span-6">
+        <LabeledSelect
+          v-model:value="value.s3_region"
+          :mode="mode"
+          :disabled="disabled"
+          :options="knownRegions"
+          :taggable="true"
+          :searchable="true"
+          :tooltip="t('logging.s3.regionTooltip')"
+          data-testid="s3-region"
+          :label="t('logging.s3.region')"
+        />
+      </div>
+      <div class="col span-6">
         <LabeledInput
           v-model:value="value.s3_endpoint"
           :mode="mode"
           :disabled="disabled"
+          :tooltip="t('logging.s3.endpointTooltip')"
           :label="t('logging.s3.endpoint')"
         />
       </div>
+    </div>
+    <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput
           v-model:value="value.s3_bucket"
@@ -64,8 +95,6 @@ export default {
           :label="t('logging.s3.bucket')"
         />
       </div>
-    </div>
-    <div class="row">
       <div class="col span-6">
         <LabeledInput
           v-model:value="value.path"
@@ -74,7 +103,9 @@ export default {
           :label="t('logging.s3.path')"
         />
       </div>
-      <div class="col span-6 overwrite">
+    </div>
+    <div class="row">
+      <div class="col span-6 offset-6">
         <Checkbox
           v-model:value="overwrite"
           :mode="mode"
@@ -113,10 +144,3 @@ export default {
     </div>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.overwrite {
-    display: flex;
-    align-items: center;
-}
-</style>

--- a/shell/edit/logging.banzaicloud.io.output/providers/s3.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/s3.vue
@@ -71,7 +71,6 @@ export default {
           :options="knownRegions"
           :taggable="true"
           :searchable="true"
-          :tooltip="t('logging.s3.regionTooltip')"
           data-testid="s3-region"
           :label="t('logging.s3.region')"
         />
@@ -81,7 +80,6 @@ export default {
           v-model:value="value.s3_endpoint"
           :mode="mode"
           :disabled="disabled"
-          :tooltip="t('logging.s3.endpointTooltip')"
           :label="t('logging.s3.endpoint')"
         />
       </div>


### PR DESCRIPTION
### Summary
Fixes #18324

### Occurred changes and/or fixed issues

- The `s3` form now exposes `s3_region`, the field the issue reports missing.
- It is a select fed by `aws/defaultRegions`, the list the dashboard already ships, and stays `taggable` for MinIO and Ceph.
- Target regrouped to Region | Endpoint, then Bucket | Path, matching `cloudwatch.vue`.
- Overwrite Existing Path moved under Path, and the now-dead `.overwrite` flex rule went with it.

### Technical notes summary

- fluent-plugin-s3 defaults `s3_region` to `us-east-1` ([L100](https://github.com/fluent/fluent-plugin-s3/blob/f215613ad8947945f74ba39af868aa6af80c9cbe/lib/fluent/plugin/out_s3.rb#L100)), so other regions silently went wrong.
- I skipped endpoint validation. [`reject_s3_endpoint?`](https://github.com/fluent/fluent-plugin-s3/blob/f215613ad8947945f74ba39af868aa6af80c9cbe/lib/fluent/plugin/out_s3.rb#L193-L206) allows `vpce`, `fips` and `gov`, so the obvious guard breaks GovCloud.
- `aws/defaultRegions` returns one shared array, so the `unshift` in `cloud-credential/s3.vue` leaks regions between forms. Ours spreads.

### Areas or cases that should be tested

The form needs the logging CRDs:

```bash
helm repo add rancher-charts https://charts.rancher.io && helm repo update
helm install rancher-logging-crd rancher-charts/rancher-logging-crd \
  --version 109.0.0+up4.10.0-rancher.23 -n cattle-logging-system --create-namespace
```

Then Cluster > Logging > Outputs > Create, and pick `S3`.

- Pick a Region, open Edit as YAML, and check it lands at `spec.s3.s3_region`.
- Type a region the list lacks, say `minio-local`, then save and reopen to confirm it survives.
- Apply the fixture below, open it, and confirm Region is empty with the endpoint intact.
- Repeat on ClusterOutput, and check both themes and view mode.

<details>
<summary>Fixture: an Output in the broken state the issue describes</summary>

```yaml
apiVersion: logging.banzaicloud.io/v1beta1
kind: Output
metadata:
  name: s3-legacy-endpoint
  namespace: default
spec:
  s3:
    path: logs/
    s3_bucket: my-logs
    s3_endpoint: s3.us-east-1.amazonaws.com
```
</details>

A correct result is a new Output saving as `spec.s3` with only `s3_bucket` and `s3_region`, no `s3_endpoint`.

```bash
npx jest --ci shell/edit/logging.banzaicloud.io.output
```

### Areas which could experience regressions

- Output and ClusterOutput create, edit and view for `s3`.
- The other 20 provider forms share `index.vue` but not `s3.vue`.
- `gcs.vue`, the only other user of the `.overwrite` class.

### Screenshot/Video

**Before.** The Target section offers Endpoint, Bucket and Path, and nowhere to set a region.

https://github.com/user-attachments/assets/25bbf723-3bb7-4b53-8fff-8b67c4d02deb

**After.** The same walk, with Region beside Endpoint and the shipped region list.

https://github.com/user-attachments/assets/b82f87ac-389b-4f7e-b1b9-bc0e5bed935e

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
