### PR TITLE
Fix missing padding on resource config view for full-page-override types

### DIFF
--- a/shell/components/ResourceDetail/__tests__/index.test.ts
+++ b/shell/components/ResourceDetail/__tests__/index.test.ts
@@ -1,5 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+import {
+  _VIEW, _EDIT, _DETAIL, _CONFIG, _YAML
+} from '@shell/config/query-params';
 
 jest.mock('@shell/mixins/create-edit-view/impl', () => ({
   __esModule: true,
@@ -141,5 +144,38 @@ describe('component: ResourceDetail', () => {
 
     expect((wrapper.vm as any).resourceNotFoundError).toBeNull();
     expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  // fullDetailPageOverride should only apply to the detail view, so the config/YAML
+  // views keep the padded ".outlet" wrapper.
+  describe.each([
+    {
+      desc: 'detail view of a full-page override resource', mode: _VIEW, as: _DETAIL, fullDetailPageOverride: true, expected: true
+    },
+    {
+      desc: 'config view of a full-page override resource', mode: _VIEW, as: _CONFIG, fullDetailPageOverride: true, expected: false
+    },
+    {
+      desc: 'yaml view of a full-page override resource', mode: _VIEW, as: _YAML, fullDetailPageOverride: true, expected: false
+    },
+    {
+      desc: 'detail view of a non-override resource', mode: _VIEW, as: _DETAIL, fullDetailPageOverride: false, expected: false
+    },
+    {
+      desc: 'edit mode of a full-page override resource', mode: _EDIT, as: _CONFIG, fullDetailPageOverride: true, expected: false
+    },
+  ])('isFullPageOverride: $desc', ({
+    mode, as, fullDetailPageOverride, expected
+  }) => {
+    it(`is ${ expected }`, async() => {
+      const store = createStore({ schema: { id: 'bogus-resource-type' } });
+      const { wrapper } = createWrapper(store);
+
+      await wrapper.setData({
+        mode, as, value: { fullDetailPageOverride }
+      });
+
+      expect((wrapper.vm as any).isFullPageOverride).toBe(expected);
+    });
   });
 });

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -334,7 +334,7 @@ export default {
       }), {});
     },
     isFullPageOverride() {
-      return this.isView && this.value?.fullDetailPageOverride && !this.isYaml;
+      return this.isView && this.isDetail && this.value?.fullDetailPageOverride;
     }
   },
 


### PR DESCRIPTION
### Summary
Fixes #17827

### Occurred changes and/or fixed issues
Fixed missing padding around a cluster's config form when viewed by a standard (read-only) user.

### Technical notes summary
`isFullPageOverride` in `ResourceDetail/index.vue` was true for both the detail *and* config views, so the config form skipped the padded `.outlet` wrapper. Padding then relied on the `.outlet` class falling through to the form root, but the cluster edit component sets `inheritAttrs: false`, so it was dropped. Fix restricts the override to the detail view only (`return this.isView && this.isDetail && this.value?.fullDetailPageOverride;`).

Side note: in theory other `fullDetailPageOverride` types with an `inheritAttrs: false` edit component could hit the same path, but this was only reproduced in the original cluster case.

### Areas or cases that should be tested
Tested in Chrome — reviewer please use another browser.
- Reproduce the original issue: add a standard user to a cluster, log in as them, view/edit the cluster — confirm the config form has correct padding.
- Confirm the cluster Detail, Edit, and YAML views are unchanged.

### Areas which could experience regressions
- Cluster Detail/Config/YAML/Edit rendering.
- Other `fullDetailPageOverride` types (Secrets, ConfigMaps, Fleet GitRepo/HelmOp, Harvester mgmt cluster) — verify their detail pages still render correctly.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1722" height="903" alt="image" src="https://github.com/user-attachments/assets/d4d4b326-a130-4249-9538-3782e0030326" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
