### PR TITLE
Update charts loading state

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import Charts from '@shell/pages/c/_cluster/apps/charts/index.vue';
+import AsyncButton from '@shell/components/AsyncButton';
 import { UI_PLUGIN_ANNOTATION } from '@shell/config/uiplugins';
 
 describe('page: Charts Index', () => {
@@ -105,6 +106,55 @@ describe('page: Charts Index', () => {
 
       expect(ctx.isLoadingMore).toBe(false);
       expect(ctx._loadMoreTimer).toBeNull();
+    });
+  });
+
+  describe('progressive loading', () => {
+    const mountCharts = (pending: boolean) => shallowMount(Charts, {
+      global: {
+        mocks: {
+          t:           (key: string) => key,
+          $fetchState: { pending },
+          $route:      { params: { cluster: 'c-1' }, query: {} },
+          $store:      {
+            getters: {
+              currentCluster:      { status: { provider: 'other' }, workerOSs: [] },
+              'catalog/charts':    [],
+              'catalog/errors':    [],
+              'catalog/repos':     [],
+              'prefs/get':         () => false,
+              'i18n/withFallback': (_key: string, _fallback: any, val: string) => val,
+              clusterId:           'c-1',
+              productId:           'apps',
+            },
+          },
+        },
+        directives: { shortkey: () => {} },
+      },
+    });
+
+    it('should render the header, search bar and refresh button while fetching', () => {
+      const wrapper = mountCharts(true);
+
+      expect(wrapper.find('[data-testid="charts-header-title"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="charts-filter-input"]').exists()).toBe(true);
+      expect(wrapper.findComponent(AsyncButton).exists()).toBe(true);
+    });
+
+    it('should disable the search bar and refresh button and show the loading indicator while fetching', () => {
+      const wrapper = mountCharts(true);
+
+      expect(wrapper.find('[data-testid="charts-filter-input"]').attributes('disabled')).toBeDefined();
+      expect(wrapper.findComponent(AsyncButton).props('disabled')).toBe(true);
+      expect(wrapper.find('[data-testid="charts-loading"]').exists()).toBe(true);
+    });
+
+    it('should enable the controls and hide the loading indicator once fetching completes', () => {
+      const wrapper = mountCharts(false);
+
+      expect(wrapper.find('[data-testid="charts-filter-input"]').attributes('disabled')).toBeUndefined();
+      expect(wrapper.findComponent(AsyncButton).props('disabled')).toBe(false);
+      expect(wrapper.find('[data-testid="charts-loading"]').exists()).toBe(false);
     });
   });
 

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -1,7 +1,6 @@
 <script>
 import { markRaw } from 'vue';
 import AsyncButton from '@shell/components/AsyncButton';
