### PR TITLE
fix: retry harvester extension auto install when catalog cache error

### DIFF
--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -41,6 +41,8 @@ harvesterManager:
       warning: "Warning, [[Harvester]] UI extension automatic installation failed"
       prompt: "Please refresh the page and try again or install the [[Harvester]] UI extension manually"
       prompt-standard-user: Please contact your system administrator to install or update the [[Harvester]] extension
+    action:
+      retrying: "Retry installing...({attempt}/{max})"
   rke:
     templateError: Incorrect template format
   affinity:

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -22,7 +22,8 @@ import {
   getHelmRepositoryMatch,
   createHelmRepository,
   refreshHelmRepository,
-  installHelmChart,
+  installHelmChartWithRetry,
+  INSTALL_ACTION_MAX_RETRIES,
   waitForUIExtension,
   waitForUIPackage,
 } from '@shell/utils/uiplugins';
@@ -93,6 +94,7 @@ export default {
       harvesterRepositoryError:       false,
       harvesterExtensionInstallError: false,
       harvesterExtensionUpdateError:  false,
+      harvesterActionRetryAttempt:    0,
       clusterRepoLink:                {
         name:   'c-cluster-product-resource',
         params: {
@@ -254,6 +256,18 @@ export default {
         height: 36
       };
     },
+
+    // Overrides the AsyncButton's waiting label while an install/upgrade action is being retried
+    harvesterActionRetryLabel() {
+      if (!this.harvesterActionRetryAttempt) {
+        return null;
+      }
+
+      return this.t('harvesterManager.extension.action.retrying', {
+        attempt: this.harvesterActionRetryAttempt,
+        max:     INSTALL_ACTION_MAX_RETRIES,
+      });
+    },
   },
 
   methods: {
@@ -280,6 +294,8 @@ export default {
     async installHarvesterExtension(btnCb) {
       let installed = false;
 
+      this.harvesterActionRetryAttempt = 0;
+
       try {
         let harvesterRepository = this.harvesterRepository;
 
@@ -299,7 +315,7 @@ export default {
           return;
         }
 
-        await installHelmChart(
+        await installHelmChartWithRetry(
           harvesterRepository,
           {
             ...HARVESTER_CHART,
@@ -307,7 +323,10 @@ export default {
           },
           {},
           UI_PLUGIN_NAMESPACE,
-          'install'
+          'install',
+          (attempt) => {
+            this.harvesterActionRetryAttempt = attempt;
+          },
         );
 
         const extension = await waitForUIExtension(this.$store, HARVESTER_CHART.name, 20);
@@ -317,6 +336,7 @@ export default {
         console.error('Error installing Harvester UI extension', error); // eslint-disable-line no-console
       }
 
+      this.harvesterActionRetryAttempt = 0;
       this.harvesterExtensionInstallError = !installed;
 
       btnCb(installed);
@@ -328,6 +348,8 @@ export default {
 
     async updateHarvesterExtension(btnCb) {
       let updated = false;
+
+      this.harvesterActionRetryAttempt = 0;
 
       try {
         if (this.harvester.missingRepository) {
@@ -342,7 +364,7 @@ export default {
           return;
         }
 
-        await installHelmChart(
+        await installHelmChartWithRetry(
           this.harvesterRepository,
           {
             ...HARVESTER_CHART,
@@ -350,7 +372,10 @@ export default {
           },
           {},
           UI_PLUGIN_NAMESPACE,
-          'upgrade'
+          'upgrade',
+          (attempt) => {
+            this.harvesterActionRetryAttempt = attempt;
+          },
         );
 
         const extension = await waitForUIExtension(this.$store, HARVESTER_CHART.name);
@@ -359,6 +384,7 @@ export default {
       } catch (error) {
       }
 
+      this.harvesterActionRetryAttempt = 0;
       this.harvesterExtensionUpdateError = !updated;
 
       btnCb(updated);
@@ -527,6 +553,7 @@ export default {
           >
             <AsyncButton
               :mode="harvester.toInstall ? 'install' : 'update'"
+              :waiting-label="harvesterActionRetryLabel"
               @click="harvester.action"
             />
           </div>

--- a/shell/utils/__tests__/uiplugins-extra.test.ts
+++ b/shell/utils/__tests__/uiplugins-extra.test.ts
@@ -2,6 +2,9 @@ import {
   onExtensionsReady,
   getLatestExtensionVersion,
   installHelmChart,
+  installHelmChartWithRetry,
+  isTransientChartActionError,
+  INSTALL_ACTION_MAX_RETRIES,
 } from '@shell/utils/uiplugins';
 
 import { isSupportedChartVersion } from '@shell/config/uiplugins';
@@ -259,6 +262,139 @@ describe('shell/utils/uiplugins', () => {
       const [, installRequest] = repo.doAction.mock.calls[0];
 
       expect(installRequest.charts[0].values).toStrictEqual(values);
+    });
+  });
+
+  describe('isTransientChartActionError', () => {
+    it('returns false when status is not 500', () => {
+      const error = { _status: 404, message: 'failed to find chart harvester version v1.8.1 Not found 404' };
+
+      expect(isTransientChartActionError(error)).toBe(false);
+    });
+
+    it('returns true for a 500 with the catalog "chart not found" wording (error.message)', () => {
+      const error = { _status: 500, message: 'failed to find chartName harvester version v1.8.1 Not found 404' };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('returns true when the message is nested under error.data.message', () => {
+      const error = { status: 500, data: { message: 'failed to find chart harvester version 1.0.0 not found' } };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('is case-insensitive and tolerant of extra whitespace before "found"', () => {
+      const error = { _status: 500, message: 'FAILED TO FIND CHART harvester VERSION 1.0.0 NOT   FOUND 404' };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('returns false for a 500 with an unrelated message', () => {
+      const error = { _status: 500, message: 'permission denied' };
+
+      expect(isTransientChartActionError(error)).toBe(false);
+    });
+
+    it('returns false when there is no message at all', () => {
+      expect(isTransientChartActionError({ _status: 500 })).toBe(false);
+    });
+
+    it('prefers error._status over error.status', () => {
+      const error = {
+        _status: 500, status: 404, message: 'failed to find chart foo version 1.0.0 not found'
+      };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+  });
+
+  describe('installHelmChartWithRetry', () => {
+    const chart = {
+      name:     'harvester-extension',
+      version:  '1.9.0',
+      repoType: 'helm',
+      repoName: 'official',
+    };
+    const transientError = { _status: 500, message: 'failed to find chart harvester-extension version 1.9.0 Not found 404' };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('resolves on the first try without retrying', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({ id: 'ok' }) };
+      const onRetry = jest.fn();
+
+      const result = await installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      expect(result).toStrictEqual({ id: 'ok' });
+      expect(repo.doAction).toHaveBeenCalledTimes(1);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('throws immediately without retrying for a non-transient error', async() => {
+      const error = { _status: 500, message: 'permission denied' };
+      const repo = { doAction: jest.fn().mockRejectedValue(error) };
+      const onRetry = jest.fn();
+
+      await expect(installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry)).rejects.toBe(error);
+
+      expect(repo.doAction).toHaveBeenCalledTimes(1);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('retries a transient error and eventually succeeds, notifying onRetry each time', async() => {
+      const repo = {
+        doAction: jest.fn()
+          .mockRejectedValueOnce(transientError)
+          .mockRejectedValueOnce(transientError)
+          .mockResolvedValueOnce({ id: 'ok-after-retry' }),
+      };
+      const onRetry = jest.fn();
+
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      // Flush the two backoff waits so the retried attempts get a chance to run
+      await jest.advanceTimersByTimeAsync(10000);
+
+      const result = await promise;
+
+      expect(result).toStrictEqual({ id: 'ok-after-retry' });
+      expect(repo.doAction).toHaveBeenCalledTimes(3);
+      expect(onRetry).toHaveBeenNthCalledWith(1, 1, INSTALL_ACTION_MAX_RETRIES);
+      expect(onRetry).toHaveBeenNthCalledWith(2, 2, INSTALL_ACTION_MAX_RETRIES);
+    });
+
+    it('throws the transient error once retries are exhausted', async() => {
+      const repo = { doAction: jest.fn().mockRejectedValue(transientError) };
+      const onRetry = jest.fn();
+
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      // Swallow the rejection so advancing timers below doesn't trigger an unhandled rejection;
+      // the actual assertion happens afterwards once all backoff waits have fired.
+      promise.catch(() => {});
+
+      await jest.advanceTimersByTimeAsync(30000);
+
+      await expect(promise).rejects.toBe(transientError);
+
+      // Initial attempt + one retry per configured backoff delay
+      expect(repo.doAction).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES + 1);
+      expect(onRetry).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES);
+    });
+
+    it('passes through install/upgrade action and namespace like installHelmChart', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+
+      await installHelmChartWithRetry(repo, chart, {}, 'cattle-ui-plugin-system', 'upgrade');
+
+      expect(repo.doAction).toHaveBeenCalledWith('upgrade', expect.objectContaining({ namespace: 'cattle-ui-plugin-system' }));
     });
   });
 });

--- a/shell/utils/__tests__/uiplugins-extra.test.ts
+++ b/shell/utils/__tests__/uiplugins-extra.test.ts
@@ -370,23 +370,23 @@ describe('shell/utils/uiplugins', () => {
       expect(onRetry).toHaveBeenNthCalledWith(2, 2, INSTALL_ACTION_MAX_RETRIES);
     });
 
-    it('throws the transient error once retries are exhausted', async() => {
+    it('waits the full backoff schedule (1s, 2s, 4s, 8s) across all retries', async() => {
       const repo = { doAction: jest.fn().mockRejectedValue(transientError) };
-      const onRetry = jest.fn();
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
 
-      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install');
 
-      // Swallow the rejection so advancing timers below doesn't trigger an unhandled rejection;
-      // the actual assertion happens afterwards once all backoff waits have fired.
       promise.catch(() => {});
 
       await jest.advanceTimersByTimeAsync(30000);
 
       await expect(promise).rejects.toBe(transientError);
 
-      // Initial attempt + one retry per configured backoff delay
-      expect(repo.doAction).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES + 1);
-      expect(onRetry).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES);
+      const delays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+
+      expect(delays).toStrictEqual([1000, 2000, 4000, 8000]);
+
+      setTimeoutSpy.mockRestore();
     });
 
     it('passes through install/upgrade action and namespace like installHelmChart', async() => {

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -8,6 +8,12 @@ const MAX_RETRIES = 10;
 const RETRY_WAIT = 2500; // 2.5 seconds
 const ACTIVE_STATUS_TIMEOUT = 200000; // 20 seconds
 
+// Backoff schedule (ms) for retrying a chart install/upgrade action that failed because a
+// follower Rancher replica's in-memory catalog index cache hadn't caught up yet (see #17543)
+const ACTION_RETRY_DELAYS = [1000, 2000, 4000, 8000];
+
+export const INSTALL_ACTION_MAX_RETRIES = ACTION_RETRY_DELAYS.length;
+
 type Action = 'install' | 'upgrade';
 export type HelmRepository = any;
 export type HelmChart = any;
@@ -161,6 +167,59 @@ export async function installHelmChart(repo: any, chart: any, values: any = {}, 
   const res = await repo.doAction(action, installRequest);
 
   return res;
+}
+
+/**
+ * Whether a chart install/upgrade action error is a transient failure caused by a Rancher
+ * replica whose in-memory catalog index cache hasn't caught up with a just-created/updated
+ * repo yet, and is therefore safe to retry (as opposed to e.g. a validation or permission error).
+ */
+export function isTransientChartActionError(error: any): boolean {
+  const status = error?._status ?? error?.status;
+
+  if (status !== 500) {
+    return false;
+  }
+
+  const message = error?.message || error?.data?.message || '';
+
+  // Matches the Rancher catalog controller's own wording, e.g. "failed to find chartName
+  // harvester version v1.8.1 Not found 404", to avoid retrying (and masking) other 500s
+  return /failed to find chart.*version.*not\s*found/i.test(message);
+}
+
+/**
+ * Install/upgrade a Helm Chart, retrying with exponential backoff when the failure looks like a
+ * transient catalog index cache miss (see isTransientChartActionError). Other errors are thrown
+ * immediately without retrying.
+ *
+ * @param onRetry Called before each retry with the attempt number and the max number of retries
+ */
+export async function installHelmChartWithRetry(
+  repo: any,
+  chart: any,
+  values: any = {},
+  namespace = 'default',
+  action: Action = 'install',
+  onRetry?: (attempt: number, maxAttempts: number) => void,
+) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await installHelmChart(repo, chart, values, namespace, action);
+    } catch (error) {
+      if (attempt >= ACTION_RETRY_DELAYS.length || !isTransientChartActionError(error)) {
+        throw error;
+      }
+
+      const nextAttempt = attempt + 1;
+
+      console.log(`Installing harvester helm chart failed, attempt ${nextAttempt}, wait ${ACTION_RETRY_DELAYS[nextAttempt]/1000} second(s) and retry... `); // eslint-disable-line no-console
+
+      onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
+
+      await new Promise((resolve) => setTimeout(resolve, ACTION_RETRY_DELAYS[nextAttempt]));
+    }
+  }
 }
 
 /**

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -211,13 +211,14 @@ export async function installHelmChartWithRetry(
         throw error;
       }
 
+      const delay = ACTION_RETRY_DELAYS[attempt];
       const nextAttempt = attempt + 1;
 
-      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ ACTION_RETRY_DELAYS[nextAttempt] / 1000 } second(s) and retry... `); // eslint-disable-line no-console
+      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ delay / 1000 } second(s) and retry... `); // eslint-disable-line no-console
 
       onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
 
-      await new Promise((resolve) => setTimeout(resolve, ACTION_RETRY_DELAYS[nextAttempt]));
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 }

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -213,7 +213,7 @@ export async function installHelmChartWithRetry(
 
       const nextAttempt = attempt + 1;
 
-      console.log(`Installing harvester helm chart failed, attempt ${nextAttempt}, wait ${ACTION_RETRY_DELAYS[nextAttempt]/1000} second(s) and retry... `); // eslint-disable-line no-console
+      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ ACTION_RETRY_DELAYS[nextAttempt] / 1000 } second(s) and retry... `); // eslint-disable-line no-console
 
       onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
 


### PR DESCRIPTION
### Summary
Fixes #17543

Resolve comment : https://github.com/rancher/dashboard/issues/17543#issuecomment-5066041588

On HA Rancher setups, the Harvester UI extension auto-install fails on the first click of the Install button because the install `POST` can land on a follower replica whose in-memory catalog index cache hasn't yet observed the just-downloaded ClusterRepo. 

The server returns `500` with a message like `failed to find chartName harvester version 1.8.1: NotFound 404`. A manual retry succeeds. This PR makes the UI retry that transient failure automatically.

### Occurred changes and/or fixed issues
- The chart install/upgrade action is now wrapped with an exponential-backoff retry that only kicks in for the transient "catalog index cache miss" error (leader/follower race), not for other failures.
- The install/update button surfaces retry progress to the user while retrying, so the flow no longer appears to fail on the first attempt.

### Areas or cases that should be tested
- HA Rancher (multiple replicas behind a load balancer), clean state (no pre-existing harvester ClusterRepo / apps in `cattle-ui-plugin-system`): from Virtualization Management, click Install once and confirm the extension installs without a manual retry, with the button showing `Retrying installation… (n/4)` if a transient `500` occurs.
- Single-node Rancher: install still succeeds on the first click (no regression).
- Update flow: with an outdated extension, Update still works and retries the same way.

### Areas which could experience regressions
- Harvester extension install/update flow on the Virtualization Management page.


### Screenshot/Video

https://github.com/user-attachments/assets/363530a6-63a6-48cb-82ef-be45ce59f2d1




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`