### PR TITLE
Added characterization tests for RKE2 refactor

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -854,4 +854,869 @@ describe('component: rke2', () => {
       expect(vm.value.spec.existing).toBe('field');
     });
   });
+
+  // Characterization tests written ahead of extracting Kubernetes-version resolution
+  // (versionOptions/selectedVersion/chartVersions/defaultVersion/fetchRke2Versions/cloudProviderOptions)
+  // into a composable.
+  describe('kubernetes version resolution', () => {
+    const version = (id: string, overrides: Record<string, any> = {}) => ({
+      id, serverArgs: {}, agentArgs: {}, charts: {}, ...overrides
+    });
+
+    const baseVm = {
+      mode:                        _CREATE,
+      value:                       { spec: {} },
+      liveValue:                   { spec: {} },
+      agentConfig:                 {},
+      showDeprecatedPatchVersions: true,
+      rke2Versions:                [] as any[],
+      k3sVersions:                 [] as any[],
+      defaultRke2:                 '',
+      defaultK3s:                  '',
+      isHarvesterDriver:           false,
+      $store:                      { getters: { 'i18n/t': (key: string) => key } },
+      t:                           (key: string) => key,
+    };
+
+    describe('versionOptions', () => {
+      it('groups rke2 and k3s versions with a header when both are present', () => {
+        const vm = {
+          ...baseVm,
+          rke2Versions: [version('v1.28.0+rke2r1')],
+          k3sVersions:  [version('v1.28.0+k3s1')],
+        };
+
+        const options = (rke2.computed as any).versionOptions.call(vm);
+
+        expect(options[0]).toStrictEqual({ kind: 'group', label: 'cluster.provider.rke2' });
+        expect(options.some((o: any) => o.value === 'v1.28.0+rke2r1')).toBe(true);
+        expect(options.some((o: any) => o.kind === 'group' && o.label === 'cluster.provider.k3s')).toBe(true);
+        expect(options.some((o: any) => o.value === 'v1.28.0+k3s1')).toBe(true);
+      });
+
+      it('omits the k3s group when only rke2 versions are present', () => {
+        const vm = { ...baseVm, rke2Versions: [version('v1.28.0+rke2r1')] };
+
+        const options = (rke2.computed as any).versionOptions.call(vm);
+
+        expect(options.some((o: any) => o.kind === 'group')).toBe(false);
+        expect(options).toHaveLength(1);
+        expect(options[0].value).toBe('v1.28.0+rke2r1');
+      });
+
+      it('excludes k3s versions in edit mode when the live version is rke2', () => {
+        const vm = {
+          ...baseVm,
+          mode:         _EDIT,
+          liveValue:    { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
+          rke2Versions: [version('v1.28.0+rke2r1'), version('v1.29.0+rke2r1')],
+          k3sVersions:  [version('v1.28.0+k3s1')],
+        };
+
+        const options = (rke2.computed as any).versionOptions.call(vm);
+
+        expect(options.some((o: any) => o.value?.includes('k3s'))).toBe(false);
+      });
+
+      it('filters out deprecated patch versions by default', () => {
+        const vm = {
+          ...baseVm,
+          showDeprecatedPatchVersions: false,
+          rke2Versions:                [version('v1.28.0+rke2r1'), version('v1.28.1+rke2r1')],
+        };
+
+        const options = (rke2.computed as any).versionOptions.call(vm);
+
+        expect(options.map((o: any) => o.value)).toStrictEqual(['v1.28.1+rke2r1']);
+      });
+    });
+
+    describe('selectedVersion', () => {
+      it('returns undefined when no kubernetesVersion is set', () => {
+        const vm = {
+          ...baseVm, value: { spec: {} }, versionOptions: []
+        };
+
+        expect((rke2.computed as any).selectedVersion.call(vm)).toBeUndefined();
+      });
+
+      it('finds the matching version option by kubernetesVersion', () => {
+        const match = { value: 'v1.28.0+rke2r1', serverArgs: {} };
+        const vm = {
+          ...baseVm,
+          value:          { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
+          versionOptions: [match, { value: 'v1.29.0+rke2r1' }],
+        };
+
+        expect((rke2.computed as any).selectedVersion.call(vm)).toBe(match);
+      });
+
+      it('adds a "none" cni option once, without duplicating it on repeated access', () => {
+        const match = { value: 'v1.28.0+rke2r1', serverArgs: { cni: { options: ['calico'] } } };
+        const vm = {
+          ...baseVm,
+          value:          { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
+          versionOptions: [match],
+        };
+
+        (rke2.computed as any).selectedVersion.call(vm);
+        (rke2.computed as any).selectedVersion.call(vm);
+
+        expect(match.serverArgs.cni.options).toStrictEqual(['calico', 'none']);
+      });
+    });
+
+    describe('chartVersions', () => {
+      it('returns the charts of the selected version', () => {
+        const vm = { selectedVersion: { charts: { 'rke2-ingress-nginx': { version: '1.0.0' } } } };
+
+        expect((rke2.computed as any).chartVersions.call(vm)).toStrictEqual({ 'rke2-ingress-nginx': { version: '1.0.0' } });
+      });
+
+      it('returns an empty object when there is no selected version', () => {
+        const vm = { selectedVersion: undefined };
+
+        expect((rke2.computed as any).chartVersions.call(vm)).toStrictEqual({});
+      });
+    });
+
+    describe('defaultVersion', () => {
+      it('prefers the version matching the defaultRke2 setting when present among version options', () => {
+        const vm = {
+          ...baseVm,
+          versionOptions: [{ value: 'v1.29.0+rke2r1' }, { value: 'v1.28.0+rke2r1' }],
+          defaultRke2:    'v1.28.0+rke2r1',
+          rke2Versions:   [],
+        };
+
+        expect((rke2.computed as any).defaultVersion.call(vm)).toBe('v1.28.0+rke2r1');
+      });
+
+      it('falls back to the first version option when defaultRke2 is not among the options', () => {
+        const vm = {
+          ...baseVm,
+          versionOptions: [{ value: 'v1.29.0+rke2r1' }, { value: 'v1.28.0+rke2r1' }],
+          defaultRke2:    'v1.99.0+rke2r1',
+          rke2Versions:   [],
+        };
+
+        expect((rke2.computed as any).defaultVersion.call(vm)).toBe('v1.29.0+rke2r1');
+      });
+
+      it('prefers the first Harvester-compatible rke2 version when on the Harvester driver', () => {
+        const vm = {
+          ...baseVm,
+          versionOptions:    [{ value: 'v1.29.0+rke2r1' }],
+          defaultRke2:       '',
+          isHarvesterDriver: true,
+          rke2Versions:      [version('v1.20.0+rke2r1'), version('v1.25.0+rke2r1')],
+        };
+
+        expect((rke2.computed as any).defaultVersion.call(vm)).toBe('v1.25.0+rke2r1');
+      });
+    });
+
+    describe('cloudProviderOptions', () => {
+      const cpBaseVm = () => ({
+        provider:                      'custom',
+        agentConfig:                   {},
+        isHarvesterExternalCredential: false,
+        isHarvesterIncompatible:       false,
+        $store:                        {
+          getters: {
+            'i18n/t':                         (key: string) => key,
+            'i18n/withFallback':              (_key: string, _fallback: any, opt: string) => opt,
+            'plugins/cloudProviderForDriver': () => undefined,
+          },
+        },
+      });
+
+      it('always excludes the azure option, even when the driver lists it', () => {
+        const vm = { ...cpBaseVm(), agentArgs: { 'cloud-provider-name': { options: ['azure', 'amazon'] } } };
+
+        const options = (rke2.computed as any).cloudProviderOptions.call(vm);
+
+        expect(options.find((o: any) => o.value === 'azure')).toBeUndefined();
+        expect(options.find((o: any) => o.value === 'amazon')).toBeDefined();
+      });
+
+      it('shows every non-azure option when there is no preferred provider', () => {
+        const vm = { ...cpBaseVm(), agentArgs: { 'cloud-provider-name': { options: ['amazon', 'external', 'vsphere'] } } };
+
+        const options = (rke2.computed as any).cloudProviderOptions.call(vm);
+
+        expect(options.map((o: any) => o.value)).toStrictEqual(['', 'amazon', 'external', 'vsphere']);
+      });
+
+      it('only shows the default, preferred and external options when a preferred provider exists', () => {
+        const base = cpBaseVm();
+        const vm = {
+          ...base,
+          $store:    { getters: { ...base.$store.getters, 'plugins/cloudProviderForDriver': () => 'vsphere' } },
+          agentArgs: { 'cloud-provider-name': { options: ['amazon', 'external', 'vsphere'] } },
+        };
+
+        const options = (rke2.computed as any).cloudProviderOptions.call(vm);
+
+        expect(options.map((o: any) => o.value)).toStrictEqual(['', 'external', 'vsphere']);
+      });
+
+      it('disables the preferred option when the Harvester credential is external or incompatible', () => {
+        const base = cpBaseVm();
+        const vm = {
+          ...base,
+          isHarvesterIncompatible: true,
+          $store:                  { getters: { ...base.$store.getters, 'plugins/cloudProviderForDriver': () => 'harvester' } },
+          agentArgs:               { 'cloud-provider-name': { options: ['harvester', 'external'] } },
+        };
+
+        const options = (rke2.computed as any).cloudProviderOptions.call(vm);
+
+        expect(options.find((o: any) => o.value === 'harvester').disabled).toBe(true);
+      });
+
+      it('prepends the current cloud provider as "(Current)" when it is not among the listed options', () => {
+        const vm = {
+          ...cpBaseVm(),
+          agentConfig: { 'cloud-provider-name': 'legacy-provider' },
+          agentArgs:   { 'cloud-provider-name': { options: ['amazon'] } },
+        };
+
+        const options = (rke2.computed as any).cloudProviderOptions.call(vm);
+
+        expect(options[0]).toStrictEqual({ label: 'legacy-provider (Current)', value: 'legacy-provider' });
+      });
+    });
+  });
+
+  // Characterization tests written ahead of extracting fetchRke2Versions into a composable.
+  describe('methods: fetchRke2Versions', () => {
+    const buildStore = ({ canListPsa = false, settings = [] as any[], channelResponses = {} as Record<string, any[]> } = {}) => {
+      const dispatch = jest.fn((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (action === 'management/request') {
+          if (url === '/v1-rke2-release/releases') {
+            return Promise.resolve({ data: [{ id: 'v1.28.0+rke2r1', serverArgs: {} }] });
+          }
+          if (url === '/v1-k3s-release/releases') {
+            return Promise.resolve({ data: [{ id: 'v1.28.0+k3s1', serverArgs: {} }] });
+          }
+          if (url === '/v1-rke2-release/channels') {
+            return Promise.resolve({ data: channelResponses.rke2 || [] });
+          }
+          if (url === '/v1-k3s-release/channels') {
+            return Promise.resolve({ data: channelResponses.k3s || [] });
+          }
+        }
+
+        if (action === 'management/findAll') {
+          return Promise.resolve([]);
+        }
+
+        return Promise.resolve();
+      });
+
+      return {
+        dispatch,
+        getters: {
+          'management/canList': () => canListPsa,
+          'management/all':     () => settings,
+        },
+      };
+    };
+
+    it('does nothing when versions are already loaded', async() => {
+      const dispatch = jest.fn();
+      const vm = { rke2Versions: [{ id: 'cached' }], $store: { dispatch, getters: {} } } as any;
+
+      await (rke2.methods as any).fetchRke2Versions.call(vm);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('populates versions and default versions from global settings when present', async() => {
+      const vm = {
+        rke2Versions: null,
+        k3sVersions:  null,
+        $store:       buildStore({
+          settings: [
+            { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+            { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+          ],
+        }),
+      } as any;
+
+      await (rke2.methods as any).fetchRke2Versions.call(vm);
+
+      expect(vm.rke2Versions).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
+      expect(vm.k3sVersions).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
+      expect(vm.defaultRke2).toBe('v1.28.0+rke2r1');
+      expect(vm.defaultK3s).toBe('v1.28.0+k3s1');
+    });
+
+    it('falls back to the default channel latest version when no setting value/default exists', async() => {
+      const vm = {
+        rke2Versions: null,
+        k3sVersions:  null,
+        $store:       buildStore({
+          settings:         [],
+          channelResponses: {
+            rke2: [{ id: 'default', latest: 'v1.29.0+rke2r1' }],
+            k3s:  [{ id: 'default', latest: 'v1.29.0+k3s1' }],
+          },
+        }),
+      } as any;
+
+      await (rke2.methods as any).fetchRke2Versions.call(vm);
+
+      expect(vm.defaultRke2).toBe('v1.29.0+rke2r1');
+      expect(vm.defaultK3s).toBe('v1.29.0+k3s1');
+    });
+
+    it('throws when no version info is returned for either distro', async() => {
+      const dispatch = jest.fn((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (url?.includes('/releases') || url?.includes('/channels')) {
+          return Promise.resolve({ data: [] });
+        }
+
+        return Promise.resolve();
+      });
+      const vm = {
+        rke2Versions: null,
+        k3sVersions:  null,
+        $store:       { dispatch, getters: { 'management/canList': () => false, 'management/all': () => [] } },
+      } as any;
+
+      await expect((rke2.methods as any).fetchRke2Versions.call(vm)).rejects.toThrow('No version info found in KDM');
+    });
+  });
+
+  // Characterization tests written ahead of extracting machine-pool orchestration into a composable.
+  describe('methods: removeMachinePool', () => {
+    it('does nothing when the index does not exist', () => {
+      const vm: any = { machinePools: [{ create: true }] };
+
+      (rke2.methods as any).removeMachinePool.call(vm, 5);
+
+      expect(vm.machinePools).toHaveLength(1);
+    });
+
+    it('drops a not-yet-saved pool entirely', () => {
+      const pool = { create: true };
+      const vm: any = { machinePools: [pool] };
+
+      (rke2.methods as any).removeMachinePool.call(vm, 0);
+
+      expect(vm.machinePools).toHaveLength(0);
+    });
+
+    it('marks an existing pool for removal instead of deleting it', () => {
+      const pool: { create: boolean; remove?: boolean } = { create: false };
+      const vm: any = { machinePools: [pool] };
+
+      (rke2.methods as any).removeMachinePool.call(vm, 0);
+
+      expect(vm.machinePools).toHaveLength(1);
+      expect(pool.remove).toBe(true);
+    });
+  });
+
+  describe('methods: machinePoolValidationChanged', () => {
+    it('records the validation state for a pool', () => {
+      const vm: any = { machinePoolValidation: {} };
+
+      (rke2.methods as any).machinePoolValidationChanged.call(vm, 'pool-1', false);
+
+      expect(vm.machinePoolValidation['pool-1']).toBe(false);
+    });
+
+    it('removes the entry when the value is undefined', () => {
+      const vm: any = { machinePoolValidation: { 'pool-1': false } };
+
+      (rke2.methods as any).machinePoolValidationChanged.call(vm, 'pool-1', undefined);
+
+      expect(vm.machinePoolValidation).not.toHaveProperty('pool-1');
+    });
+  });
+
+  // Characterization tests written ahead of extracting registry configuration into a composable.
+  describe('methods: initRegistry', () => {
+    const buildVm = (overrides: Record<string, any> = {}) => {
+      const { systemRegistryValue, ...rest } = overrides;
+
+      return {
+        agentConfig: {},
+        rkeConfig:   {},
+        ...rest,
+        $store:      { dispatch: jest.fn().mockResolvedValue({ value: systemRegistryValue ?? '' }) },
+      } as any;
+    };
+
+    it('prefers the cluster-scoped registry over the global system registry', async() => {
+      const vm = buildVm({ agentConfig: { 'system-default-registry': 'cluster.registry.io' }, systemRegistryValue: 'global.registry.io' });
+
+      await (rke2.methods as any).initRegistry.call(vm);
+
+      expect(vm.registryHost).toBe('cluster.registry.io');
+    });
+
+    it('falls back to the global system registry when no cluster-scoped registry is set', async() => {
+      const vm = buildVm({ systemRegistryValue: 'global.registry.io' });
+
+      await (rke2.methods as any).initRegistry.call(vm);
+
+      expect(vm.registryHost).toBe('global.registry.io');
+      expect(vm.systemRegistry).toBe('global.registry.io');
+    });
+
+    it('initializes empty registries/configs/mirrors when none exist', async() => {
+      const vm = buildVm();
+
+      await (rke2.methods as any).initRegistry.call(vm);
+
+      expect(vm.rkeConfig.registries).toStrictEqual({ configs: {}, mirrors: {} });
+    });
+
+    it('picks up an existing auth secret for the resolved registry host and shows the custom registry input', async() => {
+      const vm = buildVm({
+        systemRegistryValue: 'my.registry.io',
+        rkeConfig:           { registries: { configs: { 'my.registry.io': { authConfigSecretName: 'my-secret' } } } },
+      });
+
+      await (rke2.methods as any).initRegistry.call(vm);
+
+      expect(vm.registrySecret).toBe('my-secret');
+      expect(vm.showCustomRegistryInput).toBe(true);
+    });
+
+    it('shows the advanced registry input when mirrors are configured', async() => {
+      const vm = buildVm({ rkeConfig: { registries: { mirrors: { 'docker.io': { endpoint: ['https://mirror.example.com'] } } } } });
+
+      await (rke2.methods as any).initRegistry.call(vm);
+
+      expect(vm.showCustomRegistryAdvancedInput).toBe(true);
+    });
+  });
+
+  describe('methods: setRegistryConfig', () => {
+    it('clears the override when there is no hostname and a system registry is set', () => {
+      const vm: any = {
+        registryHost: '', systemRegistry: 'global.registry.io', registrySecret: null, agentConfig: {}, value: { spec: {} }
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.agentConfig['system-default-registry']).toBeUndefined();
+    });
+
+    it('clears the override when the hostname matches the system registry', () => {
+      const vm: any = {
+        registryHost: 'global.registry.io', systemRegistry: 'global.registry.io', registrySecret: null, agentConfig: {}, value: { spec: {} }
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.agentConfig['system-default-registry']).toBeUndefined();
+    });
+
+    it('sets the override to the hostname when it differs from the system registry', () => {
+      const vm: any = {
+        registryHost: 'custom.registry.io', systemRegistry: 'global.registry.io', registrySecret: null, agentConfig: {}, value: { spec: {} }
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.agentConfig['system-default-registry']).toBe('custom.registry.io');
+    });
+
+    it('sets the override to the hostname when there is no system registry', () => {
+      const vm: any = {
+        registryHost: 'custom.registry.io', systemRegistry: '', registrySecret: null, agentConfig: {}, value: { spec: {} }
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.agentConfig['system-default-registry']).toBe('custom.registry.io');
+    });
+
+    it('creates rkeConfig with the basic auth config when none exists', () => {
+      const vm: any = {
+        registryHost: 'custom.registry.io', systemRegistry: '', registrySecret: 'my-secret', agentConfig: {}, value: { spec: {} }
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.value.spec.rkeConfig.registries.configs['custom.registry.io']).toStrictEqual({
+        authConfigSecretName: 'my-secret', caBundle: null, insecureSkipVerify: false, tlsSecretName: null,
+      });
+    });
+
+    it('merges the basic auth config alongside existing registry configs', () => {
+      const vm: any = {
+        registryHost:   'custom.registry.io',
+        systemRegistry: '',
+        registrySecret: 'my-secret',
+        agentConfig:    {},
+        value:          { spec: { rkeConfig: { registries: { configs: { 'other.registry.io': { authConfigSecretName: 'other-secret' } } } } } },
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      const configs = vm.value.spec.rkeConfig.registries.configs;
+
+      expect(Object.keys(configs).sort()).toStrictEqual(['custom.registry.io', 'other.registry.io']);
+    });
+
+    it('adds a configs entry alongside existing mirrors when no configs exist yet', () => {
+      const vm: any = {
+        registryHost:   'custom.registry.io',
+        systemRegistry: '',
+        registrySecret: 'my-secret',
+        agentConfig:    {},
+        value:          { spec: { rkeConfig: { registries: { mirrors: { 'docker.io': {} } } } } },
+      };
+
+      (rke2.methods as any).setRegistryConfig.call(vm);
+
+      expect(vm.value.spec.rkeConfig.registries.mirrors).toStrictEqual({ 'docker.io': {} });
+      expect(vm.value.spec.rkeConfig.registries.configs['custom.registry.io']).toBeDefined();
+    });
+  });
+
+  describe('methods: updateConfigs', () => {
+    it('initializes rkeConfig when missing and sets the configs', () => {
+      const vm: any = { value: { spec: {} } };
+      const configs = { 'registry.io': {} };
+
+      (rke2.methods as any).updateConfigs.call(vm, configs);
+
+      expect(vm.value.spec.rkeConfig.registries.configs).toBe(configs);
+    });
+
+    it('sets the configs on an existing rkeConfig', () => {
+      const vm: any = { value: { spec: { rkeConfig: { registries: {} } } } };
+      const configs = { 'registry.io': {} };
+
+      (rke2.methods as any).updateConfigs.call(vm, configs);
+
+      expect(vm.value.spec.rkeConfig.registries.configs).toBe(configs);
+    });
+  });
+
+  describe('methods: registry input handlers', () => {
+    it('updates the registry host', () => {
+      const vm: any = { registryHost: null };
+
+      (rke2.methods as any).handleRegistryHostChanged.call(vm, 'registry.io');
+
+      expect(vm.registryHost).toBe('registry.io');
+    });
+
+    it('updates the registry secret', () => {
+      const vm: any = { registrySecret: null };
+
+      (rke2.methods as any).handleRegistrySecretChanged.call(vm, 'my-secret');
+
+      expect(vm.registrySecret).toBe('my-secret');
+    });
+
+    describe('toggleCustomRegistry', () => {
+      it('sets showCustomRegistryInput and clears an existing host/secret', () => {
+        const vm: any = {
+          showCustomRegistryInput: false, registryHost: 'registry.io', registrySecret: 'secret', initRegistry: jest.fn(),
+        };
+
+        (rke2.methods as any).toggleCustomRegistry.call(vm, true);
+
+        expect(vm.showCustomRegistryInput).toBe(true);
+        expect(vm.registryHost).toBeNull();
+        expect(vm.registrySecret).toBeNull();
+        expect(vm.initRegistry).not.toHaveBeenCalled();
+      });
+
+      it('re-initializes the registry when there is no existing host', () => {
+        const vm: any = {
+          showCustomRegistryInput: false, registryHost: null, registrySecret: null, initRegistry: jest.fn(),
+        };
+
+        (rke2.methods as any).toggleCustomRegistry.call(vm, true);
+
+        expect(vm.initRegistry).toHaveBeenCalledWith();
+      });
+    });
+  });
+
+  // Characterization tests written ahead of extracting chart/addon value handling into a composable.
+  describe('methods: getChartValue', () => {
+    it('does nothing when there is no chart version entry for the chart', async() => {
+      const dispatch = jest.fn();
+      const vm: any = {
+        chartVersions: {}, versionInfo: {}, userChartValues: {}, $store: { dispatch }, chartVersionKey: (n: string) => n,
+      };
+
+      await (rke2.methods as any).getChartValue.call(vm, 'rke2-ingress-nginx');
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('fetches and stores version info, initializing empty user chart values', async() => {
+      const versionInfo = { questions: [] };
+      const dispatch = jest.fn().mockResolvedValue(versionInfo);
+      const vm: any = {
+        chartVersions:   { 'rke2-ingress-nginx': { repo: 'rke2-charts', version: '1.0.0' } },
+        versionInfo:     {},
+        userChartValues: {},
+        $store:          { dispatch },
+        chartVersionKey: (n: string) => n,
+      };
+
+      await (rke2.methods as any).getChartValue.call(vm, 'rke2-ingress-nginx');
+
+      expect(dispatch).toHaveBeenCalledWith('catalog/getVersionInfo', {
+        repoType: 'cluster', repoName: 'rke2-charts', chartName: 'rke2-ingress-nginx', versionName: '1.0.0',
+      });
+      expect(vm.versionInfo['rke2-ingress-nginx']).toBe(versionInfo);
+      expect(vm.userChartValues['rke2-ingress-nginx']).toStrictEqual({});
+    });
+
+    it('does not overwrite existing user chart values', async() => {
+      const dispatch = jest.fn().mockResolvedValue({});
+      const existing = { foo: 'bar' };
+      const vm: any = {
+        chartVersions:   { 'rke2-ingress-nginx': { repo: 'rke2-charts', version: '1.0.0' } },
+        versionInfo:     {},
+        userChartValues: { 'rke2-ingress-nginx': existing },
+        $store:          { dispatch },
+        chartVersionKey: (n: string) => n,
+      };
+
+      await (rke2.methods as any).getChartValue.call(vm, 'rke2-ingress-nginx');
+
+      expect(vm.userChartValues['rke2-ingress-nginx']).toBe(existing);
+    });
+
+    it('swallows dispatch errors without throwing', async() => {
+      const dispatch = jest.fn().mockRejectedValue(new Error('network error'));
+      const vm: any = {
+        chartVersions:   { 'rke2-ingress-nginx': { repo: 'rke2-charts', version: '1.0.0' } },
+        versionInfo:     {},
+        userChartValues: {},
+        $store:          { dispatch },
+        chartVersionKey: (n: string) => n,
+      };
+
+      await expect((rke2.methods as any).getChartValue.call(vm, 'rke2-ingress-nginx')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('methods: initAddons', () => {
+    it('skips charts that already have version info cached', async() => {
+      const getChartValue = jest.fn();
+      const vm: any = {
+        addonConfigValidation: { stale: true }, isK3s: true, addonNames: ['rke2-cilium'], versionInfo: { 'rke2-cilium': {} }, getChartValue,
+      };
+
+      await (rke2.methods as any).initAddons.call(vm);
+
+      expect(getChartValue).not.toHaveBeenCalled();
+      expect(vm.addonConfigValidation).toStrictEqual({});
+    });
+
+    it('skips the "none" CNI placeholder chart', async() => {
+      const getChartValue = jest.fn();
+      const vm: any = {
+        addonConfigValidation: {}, isK3s: true, addonNames: ['none'], versionInfo: {}, getChartValue,
+      };
+
+      await (rke2.methods as any).initAddons.call(vm);
+
+      expect(getChartValue).not.toHaveBeenCalled();
+    });
+
+    it('fetches remaining addon charts', async() => {
+      const getChartValue = jest.fn();
+      const vm: any = {
+        addonConfigValidation: {}, isK3s: true, addonNames: ['rke2-cilium'], versionInfo: {}, getChartValue,
+      };
+
+      await (rke2.methods as any).initAddons.call(vm);
+
+      expect(getChartValue).toHaveBeenCalledWith('rke2-cilium');
+    });
+
+    it('also fetches the ingress charts for RKE2 (not K3s) clusters', async() => {
+      const getChartValue = jest.fn();
+      const vm: any = {
+        addonConfigValidation: {}, isK3s: false, addonNames: [], versionInfo: {}, getChartValue,
+      };
+
+      await (rke2.methods as any).initAddons.call(vm);
+
+      expect(getChartValue).toHaveBeenCalledWith('rke2-ingress-nginx');
+      expect(getChartValue).toHaveBeenCalledWith('rke2-traefik');
+    });
+
+    it('does not fetch ingress charts for K3s clusters', async() => {
+      const getChartValue = jest.fn();
+      const vm: any = {
+        addonConfigValidation: {}, isK3s: true, addonNames: [], versionInfo: {}, getChartValue,
+      };
+
+      await (rke2.methods as any).initAddons.call(vm);
+
+      expect(getChartValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('methods: refreshYamls', () => {
+    it('calls refresh on yaml-prefixed refs, ignoring others', () => {
+      const yamlRef = { refresh: jest.fn() };
+      const otherRef = { refresh: jest.fn() };
+      const vm: any = {};
+
+      (rke2.methods as any).refreshYamls.call(vm, { yamlEditor: yamlRef, somethingElse: otherRef });
+
+      expect(yamlRef.refresh).toHaveBeenCalledWith();
+      expect(otherRef.refresh).not.toHaveBeenCalled();
+    });
+
+    it('refreshes every entry when the ref is an array', () => {
+      const first = { refresh: jest.fn() };
+      const second = { refresh: jest.fn() };
+      const vm: any = {};
+
+      (rke2.methods as any).refreshYamls.call(vm, { yamlEditor: [first, second] });
+
+      expect(first.refresh).toHaveBeenCalledWith();
+      expect(second.refresh).toHaveBeenCalledWith();
+    });
+
+    it('tolerates an undefined ref entry without throwing', () => {
+      const vm: any = {};
+
+      expect(() => (rke2.methods as any).refreshYamls.call(vm, { yamlEditor: undefined })).not.toThrow();
+    });
+  });
+
+  describe('methods: showAddonConfirmation', () => {
+    it('resolves with the value passed to the confirmation dialog callback', async() => {
+      const dispatch = jest.fn((_action: string, opts: any) => {
+        opts.resources[0](true);
+      });
+      const vm: any = { $store: { dispatch } };
+
+      const result = await (rke2.methods as any).showAddonConfirmation.call(vm, ['rke2-cilium'], 'v1.27.0', 'v1.28.0');
+
+      expect(result).toBe(true);
+      expect(dispatch).toHaveBeenCalledWith('cluster/promptModal', expect.objectContaining({
+        component:      'AddonConfigConfirmationDialog',
+        componentProps: {
+          addonNames: ['rke2-cilium'], previousKubeVersion: 'v1.27.0', newKubeVersion: 'v1.28.0'
+        },
+      }));
+    });
+  });
+
+  describe('methods: chartVersionKey', () => {
+    it('returns a version-qualified key when a matching addon version exists', () => {
+      const vm: any = { addonVersions: [{ name: 'rke2-cilium', version: '1.2.3' }] };
+
+      expect((rke2.methods as any).chartVersionKey.call(vm, 'rke2-cilium')).toBe('rke2-cilium-1.2.3');
+    });
+
+    it('returns the plain chart name when there is no matching addon version', () => {
+      const vm: any = { addonVersions: [] };
+
+      expect((rke2.methods as any).chartVersionKey.call(vm, 'rke2-cilium')).toBe('rke2-cilium');
+    });
+  });
+
+  // Characterization tests written ahead of extracting vSphere/Harvester cloud-provider wiring into a composable.
+  describe('computed: isHarvesterIncompatible', () => {
+    it('returns false when no Harvester version range info is present', () => {
+      const vm: any = { chartVersions: {}, harvesterVersionRange: {} };
+
+      expect((rke2.computed as any).isHarvesterIncompatible.call(vm)).toBe(false);
+    });
+
+    it('returns false when installed chart versions satisfy the Harvester version range', () => {
+      const vm: any = {
+        chartVersions: {
+          'harvester-cloud-provider': { version: '1.2.3' },
+          'harvester-csi-driver':     { version: '1.2.3' },
+        },
+        harvesterVersionRange: {
+          'harvester-cloud-provider': '>=1.0.0',
+          'harvester-csi-provider':   '>=1.0.0',
+        },
+      };
+
+      expect((rke2.computed as any).isHarvesterIncompatible.call(vm)).toBe(false);
+    });
+
+    it('returns true when installed chart versions do not satisfy the Harvester version range', () => {
+      const vm: any = {
+        chartVersions: {
+          'harvester-cloud-provider': { version: '0.5.0' },
+          'harvester-csi-driver':     { version: '0.5.0' },
+        },
+        harvesterVersionRange: {
+          'harvester-cloud-provider': '>=1.0.0',
+          'harvester-csi-provider':   '>=1.0.0',
+        },
+      };
+
+      expect((rke2.computed as any).isHarvesterIncompatible.call(vm)).toBe(true);
+    });
+
+    it('strips a trailing "00" patch suffix from the chart version before comparing', () => {
+      const vm: any = {
+        chartVersions: {
+          'harvester-cloud-provider': { version: '1.2.300' },
+          'harvester-csi-driver':     { version: '1.2.300' },
+        },
+        harvesterVersionRange: {
+          'harvester-cloud-provider': '1.2.3',
+          'harvester-csi-provider':   '1.2.3',
+        },
+      };
+
+      expect((rke2.computed as any).isHarvesterIncompatible.call(vm)).toBe(false);
+    });
+  });
+
+  describe('methods: setHarvesterDefaultCloudProvider', () => {
+    it('sets the cloud provider to harvester when on the Harvester driver, creating, with no existing provider and no incompatibility', () => {
+      const vm: any = {
+        isHarvesterDriver: true, mode: _CREATE, agentConfig: {}, isHarvesterExternalCredential: false, isHarvesterIncompatible: false,
+      };
+
+      (rke2.methods as any).setHarvesterDefaultCloudProvider.call(vm);
+
+      expect(vm.agentConfig['cloud-provider-name']).toBe('harvester');
+    });
+
+    it('clears the cloud provider when not on the Harvester driver', () => {
+      const vm: any = {
+        isHarvesterDriver: false, mode: _CREATE, agentConfig: {}, isHarvesterExternalCredential: false, isHarvesterIncompatible: false,
+      };
+
+      (rke2.methods as any).setHarvesterDefaultCloudProvider.call(vm);
+
+      expect(vm.agentConfig['cloud-provider-name']).toBe('');
+    });
+
+    it('clears the cloud provider when the installed charts are Harvester-incompatible', () => {
+      const vm: any = {
+        isHarvesterDriver: true, mode: _CREATE, agentConfig: {}, isHarvesterExternalCredential: false, isHarvesterIncompatible: true,
+      };
+
+      (rke2.methods as any).setHarvesterDefaultCloudProvider.call(vm);
+
+      expect(vm.agentConfig['cloud-provider-name']).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18939 
<!-- Define findings related to the feature or bug issue. -->
This PR adds tests to ensure that RKE2 functionality remains intact after RKE2 refactor

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
None, this PR adds tests only

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
