### PR TITLE
add release channel input to gke provisioning

### DIFF
--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -7,9 +7,7 @@ import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 
 import {
-  DEFAULT_GCP_REGION, DEFAULT_GCP_ZONE, getGKEZones, getGKERegionFromZone,
-  getGKEVersions, getGKEClusters,
-
+  DEFAULT_GCP_REGION, DEFAULT_GCP_ZONE, getGKEZones, getGKERegionFromZone, getGKEClusters
 } from '@shell/components/google/util/gcp';
 import { sortBy, sortableNumericSuffix } from '@shell/utils/sort';
 
@@ -24,7 +22,7 @@ import { mapGetters } from 'vuex';
 export default defineComponent({
   name: 'GKEConfig',
 
-  emits: ['update:kubernetesVersion', 'update:locations', 'update:zone', 'update:region', 'update:defaultImageType', 'error', 'update:clusterName', 'update:clusterDescription'],
+  emits: ['update:kubernetesVersion', 'update:locations', 'update:zone', 'update:region', 'update:defaultImageType', 'error', 'update:clusterName', 'update:clusterDescription', 'update:releaseChannel'],
 
   components: {
     RadioGroup,
@@ -94,12 +92,27 @@ export default defineComponent({
       default: ''
     },
 
+    releaseChannel: {
+      type:    String,
+      default: ''
+    },
+
     defaultImageType: {
       type:    String,
       default: ''
     },
 
     isImport: {
+      type:    Boolean,
+      default: false
+    },
+
+    versionsResponse: {
+      type:    Object as PropType<getGKEVersionsResponse>,
+      default: () => ({})
+    },
+
+    loadingVersions: {
       type:    Boolean,
       default: false
     },
@@ -123,10 +136,9 @@ export default defineComponent({
 
     return {
       debouncedLoadGCPData: (zones = true) => {},
-      loadingVersions:      false,
       loadingZones:         false,
+      versionTouched:       false, // track whether the user has set a k8s version. Changing release channel will only change version automatically if they haven't
 
-      versionsResponse: {} as getGKEVersionsResponse,
       /**
        * these are NOT cluster objects in the Rancher cluster (management.cattle.io.cluster provisioning.cattle.io.cluster etc)
        * this is a list of clusters in the user's GCP project, which, on edit, will include the current cluster
@@ -141,12 +153,6 @@ export default defineComponent({
   },
 
   watch: {
-    versionOptions(neu) {
-      if (neu && neu.length && !this.kubernetesVersion) {
-        this.$emit('update:kubernetesVersion', this.versionOptions[0].value);
-      }
-    },
-
     cloudCredentialId() {
       this.debouncedLoadGCPData();
     },
@@ -185,6 +191,12 @@ export default defineComponent({
           this.$emit('update:locations', [defaultExtraZone]);
         }
       }
+    },
+
+    defaultVersion(neu) {
+      if (this.isNewOrUnprovisioned && !this.versionTouched && neu) {
+        this.$emit('update:kubernetesVersion', neu);
+      }
     }
   },
 
@@ -199,7 +211,8 @@ export default defineComponent({
       return this.mode === _VIEW;
     },
 
-    releaseChannel(): string | undefined {
+    // older gke clusters might not have releaseChannel defined in the Rancher object
+    releaseChannelFallback(): string | undefined {
       const cluster = (this.clustersResponse?.clusters || []).find((c) => c.name === this.clusterName);
 
       return cluster?.releaseChannel?.channel;
@@ -285,7 +298,26 @@ export default defineComponent({
       return this.zones[0].name;
     },
 
-    // if editing an existing cluster use versions from relevant release channel
+    defaultVersion() {
+      if (!this.releaseChannel) {
+        return this.versionOptions[0]?.value;
+      }
+      const channelData = (this.versionsResponse?.channels || []).find((c) => c.channel === this.releaseChannel);
+
+      return channelData?.defaultVersion;
+    },
+
+    // todo nb put constants somewhere
+    releaseChannelOptions(): {label: string, value: string}[] {
+      return [
+        { value: 'RAPID', label: this.t('gke.channel.options.RAPID') },
+        { value: 'REGULAR', label: this.t('gke.channel.options.REGULAR') },
+        { value: 'STABLE', label: this.t('gke.channel.options.STABLE') },
+        { value: 'EXTENDED', label: this.t('gke.channel.options.EXTENDED') }
+      ];
+    },
+
+    // use versions from release channel
     // filter based off supported version range
     // if current cluster version is outside of supported range, show it anyway
     // disable versions more than one minor version away from the current version
@@ -294,9 +326,10 @@ export default defineComponent({
       let versions: string[] = [];
       const { supportedVersionRange, originalVersion } = this;
       const originalMinorVersion = !!originalVersion ? semver.parse(originalVersion).minor : null;
+      const releaseChannel = this.releaseChannel || this.releaseChannelFallback;
 
-      if (!!this.releaseChannel) {
-        versions = (this.versionsResponse?.channels || []).find((ch) => ch.channel === this.releaseChannel)?.validVersions || [];
+      if (!!releaseChannel) {
+        versions = (this.versionsResponse?.channels || []).find((ch) => ch.channel === releaseChannel)?.validVersions || [];
       }
       if (!versions || !versions.length) {
         versions = this.versionsResponse?.validMasterVersions || [];
@@ -327,7 +360,7 @@ export default defineComponent({
       }
 
       return out;
-    },
+    }
   },
   methods: {
     // when credential/region/zone change, fetch dependent resources from gcp
@@ -335,8 +368,6 @@ export default defineComponent({
       if (!this.isView) {
         // wont show a version picker when initially importing a cluster
         if (!this.isImport) {
-          this.loadingVersions = true;
-          this.getVersions();
         }
 
         if (loadZones) {
@@ -348,21 +379,6 @@ export default defineComponent({
           this.getClusters();
         }
       }
-    },
-
-    async getVersions() {
-      try {
-        const res = await getGKEVersions(this.$store, this.cloudCredentialId, this.projectId, { zone: this.zone, region: this.region });
-
-        this.versionsResponse = res;
-        if (res.defaultImageType) {
-          this.$emit('update:defaultImageType', res.defaultImageType);
-        }
-      } catch (err:any) {
-        this.$emit('error', err);
-      }
-
-      this.loadingVersions = false;
     },
 
     async getClusters() {
@@ -425,7 +441,7 @@ export default defineComponent({
 <template>
   <div>
     <div class="row mb-10">
-      <div :class="{col: true, 'span-4': !isImport, 'span-6': isImport}">
+      <div class="col span-6">
         <LabeledInput
           :value="clusterName"
           :mode="mode"
@@ -436,7 +452,7 @@ export default defineComponent({
           @update:value="$emit('update:clusterName', $event)"
         />
       </div>
-      <div :class="{col: true, 'span-4': !isImport, 'span-6': isImport}">
+      <div class="col span-6">
         <LabeledInput
           :value="clusterDescription"
           :mode="mode"
@@ -446,10 +462,23 @@ export default defineComponent({
           @update:value="$emit('update:clusterDescription', $event)"
         />
       </div>
-      <div
-        v-if="!isImport"
-        class="col span-4"
-      >
+    </div>
+
+    <div
+      v-if="!isImport"
+      class="row mb-10"
+    >
+      <div class="col span-6">
+        <LabeledSelect
+          label-key="gke.channel.label"
+          :options="releaseChannelOptions"
+          :value="releaseChannel"
+          data-testid="gke-release-channel-select"
+          :mode="mode"
+          @selecting="$emit('update:releaseChannel', $event)"
+        />
+      </div>
+      <div class="col span-6">
         <LabeledSelect
           :options="versionOptions"
           label-key="gke.version.label"
@@ -458,7 +487,8 @@ export default defineComponent({
           :loading="loadingVersions"
           data-testid="gke-version-select"
           :mode="mode"
-          @selecting="$emit('update:kubernetesVersion', $event)"
+          :rules="rules.kubernetesVersion"
+          @selecting="versionTouched=true; $emit('update:kubernetesVersion', $event)"
         />
       </div>
     </div>

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -31,13 +31,13 @@ import GKENodePoolComponent from './GKENodePool.vue';
 import Config from './Config.vue';
 import Import from './Import.vue';
 import {
-  DEFAULT_GCP_ZONE, DEFAULT_GCP_SERVICE_ACCOUNT, GKEImageTypes, getGKEMachineTypes, getGKEServiceAccounts
+  DEFAULT_GCP_ZONE, DEFAULT_GCP_SERVICE_ACCOUNT, GKEImageTypes, getGKEMachineTypes, getGKEServiceAccounts, getGKEVersions
 } from '@shell/components/google/util/gcp';
-import type { getGKEMachineTypesResponse, getGKEServiceAccountsResponse } from '@shell/components/google/types/gcp.d.ts';
+import type { getGKEMachineTypesResponse, getGKEServiceAccountsResponse, getGKEVersionsResponse } from '@shell/components/google/types/gcp.d.ts';
 import type { GKEMachineTypeOption } from '@shell/components/google/types/index.d.ts';
 import debounce from 'lodash/debounce';
 import {
-  clusterNameChars, clusterNameStartEnd, requiredInCluster, ipv4WithCidr, ipv4oripv6WithCidr, GKEInitialCount
+  clusterNameChars, clusterNameStartEnd, requiredInCluster, ipv4WithCidr, ipv4oripv6WithCidr, GKEInitialCount, GKEKubernetesVersion
 } from '../util/validators';
 import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
 import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
@@ -116,9 +116,10 @@ const defaultGkeConfig = {
   },
   projectID: '',
 
-  region:     '',
-  subnetwork: '',
-  zone:       DEFAULT_GCP_ZONE
+  region:         '',
+  releaseChannel: 'REGULAR', // TODO nb constants
+  subnetwork:     '',
+  zone:           DEFAULT_GCP_ZONE
 };
 
 const defaultCluster = {
@@ -268,10 +269,11 @@ export default defineComponent({
 
       loadingMachineTypes:     false,
       loadingServiceAccounts:  false,
+      loadingVersions:         false,
       machineTypesResponse:    {} as getGKEMachineTypesResponse,
       serviceAccountsResponse: {} as getGKEServiceAccountsResponse,
-
-      fvFormRuleSets: isImport ? [{
+      versionsResponse:        {} as getGKEVersionsResponse,
+      fvFormRuleSets:          isImport ? [{
         path:  'clusterName',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd']
       }, {
@@ -328,6 +330,10 @@ export default defineComponent({
         {
           path:  'privateRegistry',
           rules: ['privateRegistryRequired']
+        },
+        {
+          path:  'kubernetesVersion',
+          rules: ['kubernetesVersion']
         },
       ],
       isAuthenticated: false,
@@ -404,6 +410,7 @@ export default defineComponent({
         servicesIpv4CidrBlockFormat: ipv4WithCidr(this, 'gke.servicesIpv4CidrBlock.label', 'gkeConfig.ipAllocationPolicy.servicesIpv4CidrBlock'),
         clusterIpv4CidrFormat:       ipv4oripv6WithCidr(this, 'gke.clusterIpv4Cidr.label', 'gkeConfig.clusterIpv4Cidr'),
         initialNodeCount:            GKEInitialCount(this),
+        kubernetesVersion:           GKEKubernetesVersion(this, 'gkeConfig.kubernetesVersion'),
         /**
          * The nodepool validators below are performing double duty. When passed directly to an input, the val argument is provided and validated - this generates the error icon in the input component.
          * otherwise they're run in the fv mixin and ALL nodepools are validated - this disables the cruresource create button
@@ -620,6 +627,7 @@ export default defineComponent({
         if (this.config.projectID && this.config.googleCredentialSecret) {
           this.getMachineTypes();
           this.getServiceAccounts();
+          this.getVersions();
         }
       }
     },
@@ -654,6 +662,24 @@ export default defineComponent({
         errors.push(err);
       }
       this.loadingServiceAccounts = false;
+    },
+
+    async getVersions() {
+      this.loadingVersions = true;
+      const zone = this.config.zone || this.config.locations?.[0];
+
+      try {
+        const res = await getGKEVersions(this.$store, this.config.googleCredentialSecret, this.config.projectID, { zone, region: this.config.region });
+
+        this.versionsResponse = res;
+        if (res?.defaultImageType) {
+          this.defaultImageType = res.defaultImageType;
+        }
+      } catch (err:any) {
+        this.errors.push(err);
+      }
+
+      this.loadingVersions = false;
     },
 
     addPool(): void {
@@ -771,6 +797,7 @@ export default defineComponent({
       data-testid="crugke-form"
     >
       <Config
+        v-model:release-channel="config.releaseChannel"
         v-model:kubernetes-version="config.kubernetesVersion"
         v-model:zone="config.zone"
         v-model:region="config.region"
@@ -784,8 +811,11 @@ export default defineComponent({
         :cluster-id="normanCluster.id"
         :cluster-name="normanCluster.name"
         :cluster-description="normanCluster.description"
+        :versions-response="versionsResponse"
+        :loading-versions="loadingVersions"
         :rules="{
-          clusterName: fvGetAndReportPathRules('clusterName')
+          clusterName: fvGetAndReportPathRules('clusterName'),
+          kubernetesVersion: fvGetAndReportPathRules('kubernetesVersion')
         }"
         :is-import="isImport"
         @update:clusterName="setClusterName"

--- a/pkg/gke/l10n/en-us.yaml
+++ b/pkg/gke/l10n/en-us.yaml
@@ -52,6 +52,13 @@ gke:
     label: Auto Upgrade
   autoscaling:
     label: Autoscaling
+  channel:
+    label: Release Channel
+    options:
+      REGULAR: Regular
+      RAPID: Rapid
+      STABLE: Stable
+      EXTENDED: Extended
   clusterIpv4Cidr:
     label: Container Address Range
     placeholder: 10.0.0.0/14
@@ -91,6 +98,7 @@ gke:
     minNodeCount: Minimum Node Count must be at least 1.
     poolNamesUnique: Pool group names must be unique.
     ssdCount: SSD Count must be a positive number.
+    versionNotSupported: This version is not available in the selected release channel.
   groupDetails: Group Details
   groupName:
     label: Name

--- a/pkg/gke/util/validators.ts
+++ b/pkg/gke/util/validators.ts
@@ -85,3 +85,15 @@ export const GKEInitialCount = (ctx:any) => {
     return !!ctx.nodePools.find((pool: GKENodePool) => !valid(pool.initialNodeCount) ) ? ctx.t('gke.errors.initialNodeCount') : null;
   };
 };
+
+export const GKEKubernetesVersion = (ctx:any, clusterPath: string) => {
+  return () => {
+    const toValidate = get(ctx.normanCluster, clusterPath);
+    const selectedChannel = ctx?.config?.releaseChannel;
+
+    const versionsResponse = ctx?.versionsResponse || {};
+    const versionOptions = (versionsResponse?.channels || []).find((c) => c.channel === selectedChannel)?.validVersions;
+
+    return versionOptions && versionOptions.length && !versionOptions.includes(toValidate) ? ctx.t('gke.errors.versionNotSupported') : null;
+  };
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18916
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds a dropdown to select release channels when creating/editing GKE clusters.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- When the release channel is changed and the version has not been manually set, the version should automatically change to the new channel's default
- When the release channel is changed and the version HAS been manually set, the version should be validated against the new list of available versions, and an error should be shown if the version isn't available in that channel
- Users should be able to change the release channel when editing, if their kubernetes version is supported by the new release channel

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/29b57f14-f720-4128-871c-8e67ee986d58



### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
