### PR TITLE
Resolve type check errors surrounding extensionless vue imports

### DIFF
--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 772
+# Total errors: 693
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
 pkg/aks/components/Config.vue: error TS2532: Object is possibly 'undefined'.
@@ -81,14 +81,8 @@ pkg/gke/components/Networking.vue: error TS2345: Argument of type 'VuexStore' is
 pkg/gke/components/Networking.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/gke/components/Networking.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue: error TS2322: Type 'string | number | Record<string, any>' is not assignable to type 'string'.
-pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
-pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue: error TS2307: Cannot find module '@shell/components/IconOrSvg' or its corresponding type declarations.
 pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue: error TS2307: Cannot find module './RcItemCardAction' or its corresponding type declarations.
 pkg/rancher-prime/config/navigation.ts: error TS2353: Object literal may only specify known properties, and 'ifFeature' does not exist in type 'ConfigureVirtualTypeOptions'.
-pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@shell/components/AsyncButton' or its corresponding type declarations.
-pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@shell/components/Tabbed' or its corresponding type declarations.
-pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@shell/components/Tabbed/Tab' or its corresponding type declarations.
-pkg/rancher-prime/pages/Registration.vue: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 pkg/rancher-prime/pages/registration.composable.ts: error TS2339: Property 'message' does not exist on type '{}'.
 scripts/__tests__/cypress.test.ts: error TS2307: Cannot find module '@/scripts/cypress' or its corresponding type declarations.
 shell/apis/resources/__tests__/resources-api-class.test.ts: error TS2352: Conversion of type 'ActionFindPageTransientResponse<ResourceInstance<Record<string, any>>>' to type 'any[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
@@ -102,7 +96,6 @@ shell/apis/shell/proxy.ts: error TS2305: Module '"@shell/apis/intf/shell"' has n
 shell/apis/shell/proxy.ts: error TS2459: Module '"@shell/apis/intf/shell"' declares 'ProxyApi' locally, but it is not exported.
 shell/apis/shell/system.ts: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/apis/shell/system.ts: error TS2724: '"@shell/config/version"' has no exported member named 'getKubeVersionData'. Did you mean 'getVersionData'?
-shell/chart/__tests__/S3.test.ts: error TS2307: Cannot find module '@shell/chart/rancher-backup/S3' or its corresponding type declarations.
 shell/components/AppModal.vue: error TS2345: Argument of type '{ role: string; 'aria-modal': "true"; style: object; class: string; id: string; ref: string; onClick: () => void; }' is not assignable to parameter of type 'HTMLAttributes & ReservedProps & Record<string, unknown>'.
 shell/components/Certificates.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<{}, {}>, {}, Data, { expiredData(): any; }, {}, ComponentOptionsMixin, ComponentOptionsMixin, ... 18 more ..., {}>'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
@@ -119,24 +112,18 @@ shell/components/ConfigMapSettings/index.vue: error TS2345: Argument of type 'T'
 shell/components/Drawer/ResourceDetailDrawer/__tests__/ConfigTab.test.ts: error TS2322: Type '{ resource: { resource: string; }; component: Raw<DefineComponent<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; mode: { type: StringConstructor; required: true; }; initialValue: { ...; }; useTabbedHash: { ...; }; }>, ... 18 more ..., any>>; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly component: any; readonly resourceType: string; readonly defaultTab?: string | undefined; } & AllowedComponentProps & ComponentCustomProps'.
 shell/components/Drawer/ResourceDetailDrawer/__tests__/ConfigTab.test.ts: error TS2322: Type '{ resource: { resource: string; }; component: Raw<DefineComponent<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; mode: { type: StringConstructor; required: true; }; initialValue: { ...; }; useTabbedHash: { ...; }; }>, ... 18 more ..., any>>; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly component: any; readonly resourceType: string; readonly defaultTab?: string | undefined; } & AllowedComponentProps & ComponentCustomProps'.
 shell/components/Drawer/ResourceDetailDrawer/index.vue: error TS2614: Module '"@shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue"' has no exported member 'Props'. Did you mean to use 'import Props from "@shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue"' instead?
