### PR TITLE
Automation: Fix cy.login() fn for Prime

### DIFF
--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -107,8 +107,13 @@ export class LoginPagePo extends PagePo {
     return this.self(MEDIUM_TIMEOUT_OPT).find('.login-welcome');
   }
 
-  isWelcomeMessage(vendor = 'Rancher') {
-    return this.welcomeMessage().contains(`Welcome to ${ vendor }`).should('be.visible');
+  /**
+   * Assert the login page heading has rendered.
+   * Don't assert its text: the heading renders `t(welcomeLabelKey, { vendor })`, and both the label
+   * key and the vendor change with the `ui-brand` and `ui-pl` settings.
+   */
+  isWelcomeMessage() {
+    return this.welcomeMessage().should('be.visible');
   }
 
   /**

--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -107,13 +107,8 @@ export class LoginPagePo extends PagePo {
     return this.self(MEDIUM_TIMEOUT_OPT).find('.login-welcome');
   }
 
-  /**
-   * Assert the login page heading has rendered.
-   * Don't assert its text: the heading renders `t(welcomeLabelKey, { vendor })`, and both the label
-   * key and the vendor change with the `ui-brand` and `ui-pl` settings.
-   */
-  isWelcomeMessage() {
-    return this.welcomeMessage().should('be.visible');
+  isWelcomeMessage(vendor = 'Rancher', expectedMessage = `Welcome to ${ vendor }`) {
+    return this.welcomeMessage().contains(expectedMessage).should('be.visible');
   }
 
   /**

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -150,7 +150,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.waitForTitle();
 
     // if rancher prime, title should be Rancher Prime - Extensions, otherewise Rancher - Extensions
-    cy.getRancherVersion().then((version) => {
+    cy.getRancherVersion(true).then((version) => {
       const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - Extensions' : 'Rancher - Extensions';
 
       cy.title().should('eq', expectedTitle);

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -143,7 +143,7 @@ declare global {
       }): Chainable;
       applyDefaultTestTheme(): Chainable<any>;
       restoreProductDefaultTestTheme(): Chainable<any>;
-      getRancherVersion(): Chainable<RancherVersion>;
+      getRancherVersion(forceRefresh?: boolean): Chainable<RancherVersion>;
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -9,6 +9,7 @@ import { base64Encode } from '@/cypress/support/utils/shell';
 // It includes the `login` command to store the `token` to use
 
 let token: any;
+let rancherVersion: Cypress.RancherVersion | undefined;
 
 /**
  * Login local authentication, including first login and bootstrap if not cached
@@ -496,17 +497,26 @@ Cypress.Commands.add('requestBase64Image', (url: string) => {
 
 /**
  * Get Rancher version info from /rancherversion (includes RancherPrime for product type).
+ * @param forceRefresh Bypass the cached response, for example after mocking /rancherversion.
  */
-Cypress.Commands.add('getRancherVersion', () => {
+Cypress.Commands.add('getRancherVersion', (forceRefresh = false): Cypress.Chainable<Cypress.RancherVersion> => {
+  if (rancherVersion && !forceRefresh) {
+    return cy.wrap<Cypress.RancherVersion>(rancherVersion);
+  }
+
   return cy.request({
     method:           'GET',
     url:              `${ Cypress.env('api') }/rancherversion`,
     headers:          { Accept: 'application/json' },
     failOnStatusCode: false
-  }).then((resp) => {
+  }).then<Cypress.RancherVersion>((resp) => {
     expect(resp.status).to.eq(200);
 
-    return JSON.parse(resp.body);
+    const version: Cypress.RancherVersion = JSON.parse(resp.body);
+
+    rancherVersion = version;
+
+    return version;
   });
 });
 

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -38,7 +38,11 @@ Cypress.Commands.add('login', (
     loginPage.checkIsCurrentPage(!skipNavigation);
 
     if (!skipNavigation) {
-      loginPage.isWelcomeMessage();
+      cy.getRancherVersion().then((version) => {
+        const expectedMessage = version.RancherPrime === 'true' ? 'Login' : 'Welcome to Rancher';
+
+        loginPage.isWelcomeMessage('Rancher', expectedMessage);
+      });
     }
 
     if (!!acceptConfirmation) {
@@ -495,12 +499,9 @@ Cypress.Commands.add('requestBase64Image', (url: string) => {
  */
 Cypress.Commands.add('getRancherVersion', () => {
   return cy.request({
-    method:  'GET',
-    url:     `${ Cypress.env('api') }/rancherversion`,
-    headers: {
-      'x-api-csrf': token.value,
-      Accept:       'application/json'
-    },
+    method:           'GET',
+    url:              `${ Cypress.env('api') }/rancherversion`,
+    headers:          { Accept: 'application/json' },
     failOnStatusCode: false
   }).then((resp) => {
     expect(resp.status).to.eq(200);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2519

Cache Rancher version information for the test run and reuse it for login welcome message checks. Tests mocking `/rancherversion` can bypass the cache with `cy.getRancherVersion(true)`.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
Before
<img width="1438" height="625" alt="Screenshot 2026-08-25 at 5 01 53 PM" src="https://github.com/user-attachments/assets/e2054908-b00c-4032-99c9-08b92519bf42" />

After
<img width="1488" height="535" alt="Screenshot 2026-08-25 at 4 51 50 PM" src="https://github.com/user-attachments/assets/5c4500f6-cccc-4594-9855-0a751b4d6d77" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
