### PR TITLE
update cypress package's build script to work on macOS, add some po methods

### DIFF
--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -110,4 +110,21 @@ export default class LabeledSelectPo extends ComponentPo {
         .next('.v-select')
     );
   }
+
+
+  /**
+   * Wait until the LabeledSelect is not loading
+   * The loading property is used when labeledselect contents depend on an async method, eg a dropdown of aws instance types fetched from an aws api
+   * @param timeout how long to wait for the loading spinner to disappear before throwing an error
+   * @returns
+   */
+  waitForLoading(timeout = 20000): Cypress.Chainable {
+    // data-testid lands on the inner v-select (LabeledSelect
+    // has inheritAttrs: false), but the loading spinner is a sibling of v-select under
+    // the outer .labeled-select wrapper, so we have to search from there instead
+    return this.self()
+      .closest('.labeled-select')
+      .find('.icon-spinner', { timeout })
+      .should('not.exist');
+  }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -46,6 +46,10 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
     return this.resourceDetail().cruResource().selectSubType(2, index).click();
   }
 
+  selectTypeByName(name: string) {
+    return this.self().find(`[data-testid="cluster-manager-create-grid-${ name }"]`);
+  }
+
   commandFromCustomClusterUI() {
     return this.self().get('code').contains('--insecure');
   }

--- a/cypress/scripts/build.sh
+++ b/cypress/scripts/build.sh
@@ -38,8 +38,11 @@ mkdir -p tmp/
 echo "Copying source files..."
 
 # Copy the main package structure to a temporary directory for processing
-cp -r e2e/ tmp/
-cp -r support/ tmp/
+# (no trailing slash on the source: macOS/BSD cp flattens src/'s contents
+# into dst/ when the source has a trailing slash, unlike GNU cp on Linux,
+# which always nests as dst/e2e - the relative-path math below assumes nesting)
+cp -r e2e tmp/
+cp -r support tmp/
 cp base-config.ts tmp/
 cp extend-config.ts tmp/
 cp globals.d.ts tmp/
@@ -65,13 +68,16 @@ find tmp/ -name "*.ts" -type f | while read file; do
   fi
   
   # Replace @/cypress/ with the relative path
-  sed -i "s|@/cypress/|${relative_path}|g" "$file"
+  # (-i.bak + rm is used instead of bare -i for portability between BSD sed on
+  # macOS, which requires a backup-extension argument, and GNU sed on Linux)
+  sed -i.bak "s|@/cypress/|${relative_path}|g" "$file"
   # Also handle @/cypress without trailing slash
-  sed -i "s|@/cypress|${relative_path}|g" "$file"
+  sed -i.bak "s|@/cypress|${relative_path}|g" "$file"
   # Replace ~/cypress/ with the relative path
-  sed -i "s|~/cypress/|${relative_path}|g" "$file"
+  sed -i.bak "s|~/cypress/|${relative_path}|g" "$file"
   # Also handle ~/cypress without trailing slash
-  sed -i "s|~/cypress|${relative_path}|g" "$file"
+  sed -i.bak "s|~/cypress|${relative_path}|g" "$file"
+  rm -f "$file.bak"
 done
 
 echo "Compiling TypeScript from tmp/ to dist/..."

--- a/cypress/scripts/build.sh
+++ b/cypress/scripts/build.sh
@@ -38,9 +38,6 @@ mkdir -p tmp/
 echo "Copying source files..."
 
 # Copy the main package structure to a temporary directory for processing
-# (no trailing slash on the source: macOS/BSD cp flattens src/'s contents
-# into dst/ when the source has a trailing slash, unlike GNU cp on Linux,
-# which always nests as dst/e2e - the relative-path math below assumes nesting)
 cp -r e2e tmp/
 cp -r support tmp/
 cp base-config.ts tmp/
@@ -68,8 +65,6 @@ find tmp/ -name "*.ts" -type f | while read file; do
   fi
   
   # Replace @/cypress/ with the relative path
-  # (-i.bak + rm is used instead of bare -i for portability between BSD sed on
-  # macOS, which requires a backup-extension argument, and GNU sed on Linux)
   sed -i.bak "s|@/cypress/|${relative_path}|g" "$file"
   # Also handle @/cypress without trailing slash
   sed -i.bak "s|@/cypress|${relative_path}|g" "$file"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the cypress package's build-pkg script to work on macOS. It also adds two new methods to POs, used by the new virtual clusters e2e tests


### Areas or cases that should be tested
- PO changes can be tested by running the virtual clusters tests https://github.com/rancher/virtual-clusters-ui/pull/197
- test the build script changes by navigating to the cypress dir, running `yarn build-pkg && cd ./dist && yarn && yarn link` then running `yarn link @rancher/cypress` in a project that uses the @rancher/cypress package.

### Areas which could experience regressions
Running yarn build-pkg on linux machines.

No possibility of regression from the PO changes as they are additive. 


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