-shell/components/FailWhale.vue: error TS2307: Cannot find module '@shell/components/BrandImage' or its corresponding type declarations.
-shell/components/Questions/__tests__/Boolean.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Float.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Int.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/String.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Yaml.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2532: Object is possibly 'undefined'.
@@ -184,10 +171,8 @@ shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322:
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceTo: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
-shell/components/Resource/Detail/TitleBar/index.vue: error TS2307: Cannot find module '@shell/components/TabTitle' or its corresponding type declarations.
 shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2571: Object is of type 'unknown'.
-shell/components/Resource/Detail/ViewOptions/index.vue: error TS2307: Cannot find module '@shell/components/ButtonGroup' or its corresponding type declarations.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
@@ -277,22 +262,11 @@ shell/components/__tests__/TabTitle.test.ts: error TS2322: Type 'any[]' is not a
 shell/components/__tests__/TabTitle.test.ts: error TS2540: Cannot assign to 'getVendor' because it is a read-only property.
 shell/components/__tests__/TabTitle.test.ts: error TS2540: Cannot assign to 'updatePageTitle' because it is a read-only property.
 shell/components/__tests__/TabTitle.test.ts: error TS2740: Type '{ warn: Mock<any, any, any>; error: Mock<any, any, any>; }' is missing the following properties from type 'Console': assert, clear, count, countReset, and 14 more.
-shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
-shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@shell/components/form/Select' or its corresponding type declarations.
-shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader' or its corresponding type declarations.
-shell/components/fleet/AppCoVersionSelect.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
 shell/components/fleet/FleetClusterTargets/index.vue: error TS2345: Argument of type '{ raw: boolean; }' is not assignable to parameter of type 'boolean | undefined'.
 shell/components/fleet/FleetConfigMapSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; }>, { ...; }>, ... 24 more ..., { ...; }>'.
 shell/components/fleet/FleetSecretSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; lockedOptions: { ...; }; }>, { ...; }>, ......'.
-shell/components/fleet/HelmOpAdvancedTab.vue: error TS2307: Cannot find module '@shell/components/form/SelectOrCreateAuthSecret' or its corresponding type declarations.
-shell/components/fleet/HelmOpAdvancedTab.vue: error TS2307: Cannot find module '@shell/components/form/UnitInput' or its corresponding type declarations.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/LazyImage' or its corresponding type declarations.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/form/Labels' or its corresponding type declarations.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/form/NameNsDescription' or its corresponding type declarations.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/form/SelectOrCreateAuthSecret' or its corresponding type declarations.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader' or its corresponding type declarations.
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2739: Type 'Record<string, any>' is missing the following properties from type 'HelmOpResource': spec, metadata
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2739: Type 'Record<string, any>' is missing the following properties from type 'HelmOpValue': spec, metadata, targetClusters
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2739: Type 'Record<string, any>' is missing the following properties from type 'HelmOpValue': spec, metadata, targetClusters
@@ -301,8 +275,6 @@ shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS7005: Variable 'items' 
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS7034: Variable 'items' implicitly has type 'any[]' in some locations where its type cannot be determined.
 shell/components/fleet/HelmOpTargetTab.vue: error TS2322: Type 'object[]' is not assignable to type 'Cluster[]'.
 shell/components/fleet/HelmOpTargetTab.vue: error TS2322: Type 'string' is not assignable to type 'TargetMode | undefined'.
-shell/components/fleet/HelmOpValuesTab.vue: error TS2307: Cannot find module '@shell/components/ButtonGroup' or its corresponding type declarations.
-shell/components/fleet/HelmOpValuesTab.vue: error TS2307: Cannot find module '@shell/components/YamlEditor' or its corresponding type declarations.
 shell/components/fleet/HelmOpValuesTab.vue: error TS2322: Type 'unknown' is not assignable to type 'ValueFrom[] | undefined'.
 shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
@@ -327,8 +299,6 @@ shell/components/form/NodeScheduling.vue: error TS2322: Type 'string | null' is 
 shell/components/form/NodeScheduling.vue: error TS2554: Expected 1-2 arguments, but got 3.
 shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resourceType: { type: StringConstructor; required: true; }; context: { type: StringConstructor; default: null; }; inStore: { type: StringConstructor; default: undefined; }; paginateMode: { ...; }; allResourcesSettings: { ...; }; paginatedReso...'.
 shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resourceType: { type: StringConstructor; required: true; }; context: { type: StringConstructor; default: null; }; inStore: { type: StringConstructor; default: undefined; }; paginateMode: { ...; }; allResourcesSettings: { ...; }; paginatedReso...'.
