### PR TITLE
Fixed changing region may lead to AKS cluster being provisioned with unsupported k8s version

### DIFF
--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -133,12 +133,22 @@ export default defineComponent({
       touchedVmSize:         false,
       touchedVirtualNetwork: false,
 
+      // false until the first successful versions fetch completes - used to tell an initial load (where an
+      // already-set but not-yet-valid version, eg on edit, should be left alone) apart from a later refetch
+      // (triggered by a credential or region change) where a now-invalid version should be reconciled
+      hasFetchedVersionsBefore: false,
+
       loadingVersions:        false,
       loadingVmSizes:         false,
       loadingVirtualNetworks: false,
-      setAuthorizedIPRanges:  false,
-      networkingAuthMode:     NETWORKING_AUTH_MODES.SERVICE_PRINCIPAL,
-      fvFormRuleSets:         [
+
+      // guard against out-of-order responses when a credential or region change triggers overlapping requests
+      versionsRequestId:        0,
+      vmSizesRequestId:         0,
+      virtualNetworksRequestId: 0,
+      setAuthorizedIPRanges:    false,
+      networkingAuthMode:       NETWORKING_AUTH_MODES.SERVICE_PRINCIPAL,
+      fvFormRuleSets:           [
 
         {
           path:  'resourceGroup',
@@ -686,7 +696,12 @@ export default defineComponent({
     'config.azureCredentialSecret'(neu) {
       if (neu) {
         this.resetCredentialDependentProperties();
-        // this.getLocations();
+
+        if (this.config.resourceLocation) {
+          this.getAksVersions();
+          this.getVmSizes();
+          this.getVirtualNetworks();
+        }
       }
     },
 
@@ -751,9 +766,8 @@ export default defineComponent({
   },
 
   methods: {
-    // reset properties dependent on AKS queries so if they're lodaded with a valid credential then an invalid credential is selected, they're cleared
+    // reset properties dependent on AKS queries so if they're loaded with a valid credential then an invalid credential is selected, they're cleared
     resetCredentialDependentProperties(): void {
-    //   this.locationOptions = [];
       this.allAksVersions = [];
       this.vmSizeOptions = [];
       this.allVirtualNetworks = [];
@@ -764,6 +778,8 @@ export default defineComponent({
     },
 
     async getAksVersions(): Promise<void> {
+      const requestId = ++this.versionsRequestId;
+
       this.loadingVersions = true;
       this.allAksVersions = [];
       const { azureCredentialSecret, resourceLocation } = this.config;
@@ -771,10 +787,26 @@ export default defineComponent({
       try {
         const res = await getAKSKubernetesVersions(this.$store, azureCredentialSecret, resourceLocation, this.clusterId);
 
+        if (requestId !== this.versionsRequestId) {
+          return;
+        }
+
+        const isRefetch = this.hasFetchedVersionsBefore;
+
         // the default version is set once these are filtered and sorted in computed prop
         this.allAksVersions = res;
         this.loadingVersions = false;
+        this.hasFetchedVersionsBefore = true;
+
+        if (isRefetch && !this.touchedVersion && !this.aksVersionOptions.find((v) => v.value === this.config.kubernetesVersion)) {
+          const firstValid = this.aksVersionOptions.find((v) => !v.disabled);
+
+          this.config.kubernetesVersion = firstValid?.value;
+        }
       } catch (err:any) {
+        if (requestId !== this.versionsRequestId) {
+          return;
+        }
         this.loadingVersions = false;
 
         const parsedError = parseAzureError(err.error || '');
@@ -785,12 +817,18 @@ export default defineComponent({
     },
 
     async getVmSizes(): Promise<void> {
+      const requestId = ++this.vmSizesRequestId;
+
       this.loadingVmSizes = true;
       this.vmSizeOptions = [];
       const { azureCredentialSecret, resourceLocation } = this.config;
 
       try {
         const res = await getAKSVMSizes(this.$store, azureCredentialSecret, resourceLocation, this.clusterId);
+
+        if (requestId !== this.vmSizesRequestId) {
+          return;
+        }
 
         if (isArray(res)) {
           this.vmSizeOptions = res.sort();
@@ -802,6 +840,9 @@ export default defineComponent({
 
         this.loadingVmSizes = false;
       } catch (err: any) {
+        if (requestId !== this.vmSizesRequestId) {
+          return;
+        }
         this.loadingVmSizes = false;
 
         const parsedError = parseAzureError(err.error || '');
@@ -812,6 +853,8 @@ export default defineComponent({
     },
 
     async getVirtualNetworks(): Promise<void> {
+      const requestId = ++this.virtualNetworksRequestId;
+
       this.loadingVirtualNetworks = true;
       this.allVirtualNetworks = [];
       const { azureCredentialSecret, resourceLocation } = this.config;
@@ -819,12 +862,17 @@ export default defineComponent({
       try {
         const res = await getAKSVirtualNetworks(this.$store, azureCredentialSecret, resourceLocation, this.clusterId);
 
-        if (res && isArray(res)) {
-          this.allVirtualNetworks.push(...res);
+        if (requestId !== this.virtualNetworksRequestId) {
+          return;
         }
+
+        this.allVirtualNetworks = (res && isArray(res)) ? res : [];
 
         this.loadingVirtualNetworks = false;
       } catch (err:any) {
+        if (requestId !== this.virtualNetworksRequestId) {
+          return;
+        }
         const parsedError = parseAzureError(err.error || '');
         const errors = this.errors as Array<string>;
 

--- a/pkg/aks/components/__tests__/Config.test.ts
+++ b/pkg/aks/components/__tests__/Config.test.ts
@@ -4,6 +4,7 @@ import { shallowMount, VueWrapper } from '@vue/test-utils';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import * as aksUtil from '@pkg/aks/util/aks';
 // eslint-disable-next-line jest/no-mocks-import
 import { mockVersionsSorted } from '@pkg/aks/util/__mocks__/aks';
 import { AKSConfig, AKSNodePool } from '@pkg/aks/types';
@@ -531,5 +532,92 @@ describe('aks provisioning form', () => {
     const virtualNetworkSelect = wrapper.findComponent<typeof LabeledSelect>('[data-testid="aks-virtual-network-select"]');
 
     expect(virtualNetworkSelect.props().required).toBe(true);
+  });
+
+  describe('kubernetes version and region changes', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should update the selected kubernetes version to a new default when the region changes and the previous selection is no longer available and the user has not touched it', async() => {
+      const wrapper = shallowMount(Config, {
+        props: {
+          config: DEFAULT_CLUSTER_CONFIG, value: {}, mode: _CREATE
+        },
+        ...requiredSetup()
+      });
+
+      await setCredential(wrapper);
+      expect(wrapper.vm.config.kubernetesVersion).toBe('1.27.0');
+
+      jest.spyOn(aksUtil, 'getAKSKubernetesVersions').mockResolvedValueOnce(['1.20.0']);
+
+      wrapper.setProps({ config: { ...wrapper.vm.config, resourceLocation: 'westus' } });
+      await flushPromises();
+
+      expect(wrapper.vm.config.kubernetesVersion).toBe('1.20.0');
+    });
+
+    it('should leave the selected kubernetes version untouched and show a validation error when the region changes and the user-selected version is no longer available', async() => {
+      const wrapper = shallowMount(Config, {
+        props: {
+          config: DEFAULT_CLUSTER_CONFIG, value: {}, mode: _CREATE
+        },
+        ...requiredSetup()
+      });
+
+      await setCredential(wrapper);
+
+      // simulate the user manually selecting a version, which marks the field as touched
+      wrapper.setProps({ config: { ...wrapper.vm.config, kubernetesVersion: '1.26.5' } });
+      await flushPromises();
+      expect(wrapper.vm.touchedVersion).toBe(true);
+
+      jest.spyOn(aksUtil, 'getAKSKubernetesVersions').mockResolvedValueOnce(['1.20.0']);
+
+      wrapper.setProps({ config: { ...wrapper.vm.config, resourceLocation: 'westus' } });
+      await flushPromises();
+
+      expect(wrapper.vm.config.kubernetesVersion).toBe('1.26.5');
+      expect(wrapper.vm.fvExtraRules.k8sVersionAvailable()).toBe('aks.kubernetesVersion.notAvailableInRegion');
+    });
+
+    it('should refetch AKS versions when the credential changes even if the region stays the same', async() => {
+      const getVersionsSpy = jest.spyOn(aksUtil, 'getAKSKubernetesVersions');
+      const wrapper = shallowMount(Config, {
+        props: {
+          config: DEFAULT_CLUSTER_CONFIG, value: {}, mode: _CREATE
+        },
+        ...requiredSetup()
+      });
+
+      await setCredential(wrapper);
+      const callsAfterInitialLoad = getVersionsSpy.mock.calls.length;
+
+      wrapper.setProps({ config: { ...wrapper.vm.config, azureCredentialSecret: 'a-different-credential' } });
+      await flushPromises();
+
+      expect(getVersionsSpy.mock.calls.length).toBeGreaterThan(callsAfterInitialLoad);
+    });
+
+    it('should update the selected kubernetes version to a new default when the credential changes (region unchanged) and the previous selection is no longer available and the user has not touched it', async() => {
+      const config = { ...DEFAULT_CLUSTER_CONFIG };
+      const wrapper = shallowMount(Config, {
+        props: {
+          config, value: {}, mode: _EDIT
+        },
+        ...requiredSetup()
+      });
+
+      await setCredential(wrapper, config);
+      expect(wrapper.vm.config.kubernetesVersion).toBe('1.27.0');
+
+      jest.spyOn(aksUtil, 'getAKSKubernetesVersions').mockResolvedValueOnce(['1.20.0']);
+
+      wrapper.setProps({ config: { ...wrapper.vm.config, azureCredentialSecret: 'a-different-credential' } });
+      await flushPromises();
+
+      expect(wrapper.vm.config.kubernetesVersion).toBe('1.20.0');
+    });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16921 #18915
<!-- Define findings related to the feature or bug issue. -->
Fixed k8s version not being updated when the region's supported version list changes.
Added a guard against multiple resets due to concurrent requests

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- switching the Azure credential now refreshes the versions/VM sizes/virtual networks lists. 
- New behavior — when the version list is refetched (after a region or credential change) and the currently selected kubernetesVersion is no longer offered: if the user hasn't touched the field, it's auto-updated to the new default; if they had manually picked it, it's left as-is and the existing k8sVersionAvailable validator now correctly flags it. 
- Race-condition guard — added request-id tracking to getAksVersions/getVmSizes/getVirtualNetworks so overlapping requests (e.g. credential and region changing together) can't apply a stale response; also fixes a duplicate-entries bug in getVirtualNetworks (concurrent calls could append results twice).

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Covered by the unit tests:
1. Region changes, version untouched, current selection no longer offered → auto-updates to new default. (Can use India South Central for manual check)
2. Region changes, version touched (user manually selected), current selection no longer offered → version left as-is, k8sVersionAvailable returns the "not available in region" error.
3. Credential changes, region unchanged → versions are refetched at all (root bug — previously not refetched).
4. Credential changes, region unchanged, version untouched, current selection no longer offered → auto-updates to new default.

Needs manual validation:
1. Credential changes, region unchanged, version touched, selection no longer offered → should leave it and surface the validation error.
2. Region changes, but the previously selected version is still valid in the new list, untouched → version must stay as-is, not jump to some other "first" default.
3. Rapid double region change (switch before the first fetch resolves) → only the latest region's data wins; no duplicate/mixed entries in versions, VM sizes, and virtual networks.
4. Credential changes while resourceLocation is still unset (early in CREATE flow) → must not double-fetch or throw once the default region later gets assigned.
5. Refetch resolves to an empty version list (no versions available for that credential/region) → dropdown empties out without crashing; no infinite validation loop. - I don't think we have access to a region like that but maybe QA does?
6. Node pool orchestratorVersion sync: when the version is auto-corrected (not user-selected) after a region/credential change, unprovisioned pools should still pick up the new version.

### Areas which could experience regressions
Editing AKS cluster, especially an older unsupported one could experience regressions, but we do not have a way to verify it. 
I also haven't been able to test the edit behavior when the version is not available due to a cloud credential

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/067ddeae-43b5-4837-a82c-6968cf5a114e

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
