### PR TITLE
Lift code freeze and bump milestones

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -32,8 +32,8 @@
     },
     "release-2.15": {
       "milestone": {
-        "version": "v2.15.1",
-        "codeFreeze": true
+        "version": "v2.15.2",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -61,8 +61,8 @@
     },
     "release-2.14": {
       "milestone": {
-        "version": "v2.14.5",
-        "codeFreeze": true
+        "version": "v2.14.6",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -80,8 +80,8 @@
     },
     "release-2.13": {
       "milestone": {
-        "version": "v2.13.9",
-        "codeFreeze": true
+        "version": "v2.13.10",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -99,8 +99,8 @@
     },
     "release-2.12": {
       "milestone": {
-        "version": "v2.12.13",
-        "codeFreeze": true
+        "version": "v2.12.14",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -118,8 +118,8 @@
     },
     "release-2.11": {
       "milestone": {
-        "version": "v2.11.17",
-        "codeFreeze": true
+        "version": "v2.11.18",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
## Post-release: lift code freeze & bump milestones

Prepares the post-release lift of the code freeze applied in rancher/dashboard#18860, so it is ready to merge as soon as the release train finishes. Each release line points at its **next** milestone with its code freeze **lifted** in master's `branches-metadata.json`.

The **v2.14.5 / v2.13.9 / v2.12.13 / v2.11.17** patch releases shipped on 2026-08-26. **v2.15.1** is still in flight, so this is staged now and merges once it lands.

### Milestones bumped (old → new) + freeze lifted
- `release-2.15`: `v2.15.1` → **`v2.15.2`**, `codeFreeze: true → false`
- `release-2.14`: `v2.14.5` → **`v2.14.6`**, `codeFreeze: true → false`
- `release-2.13`: `v2.13.9` → **`v2.13.10`**, `codeFreeze: true → false`
- `release-2.12`: `v2.12.13` → **`v2.12.14`**, `codeFreeze: true → false`
- `release-2.11`: `v2.11.17` → **`v2.11.18`**, `codeFreeze: true → false`

`master`'s own milestone (`v2.16.0`) is unchanged, and no `e2e` or `rancher-rancher-repo` entry is touched.

> **Merge gate (out of automation):** hold until **`v2.15.1`** ships. As of opening, `rancher/rancher` has `v2.15.1-rc1` (2026-08-25) but no final `v2.15.1`, and the `v2.15.1` milestone still has open issues. Merging before then would open `release-2.15` while it is still cutting.

> **Manual gate (out of automation):** the **`v2.11.18` milestone did not exist** and was created as part of this change. The other four target milestones (`v2.15.2`, `v2.14.6`, `v2.13.10`, `v2.12.14`) already existed. Not blocking.

After merging, PRs targeting the release branches should be mergeable again, and the milestone checker from rancher/dashboard#16836 should accept the bumped milestones rather than blocking on the freeze.

Reference: rancher/dashboard#18584, rancher/dashboard#18860, rancher/dashboard#18220

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