-import Loading from '@shell/components/Loading';
 import { Banner } from '@components/Banner';
 import {
   REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, SORT_BY, _FLAGGED, CATEGORY, DEPRECATED, HIDDEN, TAG, STATUS
@@ -44,7 +43,6 @@ export default {
   components: {
     AsyncButton,
     Banner,
-    Loading,
     RcItemCard,
     FilterPanel,
     AppChartCardSubHeader,
@@ -583,8 +581,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
-  <div v-else>
+  <div>
     <div class="header">
       <h1
         data-testid="charts-header-title"
@@ -602,6 +599,7 @@ export default {
         :aria-label="t('catalog.charts.refresh')"
         actionColor="role-secondary"
         successColor="bg-success"
+        :disabled="$fetchState.pending"
         @click="refresh"
       />
     </div>
@@ -614,6 +612,8 @@ export default {
         :placeholder="t('catalog.charts.search')"
         data-testid="charts-filter-input"
         :aria-label="t('catalog.charts.search')"
+        role="textbox"
+        :disabled="$fetchState.pending"
       >
       <i
         v-if="!searchQuery"
@@ -626,199 +626,214 @@ export default {
       @shortkey="focusSearch()"
     />
 
-    <Banner
-      v-for="(err, i) in loadingErrors"
-      :key="i"
-      color="error"
-      :label="err"
-      class="banner-mb-15px"
-    />
-    <Banner
-      v-if="showAppCollectionBannerLogic"
-      :key="i"
-      color="info"
-      closable
-      class="banner-mb-15px"
-      @close="closeSuseAppCollectionBanner"
-    >
-      <RichTranslation
-        k="catalog.charts.appCollectionRepoMissing"
-        tag="div"
-      >
-        <template #repoCreate="{ content }">
-          <router-link
-            :to="{ name: 'c-cluster-product-resource-create', params: { resource: CATALOG_TYPES.CLUSTER_REPO, cluster: $route.params.cluster, product: $store.getters['productId'] }, query: { target: CLUSTER_REPO_TYPES.SUSE_APP_COLLECTION } }"
-            class="secondary-text-link"
-            tabindex="0"
-          >
-            {{ content }}
-          </router-link>
-        </template>
-      </RichTranslation>
-    </Banner>
     <div
-      v-if="showAppCollectionBannerLogic || showErrorBanner"
-      class="banner-spacer"
-    />
-
-    <div class="wrapper">
-      <FilterPanel
-        :modelValue="internalFilters"
-        :filters="filterPanelFilters"
-        @update:modelValue="onFilterChange"
+      v-if="$fetchState.pending"
+      class="charts-loading"
+      role="status"
+      aria-live="polite"
+      data-testid="charts-loading"
+    >
+      <i class="icon icon-spinner icon-spin" />
+      <t
+        k="generic.loading"
+        :raw="true"
+      />
+    </div>
+    <template v-else>
+      <Banner
+        v-for="(err, i) in loadingErrors"
+        :key="i"
+        color="error"
+        :label="err"
+        class="banner-mb-15px"
+      />
+      <Banner
+        v-if="showAppCollectionBannerLogic"
+        :key="i"
+        color="info"
+        closable
+        class="banner-mb-15px"
+        @close="closeSuseAppCollectionBanner"
+      >
+        <RichTranslation
+          k="catalog.charts.appCollectionRepoMissing"
+          tag="div"
+        >
+          <template #repoCreate="{ content }">
+            <router-link
+              :to="{ name: 'c-cluster-product-resource-create', params: { resource: CATALOG_TYPES.CLUSTER_REPO, cluster: $route.params.cluster, product: $store.getters['productId'] }, query: { target: CLUSTER_REPO_TYPES.SUSE_APP_COLLECTION } }"
+              class="secondary-text-link"
+              tabindex="0"
+            >
+              {{ content }}
+            </router-link>
+          </template>
+        </RichTranslation>
+      </Banner>
+      <div
+        v-if="showAppCollectionBannerLogic || showErrorBanner"
+        class="banner-spacer"
       />
 
-      <div
-        v-if="filteredCharts.length === 0"
-        class="charts-empty-state"
-        data-testid="charts-empty-state"
-      >
-        <h1
-          class="empty-state-title"
-          data-testid="charts-empty-state-title"
-        >
-          {{ t('catalog.charts.noCharts.title') }}
-        </h1>
-        <div class="empty-state-tips">
-          <RichTranslation k="catalog.charts.noCharts.message">
-            <template #resetAllFilters="{ content }">
-              <a
-                tabindex="0"
-                role="button"
-                class="link"
-                data-testid="charts-empty-state-reset-filters"
-                @click="resetAllFilters"
-                @keyup.enter="resetAllFilters"
-                @keyup.space="resetAllFilters"
-              >{{ content }}</a>
-            </template>
-            <template #repositoriesUrl="{ content }">
-              <router-link :to="{ name: 'c-cluster-apps-catalog-repo'}">
-                {{ content }}
-              </router-link>
-            </template>
-          </RichTranslation>
-          <RichTranslation
-            k="catalog.charts.noCharts.docsMessage"
-            tag="span"
-          >
-            <template #docsUrl="{ content }">
-              <SubtleLink
-                :href="`${DOCS_BASE}/how-to-guides/new-user-guides/helm-charts-in-rancher`"
-                target="_blank"
-                :open-in-new-tab-label="t('generic.opensInNewTab')"
-              >
-                {{ content }}
-              </SubtleLink>
-            </template>
-          </RichTranslation>
-        </div>
-      </div>
-      <div
-        v-else
-        class="right-section"
-      >
-        <div class="total-and-sort">
-          <div class="total">
-            <p
-              class="total-message"
-              data-testid="charts-total-message"
-            >
-              {{ totalMessage }}
-            </p>
-            <a
-              v-if="!noFiltersApplied"
-              class="reset-filters"
-              role="button"
-              :aria-label="t('catalog.charts.resetFilters.title')"
-              @click="resetAllFilters"
-            >
-              {{ t('catalog.charts.resetFilters.title') }}
-            </a>
-          </div>
-          <Select
-            v-model:value="selectedSortOption"
-            :clearable="false"
-            :searchable="false"
-            :options="sortOptions"
-            placement="bottom"
-            class="charts-sort-select"
-          >
-            <template #selected-option="{ label }">
-              <span class="mmr-1">{{ t('catalog.charts.sort.prefix') }}:</span>{{ label }}
-            </template>
-
-            <template #option="{ label, kind }">
-              <span
-                v-if="kind === 'group'"
-                class="mml-2 mmr-2"
-              >
-                {{ label }}:
-              </span>
-              <span
-                v-else
-                class="mml-6"
-              >
-                {{ label }}
-              </span>
-            </template>
-          </Select>
-        </div>
-        <div
-          ref="chartsContainer"
-          class="app-chart-cards"
-          data-testid="app-chart-cards-container"
-        >
-          <rc-item-card
-            v-for="card in appChartCards"
-            :id="card.id"
-            :key="card.id"
-            :pill="card.pill"
-            :header="card.header"
-            :image="card.image"
-            :content="card.content"
-            :value="card.rawChart"
-            variant="medium"
-            role="link"
-            :class="{ 'single-card': appChartCards.length === 1 }"
-            :clickable="true"
-            @card-click="selectChart"
-          >
-            <template
-              v-once
-              #item-card-sub-header
-            >
-              <AppChartCardSubHeader :items="card.subHeaderItems" />
-            </template>
-            <template
-              v-once
-              #item-card-footer
-            >
-              <AppChartCardFooter
-                :items="card.footerItems"
-                :clickable="true"
-                @click:item="handleFooterItemClick"
-              />
-            </template>
-          </rc-item-card>
-        </div>
-        <div
-          v-if="isLoadingMore"
-          class="loading-more"
-          role="status"
-          aria-live="polite"
-          data-testid="charts-loading-more"
-        >
-          <i class="icon icon-spinner icon-spin" />
-          {{ t('catalog.charts.loadingMore') }}
-        </div>
-        <div
-          ref="sentinel"
-          class="sentinel-charts"
-          data-testid="charts-lazy-load-sentinel"
+      <div class="wrapper">
+        <FilterPanel
+          :modelValue="internalFilters"
+          :filters="filterPanelFilters"
+          @update:modelValue="onFilterChange"
         />
+
+        <div
+          v-if="filteredCharts.length === 0"
+          class="charts-empty-state"
+          data-testid="charts-empty-state"
+        >
+          <h1
+            class="empty-state-title"
+            data-testid="charts-empty-state-title"
+          >
+            {{ t('catalog.charts.noCharts.title') }}
+          </h1>
+          <div class="empty-state-tips">
+            <RichTranslation k="catalog.charts.noCharts.message">
+              <template #resetAllFilters="{ content }">
+                <a
+                  tabindex="0"
+                  role="button"
+                  class="link"
+                  data-testid="charts-empty-state-reset-filters"
+                  @click="resetAllFilters"
+                  @keyup.enter="resetAllFilters"
+                  @keyup.space="resetAllFilters"
+                >{{ content }}</a>
+              </template>
+              <template #repositoriesUrl="{ content }">
+                <router-link :to="{ name: 'c-cluster-apps-catalog-repo'}">
+                  {{ content }}
+                </router-link>
+              </template>
+            </RichTranslation>
+            <RichTranslation
+              k="catalog.charts.noCharts.docsMessage"
+              tag="span"
+            >
+              <template #docsUrl="{ content }">
+                <SubtleLink
+                  :href="`${DOCS_BASE}/how-to-guides/new-user-guides/helm-charts-in-rancher`"
+                  target="_blank"
+                  :open-in-new-tab-label="t('generic.opensInNewTab')"
+                >
+                  {{ content }}
+                </SubtleLink>
+              </template>
+            </RichTranslation>
+          </div>
+        </div>
+        <div
+          v-else
+          class="right-section"
+        >
+          <div class="total-and-sort">
+            <div class="total">
+              <p
+                class="total-message"
+                data-testid="charts-total-message"
+              >
+                {{ totalMessage }}
+              </p>
+              <a
+                v-if="!noFiltersApplied"
+                class="reset-filters"
+                role="button"
+                :aria-label="t('catalog.charts.resetFilters.title')"
+                @click="resetAllFilters"
+              >
+                {{ t('catalog.charts.resetFilters.title') }}
+              </a>
+            </div>
+            <Select
+              v-model:value="selectedSortOption"
+              :clearable="false"
+              :searchable="false"
+              :options="sortOptions"
+              placement="bottom"
+              class="charts-sort-select"
+            >
+              <template #selected-option="{ label }">
+                <span class="mmr-1">{{ t('catalog.charts.sort.prefix') }}:</span>{{ label }}
+              </template>
+
+              <template #option="{ label, kind }">
+                <span
+                  v-if="kind === 'group'"
+                  class="mml-2 mmr-2"
+                >
+                  {{ label }}:
+                </span>
+                <span
+                  v-else
+                  class="mml-6"
+                >
+                  {{ label }}
+                </span>
+              </template>
+            </Select>
+          </div>
+          <div
+            ref="chartsContainer"
+            class="app-chart-cards"
+            data-testid="app-chart-cards-container"
+          >
+            <rc-item-card
+              v-for="card in appChartCards"
+              :id="card.id"
+              :key="card.id"
+              :pill="card.pill"
+              :header="card.header"
+              :image="card.image"
+              :content="card.content"
+              :value="card.rawChart"
+              variant="medium"
+              role="link"
+              :class="{ 'single-card': appChartCards.length === 1 }"
+              :clickable="true"
+              @card-click="selectChart"
+            >
+              <template
+                v-once
+                #item-card-sub-header
+              >
+                <AppChartCardSubHeader :items="card.subHeaderItems" />
+              </template>
+              <template
+                v-once
+                #item-card-footer
+              >
+                <AppChartCardFooter
+                  :items="card.footerItems"
+                  :clickable="true"
+                  @click:item="handleFooterItemClick"
+                />
+              </template>
+            </rc-item-card>
+          </div>
+          <div
+            v-if="isLoadingMore"
+            class="loading-more"
+            role="status"
+            aria-live="polite"
+            data-testid="charts-loading-more"
+          >
+            <i class="icon icon-spinner icon-spin" />
+            {{ t('catalog.charts.loadingMore') }}
+          </div>
+          <div
+            ref="sentinel"
+            class="sentinel-charts"
+            data-testid="charts-lazy-load-sentinel"
+          />
+        </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -947,6 +962,24 @@ export default {
 
   .single-card {
     max-width: 500px;
+  }
+}
+
+.charts-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap);
+  padding: 48px 16px;
+  font-size: 14px;
+  color: var(--muted);
+
+  .icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
   }
 }
 

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -645,14 +645,14 @@ export default {
         :key="i"
         color="error"
         :label="err"
-        class="banner-mb-15px"
+        class="chart-banner"
       />
       <Banner
         v-if="showAppCollectionBannerLogic"
         :key="i"
         color="info"
         closable
-        class="banner-mb-15px"
+        class="chart-banner"
         @close="closeSuseAppCollectionBanner"
       >
         <RichTranslation
@@ -983,8 +983,8 @@ export default {
   }
 }
 
-.banner-mb-15px {
-  margin: 0 0 15px 0;
+.chart-banner {
+  margin: 0 0 16px 0;
 }
 
 .banner-spacer {

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -612,7 +612,6 @@ export default {
         :placeholder="t('catalog.charts.search')"
         data-testid="charts-filter-input"
         :aria-label="t('catalog.charts.search')"
-        role="textbox"
         :disabled="$fetchState.pending"
       >
       <i


### PR DESCRIPTION
### Summary
Fixes #18910

### Occurred changes and/or fixed issues
The Charts page no longer blanks the whole content area while loading. The header, search bar, and "Refresh all repositories" button now render immediately (disabled), with an inline loading indicator underneath. Once charts load, they appear and the controls become enabled.

### Technical notes summary
- Removed the full-screen `<Loading>` gate in `shell/pages/c/_cluster/apps/charts/index.vue`; the page shell now always renders and the content below is gated on `$fetchState.pending`.
- Search input and refresh button use `:disabled="$fetchState.pending"`.
- Added an inline loading indicator matching the latest app convention (`gap: var(--gap)`, `color: var(--muted)`), with the spinner icon given fixed dimensions to prevent a layout jump when the icon font loads.
- Added unit tests covering the loading (disabled + indicator) and loaded (enabled + no indicator) states.

### Areas or cases that should be tested
- Navigate to **Apps → Charts** and confirm the header, disabled search bar, and disabled refresh button show immediately with a loading indicator below, then charts render and controls enable.
- Verify no visual "jump" of the loading text as the page loads.
- Tested locally on Chrome — please review on a different browser (e.g. Firefox).

### Areas which could experience regressions
- Charts page: search, sort, filter panel, lazy-loading/infinite scroll, refresh repositories.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/48c1ce79-1d2d-40d0-ba9b-e0267bd2285b


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