-shell/components/form/ResourceQuota/ResourceQuotaEntry.vue: error TS2307: Cannot find module '@shell/components/form/Select' or its corresponding type declarations.
-shell/components/form/ResourceQuota/ResourceQuotaEntry.vue: error TS2307: Cannot find module '@shell/components/form/UnitInput' or its corresponding type declarations.
 shell/components/form/ResourceQuota/__tests__/ResourceQuotaEntry.test.ts: error TS2322: Type '{ id: string; mode: string; types: { value: string; inputExponent: number; baseUnit: string; placeholder: string; increment: number; }[]; resourceType: string; resourceIdentifier: string; projectLimit: string; namespaceDefaultLimit: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly id: string; readonly index: number; readonly mode: string; ... 9 more ...; readonly "onUpdate:namespaceDefaultLimit"?: ((value: string | undefined) => any) | undefined; } & AllowedComponentProps & ComponentCus...'.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
@@ -340,9 +310,6 @@ shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is no
 shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is not assignable to type 'Rule[]'. Two different types with this name exist, but they are unrelated.
 shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is not assignable to type 'Rule[]'. Two different types with this name exist, but they are unrelated.
 shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is not assignable to type 'Rule[]'. Two different types with this name exist, but they are unrelated.
-shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileImageSelector' or its corresponding type declarations.
-shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
-shell/components/form/__tests__/FileSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
@@ -372,7 +339,6 @@ shell/components/formatter/__tests__/KubeconfigClusters.test.ts: error TS2339: P
 shell/components/formatter/__tests__/LiveDate.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/components/formatter/__tests__/LiveDate.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/components/formatter/__tests__/ServiceTargets.test.ts: error TS2322: Type 'null' is not assignable to type 'string | unknown[] | undefined'.
-shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts: error TS2307: Cannot find module '@shell/components/Tag' or its corresponding type declarations.
 shell/components/google/AccountAccess.vue: error TS2339: Property 'data' does not exist on type '{}'.
 shell/components/google/AccountAccess.vue: error TS7006: Parameter 'e' implicitly has an 'any' type.
 shell/components/google/util/__mocks__/gcp.ts: error TS7006: Parameter 'zone' implicitly has an 'any' type.
@@ -380,7 +346,6 @@ shell/components/google/util/gcp.ts: error TS2307: Cannot find module 'types/gcp
 shell/components/nav/NotificationCenter/Notification.vue: error TS7053: Element implicitly has an 'any' type because expression of type 'NotificationLevel' can't be used to index type '{ 0: string; 5: string; 2: string; 1: string; 4: string; 3: string; }'.
 shell/components/nav/__tests__/Group.test.ts: error TS2322: Type 'Record<string, unknown>' is not assignable to type 'Stubs | undefined'.
 shell/components/nav/__tests__/TopLevelMenu.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
-shell/components/user.retention/user-retention-header.vue: error TS2307: Cannot find module '@shell/components/TabTitle' or its corresponding type declarations.
 shell/composables/useUserRetentionValidation.ts: error TS2769: No overload matches this call.
 shell/config/__test__/home-links.test.ts: error TS2345: Argument of type '(language: String, value: string | boolean | null) => void' is not assignable to parameter of type '(...args: (string | boolean)[] | (boolean | null)[]) => any'.
 shell/config/__test__/home-links.test.ts: error TS7006: Parameter 'link' implicitly has an 'any' type.
@@ -397,7 +362,6 @@ shell/detail/__tests__/pod.test.ts: error TS2339: Property 'containers' does not
 shell/detail/__tests__/workload.test.ts: error TS2339: Property 'findMatchingIngresses' does not exist on type '{}'.
 shell/detail/auditlog.cattle.io.auditpolicy.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/detail/management.cattle.io.oidcclient.vue: error TS2307: Cannot find module '~shell/assets/images/key.svg' or its corresponding type declarations.
