### PR TITLE
Add a search by name feature to the Workload Overview page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,11 @@ Dependencies are managed via `package.json` and `yarn`
 - Ensure you have the latest of that branch `git pull --rebase`
 - Checkout the branch to commit the changes to `git checkout issue-${issueNumber}`. Replace `${issueNumber}` with the issue number.
 
+## Comments
+
+- Comments should only accompany a code change if the reason for the change is not clear and obvious.
+- Comments should be short and concise.
+
 ## Creating a commit
 
 - Follow the [Chris Beams](http://chris.beams.io/posts/git-commit/) 'seven rules of a great Git commit message'  for commit messages.
@@ -213,6 +218,7 @@ Dependencies are managed via `package.json` and `yarn`
 - Pull requests must come from forks
 - Description should always reference the issue that the PR resolves e.g. `Fixes #1234`.
 - Pull Requests that update code in `shell/` should update existing or add new unit tests to cover the change in functionality
+- Pull Request descriptions should use the github template and be concise
 - A Pull Request will only be merged once
   - The pull request checklist has been completed
   - ALL CI gates have passed

--- a/docs/agents.md/contributors/resolving_gh_issues.md
+++ b/docs/agents.md/contributors/resolving_gh_issues.md
@@ -21,6 +21,11 @@
 - Ensure you have the latest of that branch `git pull --rebase`
 - Checkout the branch to commit the changes to `git checkout issue-${issueNumber}`. Replace `${issueNumber}` with the issue number.
 
+## Comments
+
+- Comments should only accompany a code change if the reason for the change is not clear and obvious.
+- Comments should be short and concise.
+
 ## Creating a commit
 
 - Follow the [Chris Beams](http://chris.beams.io/posts/git-commit/) 'seven rules of a great Git commit message'  for commit messages.
@@ -30,6 +35,7 @@
 - Pull requests must come from forks
 - Description should always reference the issue that the PR resolves e.g. `Fixes #1234`.
 - Pull Requests that update code in `shell/` should update existing or add new unit tests to cover the change in functionality
+- Pull Request descriptions should use the github template and be concise
 - A Pull Request will only be merged once
   - The pull request checklist has been completed
   - ALL CI gates have passed

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7582,6 +7582,10 @@ workloadDashboard:
     byState: By State
     byType: By Type
     byNamespace: By Namespace
+  search:
+    placeholder: Search by name
+    startTyping: Start typing to search
+    searching: Searching...
   errors:
     noAccess: "No access to {type}"
     fetchType: "Failed to fetch {type}"

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
@@ -3,12 +3,11 @@ import {
 } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
-import { NAMESPACE, WORKLOAD_TYPES } from '@shell/config/types';
+import { WORKLOAD_TYPES } from '@shell/config/types';
 import type { StateColor } from '@shell/utils/style';
 import { useI18n } from '@shell/composables/useI18n';
 import { useStateColor } from '@shell/composables/useStateColor';
 import { stateDisplay } from '@shell/plugins/dashboard-store/resource-class';
-import { ALL_NAMESPACES } from '@shell/store/prefs';
 import {
   NAMESPACE_FILTER_ALL_USER,
   NAMESPACE_FILTER_ALL_SYSTEM,
@@ -16,6 +15,7 @@ import {
   NAMESPACE_FILTER_NS_FULL_PREFIX,
 } from '@shell/utils/namespace-filter';
 import stevePaginationUtils from '@shell/plugins/steve/steve-pagination-utils';
+import { getWorkloadNamespaceFilterParams } from './namespaceFilter';
 import {
   WORKLOAD_RESOURCE_TYPES, COLOR_ORDER,
   type WorkloadDashboardSummaryEntry,
@@ -55,15 +55,7 @@ export function useWorkloadDashboard() {
   const namespaceFilterParam = ref('');
 
   function buildNamespaceFilterParam(): string {
-    const selection: string[] = store.getters['namespaceFilters'];
-    const { projectsOrNamespaces, filters } = stevePaginationUtils.createParamsFromNsFilter({
-      allNamespaces:                 store.getters['cluster/all'](NAMESPACE),
-      selection,
-      isAllNamespaces:               isAllNamespaces.value,
-      isLocalCluster:                store.getters['currentCluster']?.isLocal,
-      showReservedRancherNamespaces: store.getters['prefs/get'](ALL_NAMESPACES),
-      productHidesSystemNamespaces:  store.getters['currentProduct']?.hideSystemResources,
-    });
+    const { projectsOrNamespaces, filters } = getWorkloadNamespaceFilterParams(store);
 
     // Getting the first schema is sufficient since the namespace filter param structure is the same across all resource types
     const schema = WORKLOAD_RESOURCE_TYPES

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/index.vue
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/index.vue
@@ -11,6 +11,7 @@ import { useWorkloadDashboard } from './composable';
 import ByStateSection from './ByStateSection.vue';
 import ByTypeSection from './ByTypeSection.vue';
 import ByNamespaceSection from './ByNamespaceSection.vue';
+import WorkloadSearch from './search/WorkloadSearch.vue';
 
 const store = useStore();
 const { t } = useI18n(store);
@@ -99,6 +100,9 @@ const {
           </div>
         </template>
       </Masthead>
+      <div class="workload-search-row">
+        <WorkloadSearch />
+      </div>
       <div class="workload-content">
         <!-- ━━━ By State ━━━ -->
         <div
@@ -151,6 +155,10 @@ const {
 .workload-dashboard {
   display: flex;
   flex-direction: column;
+
+  .workload-search-row {
+    margin-bottom: 24px;
+  }
 
   .workload-content {
     display: flex;

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/namespaceFilter.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/namespaceFilter.ts
@@ -1,0 +1,22 @@
+import type { Store } from 'vuex';
+import { NAMESPACE } from '@shell/config/types';
+import { ALL_NAMESPACES } from '@shell/store/prefs';
+import stevePaginationUtils from '@shell/plugins/steve/steve-pagination-utils';
+
+/**
+ * The project/namespace filter params (from the header's namespace filter)
+ * that scope the workload dashboard's own "by X" section requests. Shared
+ * with the search feature so search results are scoped the same way.
+ */
+export function getWorkloadNamespaceFilterParams(store: Store<any>) {
+  const selection: string[] = store.getters['namespaceFilters'];
+
+  return stevePaginationUtils.createParamsFromNsFilter({
+    allNamespaces:                 store.getters['cluster/all'](NAMESPACE),
+    selection,
+    isAllNamespaces:               store.getters['isAllNamespaces'],
+    isLocalCluster:                store.getters['currentCluster']?.isLocal,
+    showReservedRancherNamespaces: store.getters['prefs/get'](ALL_NAMESPACES),
+    productHidesSystemNamespaces:  store.getters['currentProduct']?.hideSystemResources,
+  });
+}

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/WorkloadSearch.vue
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/WorkloadSearch.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { useStore } from 'vuex';
+import { useWorkloadSearch } from './useWorkloadSearch';
+
+const store = useStore();
+const { t } = useI18n(store);
+
+const {
+  loading,
+  options,
+  onSearch,
+  onSelect,
+} = useWorkloadSearch();
+</script>
+
+<template>
+  <LabeledSelect
+    class="workload-search"
+    :options="options"
+    :searchable="true"
+    :filterable="false"
+    option-key="uniqueId"
+    :placeholder="t('workloadDashboard.search.placeholder')"
+    data-testid="workload-dashboard-search"
+    @search="onSearch"
+    @selecting="onSelect"
+  >
+    <template #option="option">
+      <b v-if="option.kind === 'group'">{{ option.label }}</b>
+      <div
+        v-else
+        class="workload-search-option"
+      >
+        <span>{{ option.label }}</span>
+        <span
+          v-if="option.namespace"
+          class="text-muted"
+        >{{ option.namespace }}</span>
+      </div>
+    </template>
+    <template #no-options="{ search }">
+      <span v-if="loading">{{ t('workloadDashboard.search.searching') }}</span>
+      <span v-else-if="search">{{ t('labelSelect.noOptions.noMatch') }}</span>
+      <span v-else>{{ t('workloadDashboard.search.startTyping') }}</span>
+    </template>
+  </LabeledSelect>
+</template>
+
+<style lang="scss" scoped>
+.workload-search {
+  // Match the width of one card in the By Namespace section's 3-column grid
+  // (ByNamespaceSection.vue: grid-template-columns: repeat(3, 1fr); gap: 15px).
+  width: calc((100% - 2 * 15px) / 3);
+}
+
+.workload-search-option {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
@@ -107,8 +107,8 @@ describe('composable: useWorkloadSearch', () => {
       expect(mockDispatch).toHaveBeenCalledWith('cluster/findPage', expect.objectContaining({
         type,
         opt: expect.objectContaining({
-          transient: true,
-          watch:     false,
+          transient:  true,
+          watch:      false,
           pagination: expect.objectContaining({
             page:     1,
             pageSize: 10,
@@ -168,6 +168,7 @@ describe('composable: useWorkloadSearch', () => {
 
   it('sets loading while requests are in flight and clears it once resolved', async() => {
     let resolveDispatch: (value: any) => void = () => {};
+
     mockDispatch.mockReturnValue(new Promise((resolve) => {
       resolveDispatch = resolve;
     }));

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
@@ -1,0 +1,213 @@
+import { useWorkloadSearch } from '@shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch';
+import { WORKLOAD_RESOURCE_TYPES } from '@shell/pages/c/_cluster/explorer/workload-dashboard/types';
+import { WORKLOAD_SEARCH_DEBOUNCE_MS } from '@shell/pages/c/_cluster/explorer/workload-dashboard/search/types';
+import { defineComponent, h } from 'vue';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+
+const mockGetters: Record<string, any> = {};
+const mockDispatch = jest.fn();
+const mockRouterPush = jest.fn();
+
+jest.mock('vuex', () => ({
+  useStore: () => ({
+    getters: new Proxy(mockGetters, {
+      get(target, prop: string) {
+        return target[prop];
+      },
+    }),
+    dispatch: mockDispatch,
+  }),
+}));
+
+jest.mock('vue-router', () => ({ useRouter: () => ({ push: mockRouterPush }) }));
+
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key: string, args?: Record<string, any>) => `%${ key }%${ args ? JSON.stringify(args) : '' }` }) }));
+
+const defaultGetters: Record<string, any> = {
+  'cluster/schemaFor': () => ({ id: 'test' }),
+  'cluster/canList':   () => true,
+};
+
+function setupGetters(overrides: Record<string, any> = {}) {
+  Object.keys(mockGetters).forEach((key) => delete mockGetters[key]);
+  Object.assign(mockGetters, defaultGetters, overrides);
+}
+
+function mountComposable() {
+  let result: ReturnType<typeof useWorkloadSearch>;
+
+  const wrapper = shallowMount(defineComponent({
+    setup() {
+      result = useWorkloadSearch();
+
+      return {};
+    },
+    render: () => h('div'),
+  }));
+
+  return {
+    wrapper,
+    get result() {
+      return result!;
+    },
+  };
+}
+
+function makeResource(name: string, namespace = 'default') {
+  return {
+    metadata:       { name, namespace },
+    detailLocation: { name: 'detail', params: { id: name, namespace } },
+  };
+}
+
+describe('composable: useWorkloadSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    setupGetters();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not dispatch a request until the debounce time has elapsed', () => {
+    mockDispatch.mockResolvedValue({ data: [] });
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS - 1);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches cluster/findPage as a transient, non-watched request for every accessible workload type once debounced', async() => {
+    mockDispatch.mockResolvedValue({ data: [] });
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+
+    expect(mockDispatch).toHaveBeenCalledTimes(WORKLOAD_RESOURCE_TYPES.length);
+
+    WORKLOAD_RESOURCE_TYPES.forEach((type) => {
+      expect(mockDispatch).toHaveBeenCalledWith('cluster/findPage', expect.objectContaining({
+        type,
+        opt: expect.objectContaining({
+          transient: true,
+          watch:     false,
+          pagination: expect.objectContaining({
+            page:     1,
+            pageSize: 10,
+            sort:     [{ field: 'metadata.name', asc: true }],
+          }),
+        }),
+      }));
+    });
+  });
+
+  it('skips types the user cannot list', async() => {
+    mockDispatch.mockResolvedValue({ data: [] });
+    setupGetters({ 'cluster/canList': (type: string) => type !== WORKLOAD_RESOURCE_TYPES[0] });
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+
+    expect(mockDispatch).toHaveBeenCalledTimes(WORKLOAD_RESOURCE_TYPES.length - 1);
+  });
+
+  it('groups returned resources under a type header option', async() => {
+    mockDispatch.mockImplementation((action: string, { type }: { type: string }) => {
+      if (type === WORKLOAD_RESOURCE_TYPES[0]) {
+        return Promise.resolve({ data: [makeResource('nginx-a'), makeResource('nginx-b', 'kube-system')] });
+      }
+
+      return Promise.resolve({ data: [] });
+    });
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+
+    expect(result.options.value).toStrictEqual([
+      {
+        kind:     'group',
+        label:    expect.any(String),
+        uniqueId: `group-${ WORKLOAD_RESOURCE_TYPES[0] }`,
+      },
+      {
+        label:     'nginx-a',
+        namespace: 'default',
+        uniqueId:  `${ WORKLOAD_RESOURCE_TYPES[0] }/default/nginx-a`,
+        value:     { name: 'detail', params: { id: 'nginx-a', namespace: 'default' } },
+      },
+      {
+        label:     'nginx-b',
+        namespace: 'kube-system',
+        uniqueId:  `${ WORKLOAD_RESOURCE_TYPES[0] }/kube-system/nginx-b`,
+        value:     { name: 'detail', params: { id: 'nginx-b', namespace: 'kube-system' } },
+      },
+    ]);
+  });
+
+  it('sets loading while requests are in flight and clears it once resolved', async() => {
+    let resolveDispatch: (value: any) => void = () => {};
+    mockDispatch.mockReturnValue(new Promise((resolve) => {
+      resolveDispatch = resolve;
+    }));
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+
+    expect(result.loading.value).toBe(true);
+
+    resolveDispatch({ data: [] });
+    await flushPromises();
+
+    expect(result.loading.value).toBe(false);
+  });
+
+  it('clears options immediately without dispatching when the search term is emptied', async() => {
+    mockDispatch.mockResolvedValue({ data: [makeResource('nginx-a')] });
+    const { result } = mountComposable();
+
+    result.onSearch('nginx');
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+    expect(result.options.value.length).toBeGreaterThan(0);
+
+    mockDispatch.mockClear();
+    result.onSearch('');
+
+    expect(result.options.value).toStrictEqual([]);
+    expect(result.loading.value).toBe(false);
+
+    jest.advanceTimersByTime(WORKLOAD_SEARCH_DEBOUNCE_MS);
+    await flushPromises();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the selected option route', () => {
+    const { result } = mountComposable();
+    const route = { name: 'detail', params: { id: 'nginx-a' } };
+
+    result.onSelect(route);
+
+    expect(mockRouterPush).toHaveBeenCalledWith(route);
+  });
+
+  it('does not navigate when no route is provided', () => {
+    const { result } = mountComposable();
+
+    result.onSelect(undefined);
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+});

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/__tests__/useWorkloadSearch.test.ts
@@ -23,9 +23,20 @@ jest.mock('vue-router', () => ({ useRouter: () => ({ push: mockRouterPush }) }))
 
 jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key: string, args?: Record<string, any>) => `%${ key }%${ args ? JSON.stringify(args) : '' }` }) }));
 
+jest.mock('@shell/plugins/steve/steve-pagination-utils', () => ({
+  __esModule: true,
+  default:    { createParamsFromNsFilter: jest.fn(() => ({ projectsOrNamespaces: [], filters: [] })) },
+}));
+
 const defaultGetters: Record<string, any> = {
   'cluster/schemaFor': () => ({ id: 'test' }),
   'cluster/canList':   () => true,
+  namespaceFilters:    [],
+  'cluster/all':       () => [],
+  isAllNamespaces:     true,
+  currentCluster:      { isLocal: true },
+  'prefs/get':         () => ({}),
+  currentProduct:      { hideSystemResources: false },
 };
 
 function setupGetters(overrides: Record<string, any> = {}) {

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/types.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/types.ts
@@ -1,0 +1,13 @@
+import type { RouteLocationRaw } from 'vue-router';
+
+export const WORKLOAD_SEARCH_DEBOUNCE_MS = 300;
+export const WORKLOAD_SEARCH_RESULTS_PER_TYPE = 10;
+
+export interface WorkloadSearchOption {
+  /** Set on group header (by-type) options; omitted on real, selectable options. */
+  kind?: 'group';
+  label: string;
+  uniqueId: string;
+  namespace?: string;
+  value?: RouteLocationRaw;
+}

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
@@ -3,8 +3,9 @@ import { useStore } from 'vuex';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
 import debounce from 'lodash/debounce';
 import { useI18n } from '@shell/composables/useI18n';
-import { PaginationParamFilter } from '@shell/types/store/pagination.types';
+import { PaginationParamFilter, type PaginationParamProjectOrNamespace } from '@shell/types/store/pagination.types';
 import { WORKLOAD_RESOURCE_TYPES } from '../types';
+import { getWorkloadNamespaceFilterParams } from '../namespaceFilter';
 import {
   WORKLOAD_SEARCH_DEBOUNCE_MS,
   WORKLOAD_SEARCH_RESULTS_PER_TYPE,
@@ -28,7 +29,11 @@ export function useWorkloadSearch() {
   // Guards against a slower, earlier search response overwriting a later one.
   let requestId = 0;
 
-  async function fetchOptionsForType(type: string, term: string): Promise<WorkloadSearchOption[]> {
+  async function fetchOptionsForType(
+    type: string,
+    term: string,
+    namespaceFilter: { projectsOrNamespaces: PaginationParamProjectOrNamespace[]; filters: PaginationParamFilter[] }
+  ): Promise<WorkloadSearchOption[]> {
     if (!store.getters['cluster/schemaFor'](type) || !store.getters['cluster/canList'](type)) {
       return [];
     }
@@ -38,10 +43,14 @@ export function useWorkloadSearch() {
         type,
         opt: {
           pagination: {
-            page:     1,
-            pageSize: WORKLOAD_SEARCH_RESULTS_PER_TYPE,
-            sort:     [{ field: 'metadata.name', asc: true }],
-            filters:  [PaginationParamFilter.createSingleField({ field: 'metadata.name', value: term, exact: false })],
+            page:                 1,
+            pageSize:             WORKLOAD_SEARCH_RESULTS_PER_TYPE,
+            sort:                 [{ field: 'metadata.name', asc: true }],
+            projectsOrNamespaces: namespaceFilter.projectsOrNamespaces,
+            filters:              [
+              ...namespaceFilter.filters,
+              PaginationParamFilter.createSingleField({ field: 'metadata.name', value: term, exact: false }),
+            ],
           },
           transient: true,
           watch:     false,
@@ -76,7 +85,10 @@ export function useWorkloadSearch() {
     loading.value = true;
 
     try {
-      const results = await Promise.all(WORKLOAD_RESOURCE_TYPES.map((type) => fetchOptionsForType(type, term)));
+      const namespaceFilter = getWorkloadNamespaceFilterParams(store);
+      const results = await Promise.all(
+        WORKLOAD_RESOURCE_TYPES.map((type) => fetchOptionsForType(type, term, namespaceFilter))
+      );
 
       if (currentRequestId !== requestId) {
         return;

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
@@ -49,7 +49,11 @@ export function useWorkloadSearch() {
             projectsOrNamespaces: namespaceFilter.projectsOrNamespaces,
             filters:              [
               ...namespaceFilter.filters,
-              PaginationParamFilter.createSingleField({ field: 'metadata.name', value: term, exact: false }),
+              PaginationParamFilter.createSingleField({
+                field: 'metadata.name',
+                value: term,
+                exact: false,
+              }),
             ],
           },
           transient: true,
@@ -66,7 +70,11 @@ export function useWorkloadSearch() {
       const label = t(`typeLabel."${ type }"`, { count: 2 })?.trim() || type;
 
       return [
-        { kind: 'group', label, uniqueId: `group-${ type }` },
+        {
+          kind:     'group',
+          label,
+          uniqueId: `group-${ type }`,
+        },
         ...data.map((resource) => ({
           label:     resource.metadata?.name || '',
           namespace: resource.metadata?.namespace,

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/search/useWorkloadSearch.ts
@@ -1,0 +1,123 @@
+import { ref } from 'vue';
+import { useStore } from 'vuex';
+import { useRouter, type RouteLocationRaw } from 'vue-router';
+import debounce from 'lodash/debounce';
+import { useI18n } from '@shell/composables/useI18n';
+import { PaginationParamFilter } from '@shell/types/store/pagination.types';
+import { WORKLOAD_RESOURCE_TYPES } from '../types';
+import {
+  WORKLOAD_SEARCH_DEBOUNCE_MS,
+  WORKLOAD_SEARCH_RESULTS_PER_TYPE,
+  type WorkloadSearchOption,
+} from './types';
+
+interface WorkloadSearchResource {
+  metadata?: { name?: string; namespace?: string };
+  detailLocation?: RouteLocationRaw;
+}
+
+export function useWorkloadSearch() {
+  const store = useStore();
+  const router = useRouter();
+  const { t } = useI18n(store);
+
+  const searchTerm = ref('');
+  const loading = ref(false);
+  const options = ref<WorkloadSearchOption[]>([]);
+
+  // Guards against a slower, earlier search response overwriting a later one.
+  let requestId = 0;
+
+  async function fetchOptionsForType(type: string, term: string): Promise<WorkloadSearchOption[]> {
+    if (!store.getters['cluster/schemaFor'](type) || !store.getters['cluster/canList'](type)) {
+      return [];
+    }
+
+    try {
+      const res = await store.dispatch('cluster/findPage', {
+        type,
+        opt: {
+          pagination: {
+            page:     1,
+            pageSize: WORKLOAD_SEARCH_RESULTS_PER_TYPE,
+            sort:     [{ field: 'metadata.name', asc: true }],
+            filters:  [PaginationParamFilter.createSingleField({ field: 'metadata.name', value: term, exact: false })],
+          },
+          transient: true,
+          watch:     false,
+        },
+      });
+
+      const data: WorkloadSearchResource[] = res?.data || [];
+
+      if (!data.length) {
+        return [];
+      }
+
+      const label = t(`typeLabel."${ type }"`, { count: 2 })?.trim() || type;
+
+      return [
+        { kind: 'group', label, uniqueId: `group-${ type }` },
+        ...data.map((resource) => ({
+          label:     resource.metadata?.name || '',
+          namespace: resource.metadata?.namespace,
+          uniqueId:  `${ type }/${ resource.metadata?.namespace }/${ resource.metadata?.name }`,
+          value:     resource.detailLocation,
+        })),
+      ];
+    } catch {
+      return [];
+    }
+  }
+
+  async function performSearch(term: string): Promise<void> {
+    const currentRequestId = ++requestId;
+
+    loading.value = true;
+
+    try {
+      const results = await Promise.all(WORKLOAD_RESOURCE_TYPES.map((type) => fetchOptionsForType(type, term)));
+
+      if (currentRequestId !== requestId) {
+        return;
+      }
+
+      options.value = results.flat();
+    } finally {
+      if (currentRequestId === requestId) {
+        loading.value = false;
+      }
+    }
+  }
+
+  const debouncedSearch = debounce(performSearch, WORKLOAD_SEARCH_DEBOUNCE_MS);
+
+  function onSearch(term: string): void {
+    searchTerm.value = term;
+
+    if (!term) {
+      debouncedSearch.cancel();
+      requestId++;
+      options.value = [];
+      loading.value = false;
+
+      return;
+    }
+
+    debouncedSearch(term);
+  }
+
+  function onSelect(route?: RouteLocationRaw): void {
+    if (route) {
+      router.push(route);
+    }
+  }
+
+  return {
+    searchTerm,
+    loading,
+    options,
+    onSearch,
+    onSelect,
+  };
+}


### PR DESCRIPTION
### Summary
Fixes #18232
Adds a search box to the Workload Overview page that lets users find a workload by name across every workload type shown on the page, and jump straight to its detail page.

### Occurred changes and/or fixed issues
- Debounced search input on the Workload Overview page, below the title and above "By State".
- Queries all workload types in parallel, partial-matching on name, sorted alphabetically and capped at 10 results per type.
- Results are grouped by resource type; selecting one navigates to its detail page.
- Search results respect the header's namespace/project filter, same as the rest of the page.

### Technical notes summary
- New `useWorkloadSearch` composable + `WorkloadSearch.vue` (thin `LabeledSelect` wrapper) under `shell/pages/c/_cluster/explorer/workload-dashboard/search/`.
- Uses `cluster/findPage` with `transient: true, watch: false`, so results aren't cached/subscribed, and the classified models' own `detailLocation` gives the route directly.
- Doesn't bind `LabeledSelect`'s `loading` prop, since that disables the input and closes the dropdown mid-keystroke; loading state uses a custom `#no-options` slot instead.
- Extracted the namespace/project-filter computation the "By X" sections already use into a shared `getWorkloadNamespaceFilterParams` helper, reused by both the existing dashboard requests and the new search requests.

### Areas or cases that should be tested
- Typing a partial name shows grouped, sorted, capped results, and clicking one navigates to its detail page.
- Typing continuously, or clearing the input mid-search, doesn't leave stale results or a stuck loading state.
- A user who can only list some workload types sees results silently limited to the types they have access to.
- Changing the header's namespace filter (all namespaces, user/system only, a project, a single namespace) scopes search results the same way it scopes the rest of the page.
- Tested locally against a Rancher instance in Chrome; should be checked in at least one other browser and in dark mode.

### Areas which could experience regressions
- Workload Overview page layout only (Masthead usage is unchanged; the search box is a new row between the subtitle and the By State section).
- The existing "By X" sections' namespace filtering, since their request-building was refactored to share code with search (behavior unchanged, but worth a regression pass).

### Screenshot/Video
Idle state
<img width="1440" height="900" alt="1-idle" src="https://github.com/user-attachments/assets/193e36c9-508e-4731-aef5-fe0d737a3897" />

Dropdown open, empty - "start typing" prompt
<img width="1440" height="900" alt="2-empty-prompt" src="https://github.com/user-attachments/assets/343b72f2-08ac-43ed-a401-e16ecc8cc132" />

Typed partial name - grouped, sorted, capped results across types
<img width="1440" height="900" alt="3-grouped-results" src="https://github.com/user-attachments/assets/9f8392cd-356c-45d9-b8b0-e1aac2e10658" />

No matches for a nonsense term
<img width="1440" height="900" alt="4-no-match" src="https://github.com/user-attachments/assets/6e0df25f-c1fb-475b-b678-0993174e7388" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
