### PR TITLE
Fix alignment on banner text when left aligned

### DIFF
--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -98,7 +98,13 @@ export default {
     &.banner-text-left {
       .title {
         justify-content: left;
-        padding-left: 20px;
+        padding-left: 5%;
+      }
+
+      @media only screen and (max-width: map-get($breakpoints, '--viewport-9')) {
+        .title {
+          padding-left: 20px;
+        }
       }
     }
   }


### PR DESCRIPTION
### Summary
Fixes #15943

The left-aligned welcome text on the home page banner (used by the SUSE brand) sat far to the left of the "Clusters" heading on wide-screen resolutions (e.g. 3840×2160), because the banner used a fixed `padding-left: 20px` while the underlying `IndentedPanel` uses `margin-left: 5%`.

### Occurred changes and/or fixed issues
- `BannerGraphic` now aligns its left-aligned title with the content indentation used by `IndentedPanel` on the home page, so the welcome text lines up with the "Clusters" heading (and other page content) on wide screens.

### Technical notes summary
- In `shell/components/BannerGraphic.vue`, the `.banner-text-left .title` rule now uses `padding-left: 5%` to match `IndentedPanel`'s `margin-left: 5%` on wide screens.
- A `max-width: --viewport-9` (992px) media query restores the original `padding-left: 20px` on smaller screens, mirroring the breakpoint `IndentedPanel` uses to switch to a `20px` gutter.
- `banner-text-center` is unchanged. Only the SUSE brand configures `textAlign: "left"`, so the change is scoped to the affected case.

### Areas or cases that should be tested
- Home page banner ("Welcome to Rancher Prime") using the SUSE brand at various widths — verify the welcome text left-aligns with the "Clusters" heading below it.
  - Wide displays (e.g. 3840×2160, 2560×1440, 1920×1080).
  - Around the 992px breakpoint (just above and just below).
  - Narrow widths (< 992px) — welcome text should sit 20px from the left, matching the `IndentedPanel` gutter.
- Verify the centered banner variant (non-SUSE brands) is unaffected.
- Tested locally in Chrome; reviewer should verify in a different browser.

### Areas which could experience regressions
- Any brand/theme stylesheet that overrides `.banner-graphic-area .title` padding.
- Home page banner rendering when the branding is set to SUSE vs other brands.

### Screenshot/Video

#### Wide screen: (padding is 5%)

<img width="1140" height="390" alt="image" src="https://github.com/user-attachments/assets/9a58c761-9cac-4018-abea-8608758ab42d" />

#### Narrow screen: (padding is 20px)

<img width="688" height="392" alt="image" src="https://github.com/user-attachments/assets/9a191226-1b7c-4053-ba1c-a80a64234b38" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