-shell/dialog/RedeployWorkloadDialog.vue: error TS2307: Cannot find module '@shell/components/AsyncButton' or its corresponding type declarations.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
 shell/dialog/__tests__/RedeployWorkloadDialog.test.ts: error TS2322: Type 'boolean' is not assignable to type 'Directive'.
@@ -438,11 +402,6 @@ shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exis
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/auditlog.cattle.io.auditpolicy/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
-shell/edit/auth/github-app-steps.vue: error TS2307: Cannot find module '@shell/components/CopyToClipboard' or its corresponding type declarations.
-shell/edit/auth/github-app-steps.vue: error TS2307: Cannot find module '@shell/components/InfoBox' or its corresponding type declarations.
-shell/edit/auth/github-steps.vue: error TS2307: Cannot find module '@shell/components/CopyToClipboard' or its corresponding type declarations.
-shell/edit/auth/github-steps.vue: error TS2307: Cannot find module '@shell/components/InfoBox' or its corresponding type declarations.
-shell/edit/autoscaling.horizontalpodautoscaler/index.vue: error TS2307: Cannot find module '@shell/components/Tabbed' or its corresponding type declarations.
 shell/edit/autoscaling.horizontalpodautoscaler/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS2322: Type '{ selected: string; } | null' is not assignable to type 'Record<string, any> | undefined'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS2345: Argument of type 'string | LocationQueryValue[]' is not assignable to parameter of type 'string'.
@@ -452,40 +411,14 @@ shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'neu' impl
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'newVal' implicitly has an 'any' type.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'old' implicitly has an 'any' type.
 shell/edit/management.cattle.io.podsecurityadmissionconfigurationtemplate.vue: error TS2339: Property 'pending' does not exist on type 'never'.
-shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2307: Cannot find module '@shell/components/YamlEditor' or its corresponding type declarations.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/list/node.vue: error TS2339: Property 'id' does not exist on type 'string'.
 shell/list/projectsecret.vue: error TS2322: Type 'false' is not assignable to type 'string | string[] | undefined'.
 shell/list/projectsecret.vue: error TS2339: Property 'row' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resource: { type: StringConstructor; required: true; }; useQueryParamsForSimpleFiltering: { type: BooleanConstructor; default: boolean; }; }>, {}>, ... 24 more ..., {}>'.
-shell/list/secret.vue: error TS2307: Cannot find module '@shell/components/PaginatedResourceTable' or its corresponding type declarations.
-shell/list/secret.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
-shell/machine-config/__tests__/generic.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/machine-config/__tests__/generic.test.ts: error TS2339: Property '$nextTick' does not exist on type 'never'.
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2345: Argument of type '(rawData: string[] | null[] | undefined[] | { label: string; value: string; }[], expected: string[] | null[] | undefined[] | { label: string; value: string; }[]) => void' is not assignable to parameter of type '(...args: (undefined[] | { label: string; value: string; }[])[] | (null[] | { label: string; value: string; }[])[] | (string[] | { label: string; value: string; }[])[]) => any'.
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2345: Argument of type '(rawData: { name: string; key: string; }[] | { label: string; value: string; }[] | { name: string; key: number; }[] | { label: string; value: string; }[], expected: { name: string; key: string; }[] | { label: string; value: string; }[] | { ...; }[] | { ...; }[]) => void' is not assignable to parameter of type '(...args: ({ name: string; key: string; }[] | { label: string; value: string; }[])[] | ({ name: string; key: number; }[] | { label: string; value: string; }[])[]) => any'.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
-shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS2349: This expression is not callable.
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"poolId"' can't be used to index type '{}'.
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"poolId"' can't be used to index type '{}'.
 shell/machine-config/__tests__/vmwarevsphere.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"poolId"' can't be used to index type '{}'.
