### PR TITLE
Improve initial scan result

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1586,6 +1586,8 @@ compliance:
   testsToSkip: Tests to Skip
   alerting: Alerting
   detail:
+    noReport: 'No scan report is available yet. Current scan state: {state}. The report will appear here once the scan completes.'
+    noReportWithMessage: 'No scan report is available yet. Current scan state: {state} - {message}. The report will appear here once the scan completes.'
     subRow:
       noNodes: No Additional Information
 

--- a/shell/detail/compliance.cattle.io.clusterscan.vue
+++ b/shell/detail/compliance.cattle.io.clusterscan.vue
@@ -88,57 +88,76 @@ export default {
       });
     },
 
-    details() {
-      if (!this.parsedReport) {
-        return [];
-      }
+    profileName() {
+      return this.value.status?.lastRunScanProfileName || this.value.spec?.scanProfileName;
+    },
 
-      const out = [
-        {
+    statusMessage() {
+      const conditions = this.value.status?.conditions || [];
+      const transitioning = conditions.find((c) => c.transitioning && c.message);
+
+      return transitioning?.message || this.value.status?.display?.message || '';
+    },
+
+    details() {
+      const out = [];
+
+      if (this.profileName) {
+        out.push({
           label: this.t('compliance.profile'),
-          value: this.value.status.lastRunScanProfileName,
+          value: this.profileName,
           to:    {
             name:   'c-cluster-product-resource-id',
             params: {
               ...this.$route.params,
               resource: COMPLIANCE.CLUSTER_SCAN_PROFILE,
-              id:       this.value.status.lastRunScanProfileName
+              id:       this.profileName
             }
           }
-        },
-        {
-          label: this.t('compliance.scan.total'),
-          value: this.parsedReport.total
-        },
-        {
-          label: this.t('compliance.scan.pass'),
-          value: this.parsedReport.pass
-        },
-        {
-          label: this.t('compliance.scan.warn'),
-          value: this.parsedReport.warn
-        },
-        {
-          label: this.t('compliance.scan.skip'),
-          value: this.parsedReport.skip
-        },
-        {
-          label: this.t('compliance.scan.fail'),
-          value: this.parsedReport.fail
-        },
-        {
-          label: this.t('compliance.scan.notApplicable'),
-          value: this.parsedReport.notApplicable
-        },
-        {
+        });
+      }
+
+      if (this.parsedReport) {
+        out.push(
+          {
+            label: this.t('compliance.scan.total'),
+            value: this.parsedReport.total
+          },
+          {
+            label: this.t('compliance.scan.pass'),
+            value: this.parsedReport.pass
+          }
+        );
+
+        if (this.canBeScheduled) {
+          out.push({
+            label: this.t('compliance.scan.warn'),
+            value: this.parsedReport.warn
+          });
+        }
+
+        out.push(
+          {
+            label: this.t('compliance.scan.skip'),
+            value: this.parsedReport.skip
+          },
+          {
+            label: this.t('compliance.scan.fail'),
+            value: this.parsedReport.fail
+          },
+          {
+            label: this.t('compliance.scan.notApplicable'),
+            value: this.parsedReport.notApplicable
+          }
+        );
+      }
+
+      if (this.value.status?.lastRunTimestamp) {
+        out.push({
           label:     this.canBeScheduled ? this.t('compliance.scan.lastScanTime') : this.t('compliance.scan.scanDate'),
           value:     this.value.status.lastRunTimestamp,
           component: 'Date'
-        },
-      ];
-
-      if (!this.canBeScheduled) {
-        return out.filter((each) => each.label !== this.t('compliance.scan.warn'));
+        });
       }
 
       return out;
@@ -261,7 +280,17 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
-    <div class="detail mb-20">
+    <Banner
+      v-if="!parsedReport"
+      color="info"
+      :label="statusMessage
+        ? t('compliance.detail.noReportWithMessage', { state: value.stateDisplay, message: statusMessage })
+        : t('compliance.detail.noReport', { state: value.stateDisplay })"
+    />
+    <div
+      v-if="details.length"
+      class="detail mb-20"
+    >
       <div
         v-for="(item, i) in details"
         :key="i"


### PR DESCRIPTION
### Summary
Fixes #3186

Better represent the state of a Compliance scan on its detail page while the initial scan is still running (or has failed to produce a report). Previously the detail page appeared blank until a report was available.

### Occurred changes and/or fixed issues
- Added an info Banner on the scan detail page that appears whenever no report is available, showing the scan's current state and (when present) the latest transitioning condition message (e.g. "Creating Job to run the Compliance scan").
- The scan profile (as a link) and last-run timestamp now render on the detail page as soon as they're known, instead of only after a report exists.
- Hid the empty details strip that previously rendered a bordered box with no content when no report was available.

### Technical notes summary
- `shell/detail/compliance.cattle.io.clusterscan.vue`
  - Added `profileName` computed that falls back from `status.lastRunScanProfileName` to `spec.scanProfileName`.
  - Added `statusMessage` computed that surfaces the first transitioning condition message, falling back to `status.display.message`.
  - Refactored `details` to build the item list conditionally: profile and last-run are always included when known; report-derived items (total/pass/warn/skip/fail/notApplicable) are added only when `parsedReport` exists. Existing behavior (order, `warn` only shown when scannable can be scheduled) is preserved when a report is present.
  - Template: added the Banner, and guarded the `.detail` container with `v-if="details.length"`.
- `shell/assets/translations/en-us.yaml`
  - Added `compliance.detail.noReport` and `compliance.detail.noReportWithMessage` strings.

### Areas or cases that should be tested
- Install the CIS Benchmark chart on a fresh cluster and create a scan; open the new scan's detail page immediately.
  - Expect: info banner with scan state and current condition message, plus profile link and last-run timestamp.
- Wait for the scan to complete and refresh: expect the standard detail view with the full details strip, report selector (if multiple reports), and results table — unchanged from previous behavior.
- Trigger a scan failure (e.g. delete the job or use an invalid profile): expect the banner to show the failed state instead of a blank page.
- Verify a scheduled scan detail page still shows the `Warn` column when a report exists.
- Tested locally in Chrome.

### Areas which could experience regressions
- `details` computed on the scan detail page — item order, conditional `warn` for scheduled scans, and empty-state handling.
- Rendering of the top details strip on the scan detail page.

### Screenshot/Video

<img width="1182" height="653" alt="image" src="https://github.com/user-attachments/assets/f009952a-58c4-49c3-bfb2-e6d61597a85a" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
