### PR TITLE
Fix scroll bars show on preview panel

### DIFF
--- a/shell/components/Resource/Detail/Preview/Preview.vue
+++ b/shell/components/Resource/Detail/Preview/Preview.vue
@@ -116,7 +116,8 @@ useBasicSetupFocusTrap('#focus-trap-preview-container-element');
   .content {
     flex: 1;
 
-    overflow: scroll;
+    overflow: auto;
+    padding: 1px 0;
   }
 
   .copy-to-clipboard {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16154

Note: This is only reproducible on Chrome on Linux.

### Occurred changes and/or fixed issues

Simple fix to change `scroll` to `auto` so that the scroll bars only appear when needed.

Had to also add `1px` of vertical padding to give a single line of text space to not need to scroll.

### Screenshot/Video

After:

<img width="499" height="184" alt="image" src="https://github.com/user-attachments/assets/a46f66cb-ee0b-461a-b886-58f7855c8bca" />

After, with long text to show scroll bar does appear correctly:

<img width="582" height="631" alt="image" src="https://github.com/user-attachments/assets/e971ab12-d3a7-44e7-b770-95262cd05e89" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