@@ -513,23 +446,13 @@ shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2339: Property 
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2339: Property 'isLocal' does not exist on type '{ id: string; metadata: { creationTimestamp: number; }; status: { provider: string; }; }'.
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'componentStatuses' does not exist in type '{ provider: string; }'.
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2740: Type '(type: string) => boolean' is missing the following properties from type 'Mock<any, any, any>': getMockName, mock, mockClear, mockReset, and 13 more.
-shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
-shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2307: Cannot find module '@shell/assets/images/content/dark/suse.svg' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2307: Cannot find module '@shell/assets/images/content/suse.svg' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/create.vue: error TS2307: Cannot find module '@shell/components/ResourceDetail/Masthead' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2339: Property 'type' does not exist on type 'string'.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2339: Property 'type' does not exist on type 'string'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailBody.vue: error TS2307: Cannot find module '@shell/components/ChartReadme' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailHeader.vue: error TS2307: Cannot find module '@shell/components/LazyImage' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailHeader.vue: error TS2307: Cannot find module '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2322: Type '{ id: string; label: string; href: string | null; name: string | undefined; }[]' is not assignable to type 'ChartMaintainer[]'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2322: Type '(chartValue: { name: string; }) => void' is not assignable to type '(value: unknown) => void'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/index.vue: error TS18047: '$event.target' is possibly 'null'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'gitRepos' does not exist on type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS2339: Property 'helmOps' does not exist on type '{}'.
@@ -636,9 +559,7 @@ shell/pages/c/_cluster/fleet/index.vue: error TS7053: Element implicitly has an 
 shell/pages/c/_cluster/fleet/index.vue: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
 shell/pages/c/_cluster/fleet/index.vue: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-shell/pages/c/_cluster/istio/__tests__/istio.index.test.ts: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts: error TS18048: 'containsProxyUrl' is possibly 'undefined'.
-shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts: error TS2307: Cannot find module '@shell/components/IconMessage' or its corresponding type declarations.
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2322: Type '"1.28.0"' is not assignable to type 'null'.
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2322: Type '"2.9.0"' is not assignable to type 'null'.
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property 'certified' does not exist on type '{ name: any; label: any; description: any; id: any; versions: any[]; installed: boolean; builtin: boolean; chart: any; incompatibilityMessage: string; }'.

--- a/shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailBody.vue
+++ b/shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailBody.vue
@@ -116,7 +116,7 @@ const formatVersionDate = (date: string | null): string => {
 
     <div class="chart-body">
       <ChartReadme
-        v-if="hasReadme"
+        v-if="versionInfo && hasReadme"
         :version-info="versionInfo"
         :show-app-readme="false"
         :hide-readme-first-title="false"

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -4,8 +4,16 @@
       "@components/*": [
         "pkg/rancher-components/src/components/*"
       ],
+      // `shell/*.vue` and `shell/*/index.vue` let TypeScript resolve extensionless `.vue`
+      // imports, by file and by directory respectively. TypeScript only ever appends
+      // .ts/.tsx/.d.ts/.js/.jsx to a specifier and that list is not configurable, so
+      // without these candidates every `from '@shell/components/Foo'` is a TS2307 and
+      // types as `any`. Webpack (`shell/vue.config.js`) and jest (`moduleFileExtensions`)
+      // already resolve these through their own resolvers.
       "@shell/*": [
-        "shell/*"
+        "shell/*",
+        "shell/*.vue",
+        "shell/*/index.vue"
       ],
       // `pkg/*` first to match the webpack alias (`shell/vue.config.js`) and the jest
       // `moduleNameMapper`, both of which resolve `@pkg` to the repo's `pkg` directory.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The TypeScript type-checker was reporting hundreds of `TS2307: Cannot find module` errors for `@shell/*` imports of `.vue` components that don't include the file extension (e.g. `import ChartReadme from '@shell/components/ChartReadme'`). Webpack and Jest resolve these fine through their own resolvers, but `tsc` only appends `.ts/.tsx/.d.ts/.js/.jsx` to specifiers. Every extensionless `.vue` import was failing type resolution and silently typing the imported component as `any`.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- `tsconfig.paths.json`: Extended the `@shell/*` path mapping with two extra resolution candidates
- `shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailBody.vue`: Guard `ChartReadme` rendering with `versionInfo &&`. Now that the import resolves to a real type, `tsc` correctly flags that `:version-info` can be `null`; the component was already only rendered when readme data was present, so this makes the existing runtime behaviour explicit.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

No runtime behavior change. Webpack and jest already handled these imports. Only the static type-check pass is affected.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- `yarn type-check` passes against the updated baseline
- `yarn test:ci` passes all checks

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Type-checking only.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
