### PR TITLE
Ensure proxying errors close the stream and UI detects this error

### DIFF
--- a/shell/config/router/navigation-guards/authentication.js
+++ b/shell/config/router/navigation-guards/authentication.js
@@ -101,11 +101,15 @@ export async function authenticate(to, from, next, { store }) {
         } else {
           if ( status === 401 ) {
             notLoggedIn(store, next, to);
+          } else if (status == 504) {
+            store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
+
+            return next('/fail-whale');
           } else {
             store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
           }
 
-          return;
+          return;        
         }
       }
     }

--- a/shell/config/router/navigation-guards/authentication.js
+++ b/shell/config/router/navigation-guards/authentication.js
@@ -101,7 +101,7 @@ export async function authenticate(to, from, next, { store }) {
         } else {
           if ( status === 401 ) {
             notLoggedIn(store, next, to);
-          } else if (status === 504) {
+          } else if (status === 598) {
             store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
 
             return next('/fail-whale');

--- a/shell/config/router/navigation-guards/authentication.js
+++ b/shell/config/router/navigation-guards/authentication.js
@@ -101,7 +101,7 @@ export async function authenticate(to, from, next, { store }) {
         } else {
           if ( status === 401 ) {
             notLoggedIn(store, next, to);
-          } else if (status == 504) {
+          } else if (status === 504) {
             store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
 
             return next('/fail-whale');
@@ -109,7 +109,7 @@ export async function authenticate(to, from, next, { store }) {
             store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
           }
 
-          return;        
+          return;
         }
       }
     }

--- a/shell/vue-config-helper.js
+++ b/shell/vue-config-helper.js
@@ -114,9 +114,33 @@ function onProxyReqWs(proxyReq, req, socket, options, head) {
 }
 
 function onError(err, req, res) {
-  res.statusCode = 598;
   console.error('Proxy Error:', err); // eslint-disable-line no-console
-  res.write(JSON.stringify(err));
+
+  // Websocket upgrades don't have a normal `res` — bail out so http-proxy-middleware handles it.
+  if (!res || typeof res.writeHead !== 'function') {
+    return;
+  }
+
+  // Guard against writing to a response that already started (or a socket that's gone away).
+  if (res.headersSent || res.writableEnded) {
+    return;
+  }
+
+  // Serialize the error with its own properties (a bare `JSON.stringify(err)` on an Error yields "{}").
+  const body = JSON.stringify({
+    code:    err?.code,
+    errno:   err?.errno,
+    syscall: err?.syscall,
+    address: err?.address,
+    port:    err?.port,
+    message: err?.message || String(err),
+  });
+
+  // IMPORTANT: we must `end()` the response. Without it the browser sees the request as pending
+  // forever, so any code awaiting it (including console logging in `.catch()` blocks) never runs
+  // until the dev server is stopped and the socket drops. See rancher/dashboard#11591.
+  res.writeHead(504, { 'content-type': 'application/json' });
+  res.end(body);
 }
 
 module.exports = {

--- a/shell/vue-config-helper.js
+++ b/shell/vue-config-helper.js
@@ -114,7 +114,7 @@ function onProxyReqWs(proxyReq, req, socket, options, head) {
 }
 
 function onError(err, req, res) {
-  res.statusCode = 504;
+  res.statusCode = 598;
   console.error('Proxy Error:', err); // eslint-disable-line no-console
   res.end(JSON.stringify(err));
 }

--- a/shell/vue-config-helper.js
+++ b/shell/vue-config-helper.js
@@ -114,33 +114,9 @@ function onProxyReqWs(proxyReq, req, socket, options, head) {
 }
 
 function onError(err, req, res) {
+  res.statusCode = 504;
   console.error('Proxy Error:', err); // eslint-disable-line no-console
-
-  // Websocket upgrades don't have a normal `res` — bail out so http-proxy-middleware handles it.
-  if (!res || typeof res.writeHead !== 'function') {
-    return;
-  }
-
-  // Guard against writing to a response that already started (or a socket that's gone away).
-  if (res.headersSent || res.writableEnded) {
-    return;
-  }
-
-  // Serialize the error with its own properties (a bare `JSON.stringify(err)` on an Error yields "{}").
-  const body = JSON.stringify({
-    code:    err?.code,
-    errno:   err?.errno,
-    syscall: err?.syscall,
-    address: err?.address,
-    port:    err?.port,
-    message: err?.message || String(err),
-  });
-
-  // IMPORTANT: we must `end()` the response. Without it the browser sees the request as pending
-  // forever, so any code awaiting it (including console logging in `.catch()` blocks) never runs
-  // until the dev server is stopped and the socket drops. See rancher/dashboard#11591.
-  res.writeHead(504, { 'content-type': 'application/json' });
-  res.end(body);
+  res.end(JSON.stringify(err));
 }
 
 module.exports = {


### PR DESCRIPTION
### Summary
Fixes #11591

### Occurred changes and/or fixed issues
- Fixed the local dev proxy error handling so proxy failures now terminate the response instead of leaving the browser request hanging indefinitely - this was the main issue here
- Updated the auth navigation guard to treat upstream 598 auth failures as a terminal error path that routes to the fail-whale page instead of leaving the UI blank.

### Technical notes summary
- Added explicit response completion in the proxy error handler to avoid pending requests during backend/proxy failures.
- Ensured the authentication middleware surfaces 598 responses consistently during login checks and routing.

### Areas or cases that should be tested
- Reproduce a backend or proxy failure during local development and confirm the UI shows an error state rather than a blank page - to do this, set the env var API to something link https://127.0.0.1:12345 and run `yarn dev`
- Verify login and auth redirect flows still behave correctly for 401, 404, and 504 responses.

### Areas which could experience regressions
- Authentication and redirect flows for logged-in, logged-out, and OIDC-backed sessions.
- Local dev proxy behavior for proxied API requests and websocket upgrades.

### Screenshot/Video
<img width="1158" height="917" alt="image" src="https://github.com/user-attachments/assets/c672d9c7-a92c-4b19-90ca-fbf2fe0fe86c" />

(Note screen shows error 504 - this was changed back to 598 afterwards)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
