### PR TITLE
Automation: Ignore third party 'No visitor ID available' exception in e2e test

### DIFF
--- a/cypress/support/utils/exception-utils.ts
+++ b/cypress/support/utils/exception-utils.ts
@@ -3,7 +3,8 @@ export const RANCHER_PAGE_EXCEPTIONS = [
   'TenantFeatures',
   'DomainData',
   'ResizeObserver loop',
-  'cross origin page'
+  'cross origin page',
+  'No visitor ID available'
 ];
 
 /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2515

Fix `can click on Rancher Prime link` test by adding `No visitor ID available` to `RANCHER_PAGE_EXCEPTIONS` so the test's existing `catchTargetPageException` call ignores it. No test changes.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
