### PR TITLE
Fix rendering issues with TextAutoGrow component

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -554,7 +554,7 @@ export default defineComponent({
         :value="value || ''"
         :placeholder="_placeholder"
         autocapitalize="off"
-        :class="{ 'multiline-password': type === 'multiline-password' }"
+        :class="{ 'multiline-password': type === 'multiline-password', 'auto-grow-labeled': hasLabel }"
         :aria-describedby="ariaDescribedBy"
         :aria-required="requiredField"
         @update:value="onInput"

--- a/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
+++ b/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
@@ -13,6 +13,18 @@ const provideProps: NonReactiveProps = {
   }
 };
 
+// CSS properties the mirror div must copy from the textarea for its text to
+// wrap identically. Anything that affects glyph metrics or wrapping belongs
+// here — anything that only affects color or interaction does not.
+const MIRROR_STYLE_PROPS = [
+  'boxSizing',
+  'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+  'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',
+  'fontFamily', 'fontSize', 'fontStyle', 'fontVariant', 'fontWeight', 'fontStretch',
+  'lineHeight', 'letterSpacing', 'wordSpacing', 'textTransform', 'textIndent',
+  'tabSize',
+] as const;
+
 export default defineComponent({
   inheritAttrs: false,
 
@@ -101,7 +113,9 @@ export default defineComponent({
   data() {
     return {
       curHeight: this.minHeight,
-      overflow:  'hidden'
+      overflow:  'hidden',
+      // Non-reactive: this is a DOM node reference. Vue won't wrap it.
+      mirror:    null as HTMLDivElement | null,
     };
   },
 
@@ -164,17 +178,29 @@ export default defineComponent({
     if (this.resizeOnValueChangeAndResizeWindow) {
       window.removeEventListener('resize', this.queueResize);
     }
+
+    if (this.mirror) {
+      this.mirror.remove();
+      this.mirror = null;
+    }
   },
 
   methods: {
     /**
      * Emits the input event and resizes the Text Area.
-    */
+     *
+     * autoSize runs synchronously (not via the debounced queueResize) so the
+     * height change lands in the same frame as the keypress. Debouncing here
+     * causes the browser to paint an interim frame where content overflows
+     * the still-too-short textarea — the caret scrolls into view, then the
+     * height catches up 100ms later and the text visibly jumps back down.
+     * See #6041.
+     */
     onInput(event: Event): void {
       const val = (event?.target as HTMLInputElement)?.value;
 
       this.$emit('update:value', val);
-      this.queueResize();
+      this.autoSize();
     },
 
     /**
@@ -186,24 +212,85 @@ export default defineComponent({
 
     /**
      * Sets the overflowY and height of the Text Area based on the content
-     * entered (calculated via scroll height).
+     * entered.
+     *
+     * The required height is measured against a hidden mirror div rather
+     * than by shrinking the textarea to 1px — that shrink+regrow trick
+     * flashed the surrounding layout up and back down every time the height
+     * changed. The mirror never touches the visible textarea, so autoSize
+     * is now visually invisible except for the final height change.
+     * See #6041.
      */
     autoSize(): void {
-      const el = this.$refs.ta as HTMLElement;
+      const el = this.$refs.ta as HTMLTextAreaElement;
 
       if (!el) {
         return;
       }
 
-      el.style.height = '1px';
+      const contentHeight = this.measureContentHeight(el);
+      const neu = Math.max(this.minHeight, Math.min(contentHeight, this.maxHeight));
+      const overflows = contentHeight > this.maxHeight;
 
-      const border = parseInt(getComputedStyle(el).getPropertyValue('borderTopWidth'), 10) || 0 + parseInt(getComputedStyle(el).getPropertyValue('borderBottomWidth'), 10) || 0;
-      const neu = Math.max(this.minHeight, Math.min(el.scrollHeight + border, this.maxHeight));
+      // Preserve scrollTop in the overflow case so the caret does not jump
+      // back to the top when the textarea has hit its cap.
+      const previousScrollTop = el.scrollTop;
 
-      el.style.overflowY = el.scrollHeight > neu ? 'auto' : 'hidden';
+      el.style.overflowY = overflows ? 'auto' : 'hidden';
       el.style.height = `${ neu }px`;
+      if (overflows) {
+        el.scrollTop = previousScrollTop;
+      }
 
+      this.overflow = overflows ? 'auto' : 'hidden';
       this.curHeight = neu;
+    },
+
+    /**
+     * Measures the required content height for the given textarea by mirroring
+     * its text into an off-screen div sized to match the textarea's rendering.
+     * Returns the border-box height needed to display all content without
+     * scrolling.
+     */
+    measureContentHeight(el: HTMLTextAreaElement): number {
+      const cs = getComputedStyle(el);
+
+      let mirror = this.mirror;
+
+      if (!mirror) {
+        mirror = document.createElement('div');
+        mirror.setAttribute('aria-hidden', 'true');
+        document.body.appendChild(mirror);
+        this.mirror = mirror;
+      }
+
+      const style = mirror.style;
+
+      // Position off-screen; visibility:hidden still lays out.
+      style.position = 'absolute';
+      style.top = '0';
+      style.left = '-9999px';
+      style.visibility = 'hidden';
+      style.pointerEvents = 'none';
+      // Textarea wraps like `pre-wrap` and breaks long words.
+      style.whiteSpace = 'pre-wrap';
+      style.overflowWrap = 'break-word';
+      // Match the textarea's width so wrapping is identical.
+      style.width = `${ el.clientWidth }px`;
+      style.height = 'auto';
+
+      for (const prop of MIRROR_STYLE_PROPS) {
+        style[prop] = cs[prop];
+      }
+
+      // Textareas need a trailing space so a final newline contributes a
+      // measurable line — otherwise the last empty line collapses.
+      mirror.textContent = `${ el.value || '' } `;
+
+      const border = (parseInt(cs.borderTopWidth, 10) || 0) +
+                     (parseInt(cs.borderBottomWidth, 10) || 0);
+
+      return mirror.scrollHeight + border;
     }
   }
 });

--- a/pkg/rancher-components/src/components/Form/TextArea/__tests__/TextAreaAutoGrow.test.ts
+++ b/pkg/rancher-components/src/components/Form/TextArea/__tests__/TextAreaAutoGrow.test.ts
@@ -27,16 +27,22 @@ describe('component: TextAreaAutoGrow', () => {
     expect(queueResize).not.toHaveBeenCalled();
   });
 
-  it('should recalculate its height on user input', async() => {
+  it('should recalculate its height synchronously on user input', async() => {
+    const component = TextAreaAutoGrow as unknown as { methods: Record<string, () => void> };
+    const autoSizeSpy = jest.spyOn(component.methods, 'autoSize');
+
     const wrapper = mount(TextAreaAutoGrow, { props: { value: '' } });
 
-    const queueResize = jest.fn();
-
-    wrapper.vm.queueResize = queueResize;
+    autoSizeSpy.mockClear();
 
     await wrapper.find('textarea').setValue('typed value');
 
-    expect(queueResize).toHaveBeenCalledWith();
+    // Running autoSize directly (not via the debounced queueResize) keeps
+    // the resize in the same frame as the keypress and prevents the visible
+    // up/down jump described in #6041.
+    expect(autoSizeSpy).toHaveBeenCalledWith();
+
+    autoSizeSpy.mockRestore();
   });
 
   it('should register a window resize listener when resizeOnValueChangeAndResizeWindow is set', () => {
@@ -91,5 +97,120 @@ describe('component: TextAreaAutoGrow', () => {
     expect(removeSpy).toHaveBeenCalledWith('resize', queueResize);
 
     removeSpy.mockRestore();
+  });
+
+  describe('autoSize', () => {
+    // The measurement path uses a hidden mirror div; stub it so tests can
+    // assert autoSize's height/overflow decisions without depending on
+    // jsdom's (fixed) layout numbers.
+    const stubMeasurement = (wrapper: ReturnType<typeof mount>, height: number) => {
+      (wrapper.vm as unknown as { measureContentHeight: () => number }).measureContentHeight = () => height;
+    };
+
+    it('should size the textarea to its content when it fits within maxHeight', () => {
+      const wrapper = mount(TextAreaAutoGrow, {
+        props: {
+          value: 'a\nb\nc', minHeight: 25, maxHeight: 200
+        }
+      });
+      const el = wrapper.find('textarea').element as HTMLTextAreaElement;
+
+      stubMeasurement(wrapper, 80);
+      wrapper.vm.autoSize();
+
+      expect(el.style.height).toBe('80px');
+      expect(el.style.overflowY).toBe('hidden');
+    });
+
+    it('should cap the textarea at maxHeight and enable scrolling when content overflows', () => {
+      const wrapper = mount(TextAreaAutoGrow, {
+        props: {
+          value: 'many\nlines', minHeight: 25, maxHeight: 200
+        }
+      });
+      const el = wrapper.find('textarea').element as HTMLTextAreaElement;
+
+      stubMeasurement(wrapper, 500);
+      wrapper.vm.autoSize();
+
+      expect(el.style.height).toBe('200px');
+      expect(el.style.overflowY).toBe('auto');
+    });
+
+    it('should preserve scrollTop when the content overflows so the caret does not jump', () => {
+      const wrapper = mount(TextAreaAutoGrow, {
+        props: {
+          value: 'many\nlines', minHeight: 25, maxHeight: 200
+        }
+      });
+      const el = wrapper.find('textarea').element as HTMLTextAreaElement;
+
+      stubMeasurement(wrapper, 500);
+
+      let scrollTop = 120;
+
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get:          () => scrollTop,
+        set:          (v: number) => {
+          scrollTop = v;
+        },
+      });
+
+      wrapper.vm.autoSize();
+
+      expect(scrollTop).toBe(120);
+    });
+
+    it('should never shrink the textarea below minHeight', () => {
+      const wrapper = mount(TextAreaAutoGrow, {
+        props: {
+          value: '', minHeight: 40, maxHeight: 200
+        }
+      });
+      const el = wrapper.find('textarea').element as HTMLTextAreaElement;
+
+      stubMeasurement(wrapper, 10);
+      wrapper.vm.autoSize();
+
+      expect(el.style.height).toBe('40px');
+      expect(el.style.overflowY).toBe('hidden');
+    });
+
+    it('should not shrink the textarea to 1px during measurement (avoids the up/down jump in #6041)', () => {
+      const wrapper = mount(TextAreaAutoGrow, {
+        props: {
+          value: 'x', minHeight: 25, maxHeight: 500
+        }
+      });
+      const el = wrapper.find('textarea').element as HTMLTextAreaElement;
+      const heightsSeen: string[] = [];
+      const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style');
+
+      Object.defineProperty(el, 'style', {
+        configurable: true,
+        get() {
+          const style = descriptor?.get?.call(this) as CSSStyleDeclaration;
+          const proxy = new Proxy(style, {
+            set(target, prop, value) {
+              if (prop === 'height') {
+                heightsSeen.push(value as string);
+              }
+              (target as unknown as Record<string | symbol, unknown>)[prop] = value;
+
+              return true;
+            },
+          });
+
+          return proxy;
+        },
+      });
+
+      stubMeasurement(wrapper, 100);
+      wrapper.vm.autoSize();
+
+      expect(heightsSeen).not.toContain('1px');
+      expect(heightsSeen).toContain('100px');
+    });
   });
 });

--- a/shell/assets/styles/global/_labeled-input.scss
+++ b/shell/assets/styles/global/_labeled-input.scss
@@ -82,6 +82,12 @@
     }
   }
 
+  // Auto-grow TEXTAREA change to margin to prevent the label from overlapping the text when the textarea grows
+  TEXTAREA.auto-grow-labeled {
+    padding: 0;
+    margin: $input-padding-lg 0 0 0;
+  }
+
   &.view>DIV:not(.addon, .sub-label) {
     font-size: 14px;
     padding: $input-padding-lg 0 0 0;


### PR DESCRIPTION
### Summary
Fixes #6041

### Occurred changes and/or fixed issues
- `TextAreaAutoGrow` no longer flashes or jumps as the user types. The content that grows/shrinks the textarea now lands on the same frame as the keypress, and the surrounding layout is no longer momentarily collapsed while the new height is calculated.
- When the textarea has hit its `maxHeight` and is scrolling, the caret stays where the user put it instead of snapping back to the top on each keystroke.
- Inside a `LabeledInput`, an auto-growing textarea no longer allows the floating label to overlap the first line of text as the textarea grows.

### Technical notes summary
- `autoSize()` used to set `el.style.height = '1px'` and then read `scrollHeight` to remeasure. That shrink+regrow was what caused the visible jump. It now measures against a hidden mirror `<div>` styled to match the textarea (font metrics, padding, border, width, wrapping) and only writes the final height back to the visible element.
- `onInput` now calls `autoSize()` directly instead of the 100ms-debounced `queueResize()`, so the height change is applied in the same frame the browser paints the new character. Debouncing was letting the browser paint one interim frame where the still-too-short textarea overflowed and scrolled its caret, then jumped back 100ms later.
- On overflow, `scrollTop` is captured before the height is changed and restored after, so the caret does not jump to the top when the textarea is capped at `maxHeight`.
- The mirror div is created lazily, reused across resizes, and removed in `beforeUnmount`.
- `LabeledInput` adds an `auto-grow-labeled` class to its textarea, and `_labeled-input.scss` uses that class to swap padding for a top margin so the floating label has room and does not sit on top of the text as the textarea grows.

### Areas or cases that should be tested
- Any form that renders `TextAreaAutoGrow` directly or via `LabeledInput` — Secrets (data / annotations), ConfigMaps, Node taints/labels, Workload env vars, cluster description fields.
- Type slowly and quickly into an empty textarea and confirm there is no visible up/down flash of either the textarea or the surrounding form as it grows.
- Grow a textarea past its `maxHeight` (paste a long block) and confirm the textarea caps at that height, becomes scrollable, and the caret does not jump to the top as you continue typing.
- Delete lines and confirm the textarea shrinks smoothly back down to `minHeight`, without collapsing below it.
- Inside a `LabeledInput`, confirm the floating label never overlaps the first line of text as the textarea grows.
- Tested locally in Chrome — reviewer should verify in Firefox and Safari.

### Areas which could experience regressions
- Any consumer of `TextAreaAutoGrow` — the sizing path was rewritten, so height on first mount, on prop-driven value changes, on window resize, and on `manualRefresh()` should all be sanity-checked.
- `LabeledInput` with `type="multiline"` — the textarea now carries an extra `auto-grow-labeled` class and its padding/margin rules changed. Check spacing looks right in both light and dark mode and that the label position is unchanged when the textarea is at `minHeight`.
- Read-only/view-mode rendering of multiline `LabeledInput` (the `&.view` selector sits next to the new rule).

### Screenshot/Video
<img width="760" height="812" alt="Screen Recording 2026-08-25 at 08 54 51" src="https://github.com/user-attachments/assets/3d9cef78-3ce2-4985-8cea-d9da69384ef2" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
