### PR TITLE
[backport 2.15.2] Automation: Fix cy.login() fn for Prime

### DIFF
--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -58,8 +58,13 @@ export class LoginPagePo extends PagePo {
     return this.self(MEDIUM_TIMEOUT_OPT).find('.login-welcome');
   }
 
-  isWelcomeMessage(vendor = 'Rancher') {
-    return this.welcomeMessage().contains(`Welcome to ${ vendor }`).should('be.visible');
+  /**
+   * Assert the login page heading has rendered.
+   * Don't assert its text: the heading renders `t(welcomeLabelKey, { vendor })`, and both the label
+   * key and the vendor change with the `ui-brand` and `ui-pl` settings.
+   */
+  isWelcomeMessage() {
+    return this.welcomeMessage().should('be.visible');
   }
 
   /**

--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -58,13 +58,8 @@ export class LoginPagePo extends PagePo {
     return this.self(MEDIUM_TIMEOUT_OPT).find('.login-welcome');
   }
 
-  /**
-   * Assert the login page heading has rendered.
-   * Don't assert its text: the heading renders `t(welcomeLabelKey, { vendor })`, and both the label
-   * key and the vendor change with the `ui-brand` and `ui-pl` settings.
-   */
-  isWelcomeMessage() {
-    return this.welcomeMessage().should('be.visible');
+  isWelcomeMessage(vendor = 'Rancher', expectedMessage = `Welcome to ${ vendor }`) {
+    return this.welcomeMessage().contains(expectedMessage).should('be.visible');
   }
 
   /**

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -142,7 +142,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.waitForTitle();
 
     // if rancher prime, title should be Rancher Prime - Extensions, otherewise Rancher - Extensions
-    cy.getRancherVersion().then((version) => {
+    cy.getRancherVersion(true).then((version) => {
       const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - Extensions' : 'Rancher - Extensions';
 
       cy.title().should('eq', expectedTitle);

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -128,7 +128,7 @@ declare global {
       }): Chainable;
       applyDefaultTestTheme(): Chainable<any>;
       restoreProductDefaultTestTheme(): Chainable<any>;
-      getRancherVersion(): Chainable<RancherVersion>;
+      getRancherVersion(forceRefresh?: boolean): Chainable<RancherVersion>;
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -9,6 +9,7 @@ import { base64Encode } from '@shell/utils/crypto/index.js';
 // It includes the `login` command to store the `token` to use
 
 let token: any;
+let rancherVersion: Cypress.RancherVersion | undefined;
 
 /**
  * Login local authentication, including first login and bootstrap if not cached
@@ -34,7 +35,11 @@ Cypress.Commands.add('login', (
     loginPage.checkIsCurrentPage(!skipNavigation);
 
     if (!skipNavigation) {
-      loginPage.isWelcomeMessage();
+      cy.getRancherVersion().then((version) => {
+        const expectedMessage = version.RancherPrime === 'true' ? 'Login' : 'Welcome to Rancher';
+
+        loginPage.isWelcomeMessage('Rancher', expectedMessage);
+      });
     }
 
     if (!!acceptConfirmation) {
@@ -470,20 +475,26 @@ Cypress.Commands.add('requestBase64Image', (url: string) => {
 
 /**
  * Get Rancher version info from /rancherversion (includes RancherPrime for product type).
+ * @param forceRefresh Bypass the cached response, for example after mocking /rancherversion.
  */
-Cypress.Commands.add('getRancherVersion', () => {
+Cypress.Commands.add('getRancherVersion', (forceRefresh = false): Cypress.Chainable<Cypress.RancherVersion> => {
+  if (rancherVersion && !forceRefresh) {
+    return cy.wrap<Cypress.RancherVersion>(rancherVersion);
+  }
+
   return cy.request({
-    method:  'GET',
-    url:     `${ Cypress.env('api') }/rancherversion`,
-    headers: {
-      'x-api-csrf': token.value,
-      Accept:       'application/json'
-    },
+    method:           'GET',
+    url:              `${ Cypress.env('api') }/rancherversion`,
+    headers:          { Accept: 'application/json' },
     failOnStatusCode: false
-  }).then((resp) => {
+  }).then<Cypress.RancherVersion>((resp) => {
     expect(resp.status).to.eq(200);
 
-    return JSON.parse(resp.body);
+    const version: Cypress.RancherVersion = JSON.parse(resp.body);
+
+    rancherVersion = version;
+
+    return version;
   });
 });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2519

Backport of https://github.com/rancher/dashboard/pull/18921

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
