### PR TITLE
fix(workload health): self-load health cells under SSP pagination

### DIFF
--- a/shell/components/formatter/WorkloadHealthScale.vue
+++ b/shell/components/formatter/WorkloadHealthScale.vue
@@ -29,6 +29,10 @@ export default {
     document.removeEventListener('click', this.onClickOutside);
   },
 
+  mounted() {
+    this.loadHealthIfPaginated();
+  },
+
   data() {
     return {
       disabled: false,
@@ -76,6 +80,12 @@ export default {
     startDelayedLoading() {
       this.loading = false;
       this.liveUpdate();
+    },
+
+    loadHealthIfPaginated() {
+      if (this.row?.hasPaginatedWorkloadHealth) {
+        this.startDelayedLoading();
+      }
     },
 
     onClickOutside(event) {

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -677,6 +677,33 @@ export default class Workload extends WorkloadService {
     return this.podSelector ? parse(this.podSelector) : null;
   }
 
+  /**
+   * True when server-side pagination is enabled for this workload type and list health
+   * uses includeAssociatedData instead of the global pod store.
+   */
+  get hasPaginatedWorkloadHealth() {
+    const typesWithEmbeddedHealth = [
+      WORKLOAD_TYPES.DEPLOYMENT,
+      WORKLOAD_TYPES.DAEMON_SET,
+      WORKLOAD_TYPES.STATEFUL_SET,
+      WORKLOAD_TYPES.JOB,
+    ];
+
+    if (!typesWithEmbeddedHealth.includes(this.type)) {
+      return false;
+    }
+
+    return !!this.$getters['paginationEnabled']?.({ id: this.type });
+  }
+
+  get healthAssociatedData() {
+    if (!this.hasPaginatedWorkloadHealth) {
+      return undefined;
+    }
+
+    return this.metadata?.associatedData || [];
+  }
+
   calcPodGauges(pods) {
     const out = { };
     let refPods = pods;
@@ -717,7 +744,51 @@ export default class Workload extends WorkloadService {
     return out;
   }
 
+  calcPodGaugesFromAssociatedData(associatedData) {
+    const out = { };
+
+    if (!Array.isArray(associatedData)) {
+      return out;
+    }
+
+    const refPods = [];
+
+    associatedData.forEach((w) => {
+      if (w.gvk.kind.toLowerCase() !== POD) {
+        return;
+      }
+
+      w.data.forEach((p) => {
+        refPods.push({
+          stateColor:   colorForStateFn(p.state.name, p.state.error === 'true', p.state.transitioning === 'true'),
+          stateDisplay: stateDisplayFn(p.state.name),
+        });
+      });
+    });
+
+    refPods.map((pod) => {
+      const { stateColor, stateDisplay } = pod;
+
+      if (out[stateDisplay]) {
+        out[stateDisplay].count++;
+      } else {
+        out[stateDisplay] = {
+          color: stateColor.replace('text-', ''),
+          count: 1
+        };
+      }
+    });
+
+    return out;
+  }
+
   get podGauges() {
+    const associatedData = this.healthAssociatedData;
+
+    if (associatedData !== undefined) {
+      return this.calcPodGaugesFromAssociatedData(associatedData);
+    }
+
     return this.calcPodGauges(this.pods);
   }
 


### PR DESCRIPTION
### Summary
Fixes rancher/dashboard#18896

When server-side pagination (SSP) is enabled and workload lists use `includeAssociatedData=true`, Workload Health could still read from the global Pod store instead of the embedded associated data.

This happened because:
1. Workloads with **zero Pods** omit `metadata.associatedData` entirely (rather than returning `[]`), so the UI fell back to `this.pods` / `matchingLabelSelector`.
2. `podGauges` previously called `calcPodGauges(this.pods)`, so **`this.pods` was evaluated before the function ran**, even when associated data was present.

This PR routes SSP workload health through `healthAssociatedData` / `calcPodGaugesFromAssociatedData`, treating missing `associatedData` as an empty array when SSP health is enabled.

A follow-up change in `WorkloadHealthScale` loads health cells on mount when `row.hasPaginatedWorkloadHealth` is true, fixing Health column spinners sticking after namespace switches on paginated workload lists (`PaginatedResourceTable` does not forward `forceUpdateLiveAndDelayed`).

---

### Occurred changes and/or fixed issues

**`shell/models/workload.js`**
- Added `hasPaginatedWorkloadHealth` to detect SSP workload types using embedded health data.
- Added `healthAssociatedData` — returns `metadata.associatedData || []` under SSP (missing property treated as empty).
- Added `calcPodGaugesFromAssociatedData()` to compute gauges from API embedded data only.
- Updated `podGauges` to use associated data when SSP health is enabled, avoiding evaluation of `this.pods`.

**`shell/components/formatter/WorkloadHealthScale.vue`**
- Added `loadHealthIfPaginated()` and call it from `mounted` when `row.hasPaginatedWorkloadHealth` is true.
- Non-paginated lists keep existing `delayLoading` behavior via `SortableTable`.

---

### Technical notes summary

- Root cause for #18896: JavaScript evaluates `calcPodGauges(this.pods)` arguments before the call, so the `pods` getter (global store scan) ran even on the SSP path.
- Fix: branch in `podGauges` on `healthAssociatedData !== undefined` before touching `this.pods`.
- `healthAssociatedData` uses `|| []` so 0-pod workloads without `associatedData` in the API response show empty health instead of falling back to the global Pod cache.
- `WorkloadHealthScale` self-load is gated by `hasPaginatedWorkloadHealth` so non-paginated workload lists retain viewport batched `delayLoading` performance.
- No `rowKey` watcher needed: `<tr :key="row.key">` recreates row components on NS switch; `mounted` is sufficient.

---

### Areas or cases that should be tested

**Environment**
- Rancher with **server-side pagination enabled**
- Browser: Chrome (reviewer: Firefox or Safari)

**Issue #18896 — associated data path**
1. Open **Cluster Explorer → Workloads → Deployments** (paginated list).
2. Confirm requests include `includeAssociatedData=true`.
3. **Deployment with Pods** — Health column shows correct pod state breakdown.
4. **Deployment with `replicas: 0`** (no pods) — Health shows empty/no gauges; **must not** trigger global Pod store lookup (`matchingLabelSelector`).
5. Repeat for **DaemonSet**, **StatefulSet**, **Job** where SSP health is supported.

**SSP Health column loading**
1. On paginated Deployment list, switch **Namespace** — Health column should render promptly (no long spinner).
2. Change page / sort / filter — Health column updates correctly.
3. Open workload detail and return to list — Health still renders correctly.

**Non-paginated regression**
1. Disable SSP (or use workload list without pagination).
2. Health column still uses delayed loading (brief spinner acceptable).
3. Health data still correct after NS switch (existing `forceUpdateLiveAndDelayed` path).

---

### Areas which could experience regressions

- Workload Health on **non-paginated** lists (Deployment, DaemonSet, StatefulSet, Job) — should be unchanged due to `hasPaginatedWorkloadHealth` guard.
- **CronJob / ReplicaSet** and other workload types not in the SSP health list — should still use `this.pods` path.
- **Pod Restarts** column on paginated workload lists (same delayed-column mechanism; not changed directly).
- Workload scale actions in Health dropdown (`WorkloadHealthScale`).

---

### Checklist

- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [ ] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

---