### PR TITLE
Automation: Fix missing build details and add test counts to ui-qa Slack notification

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -6,6 +6,8 @@
 
 def branch = "${env.BRANCH}" != 'null' && "${env.BRANCH}" != '' ? "${env.BRANCH}" : 'master'
 def testExecutionResult = null
+def testsTotal = 0
+def testsFailed = 0
 def testExitCode = null
 
 timeout(time: 270, unit: 'MINUTES') {
@@ -123,7 +125,13 @@ node('harvester-vpn-1') {
               try {
                 stage('Test Report') {
                   if (fileExists('results.xml')) {
-                    junit testResults: '**/results.xml', allowEmptyResults: true
+                    // The junit step returns a TestResultSummary — reuse its counts for the
+                    // Slack message rather than parsing results.xml a second time by hand.
+                    def summary = junit testResults: '**/results.xml', allowEmptyResults: true
+                    if (summary != null) {
+                      testsTotal = summary.totalCount
+                      testsFailed = summary.failCount
+                    }
 
                     def resultsContent = readFile('results.xml').trim()
                     if (resultsContent.contains('<failure')) {
@@ -171,7 +179,9 @@ node('harvester-vpn-1') {
 
               if (currentBuild.result != 'SUCCESS') {
                 if ("${env.SLACK_NOTIFICATION}".toLowerCase() != 'false') {
-                  withEnv(["SLACK_BUILD_STATUS=${currentBuild.result}"]) {
+                  withEnv(["SLACK_BUILD_STATUS=${currentBuild.result}",
+                           "TESTS_TOTAL=${testsTotal}",
+                           "TESTS_FAILED=${testsFailed}"]) {
                     sh 'cypress/jenkins/slack-notification.sh $SLACK_BUILD_STATUS'
                   }
                 }

--- a/cypress/jenkins/README.md
+++ b/cypress/jenkins/README.md
@@ -12,7 +12,7 @@ repo. This directory only contains what Jenkins needs to kick things off.
 | `Jenkinsfile` | Pipeline stages — pre-clean, preflight, checkout, run tests, grab results, cleanup, report |
 | `Jenkinsfile_multi` | Matrix job — fans out across Rancher versions × K8s versions × tag sets |
 | `init.sh` | Clones qa-infra-automation, builds runner image, generates vars.yaml, runs playbook in container, streams Cypress |
-| `slack-notification.sh` | Posts test results to Slack on failure |
+| `slack-notification.sh` | Posts test results to Slack on failure, with build details read from `notification_values.txt` |
 
 ## How it works
 
@@ -28,6 +28,10 @@ Jenkinsfile → init.sh → ansible-playbook (provision + setup) → docker run 
    Docker image (contains ansible, tofu, helm, kubectl), writes `vars.yaml`
    from the `VARS_YAML_CONFIG` Jenkins text area (required), then:
    - Runs the playbook inside the container with `--skip-tags test` (provision + setup)
+   - Copies `notification_values.txt` from the playbook dir into the Jenkins
+     workspace, where `slack-notification.sh` expects it. The playbook resolves
+     `workspace_dir` to its own directory because `WORKSPACE` is not exported into
+     the container, so without this copy the Slack message loses all build details.
    - Runs `docker run` directly for real-time Cypress streaming with colors
    - On destroy: runs the playbook with `--tags cleanup,never`
 

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -288,6 +288,17 @@ else
   # Run playbook: provision + setup (skip test — Docker run is below for streaming)
   run_container "" "test"
 
+  # The playbook writes notification_values.txt next to itself: WORKSPACE is not exported
+  # into the runner container, so the playbook's workspace_dir falls back to playbook_dir.
+  # slack-notification.sh reads it from the Jenkins workspace, so copy it across here —
+  # before the exits below, since those are failing builds that still notify Slack.
+  if [[ -f "${PLAYBOOK_DIR}/notification_values.txt" ]]; then
+    cp "${PLAYBOOK_DIR}/notification_values.txt" "${JENKINS_WORKSPACE}/" 2>/dev/null ||
+      echo "[init] WARNING: could not copy notification_values.txt — Slack build details will be omitted"
+  else
+    echo "[init] WARNING: notification_values.txt not found — Slack build details will be omitted"
+  fi
+
   # Run Cypress in Docker directly for real-time log streaming in Jenkins
   echo "[init] Running Cypress tests (docker)..."
 

--- a/cypress/jenkins/inspector/README.md
+++ b/cypress/jenkins/inspector/README.md
@@ -36,7 +36,7 @@ Runs automatically **Tue–Sat at 4:00 AM PST** (11:00 UTC) via GitHub Actions, 
 | `INSPECTOR_GITHUB_PROJECT_NUMBER` | Repo variable | Project board number |
 | `INSPECTOR_BUILD_WINDOW` | Repo variable | Number of recent builds to scan for the batch anchor (default: `50`) |
 | `INSPECTOR_ANCHOR_DESCRIPTION` | Repo variable | Jenkins build description that marks the batch start (default: `head · community · @adminUser`) |
-| `INSPECTOR_SLACK_THRESHOLD` | Repo variable | Unique failure count above which a Slack alert is sent instead of creating issues (default: `10`) |
+| `INSPECTOR_SLACK_THRESHOLD` | Repo variable | Unique failure count above which a Slack alert is sent instead of creating issues (default: `10`). The alert breaks the failures down into ones with an open issue, ones whose issue would be reopened, and untracked ones |
 | `INSPECTOR_SLACK_NOTIFICATION` | Repo variable | Set to `false` to disable Slack alerts (default: `true`) |
 | `INSPECTOR_COPILOT_MODEL` | Repo variable | Copilot model used for AI fix suggestions (default: `gpt-5.6-luna`). Set this if the default model is retired — the model must support the `/responses` API |
 | `GITHUB_ORG` | Workflow env | Target org (default: `rancher`) |
@@ -49,5 +49,5 @@ Runs automatically **Tue–Sat at 4:00 AM PST** (11:00 UTC) via GitHub Actions, 
 | `src/inspect.js` | Entrypoint — orchestrates the full inspection run |
 | `src/jenkins-client.js` | Jenkins REST API client — fetches builds and test results |
 | `src/github-client.js` | GitHub REST/GraphQL client — manages issues and project board |
-| `src/slack-client.js` | Slack client — sends high-failure alerts to the UI QA channel |
+| `src/slack-client.js` | Slack client — sends high-failure alerts to the UI QA channel, including a known-vs-new failure breakdown |
 | `src/fetch-utils.js` | Shared fetch utility — timeout and retry logic for all HTTP calls |

--- a/cypress/jenkins/inspector/src/inspect.js
+++ b/cypress/jenkins/inspector/src/inspect.js
@@ -60,14 +60,8 @@ function groupFailures(failures) {
   return grouped;
 }
 
-async function groupAndCreateIssues(failures) {
+async function groupAndCreateIssues(failures, existingIssues) {
   const grouped = groupFailures(failures);
-
-  // Fetch all existing issues once upfront — avoids per-failure GitHub Search API calls
-  console.log('  Fetching existing issues from GitHub...');
-  const existingIssues = await githubClient.fetchExistingIssues();
-
-  console.log(`  Found ${ existingIssues.size } existing tracked issues`);
 
   // Fetch project board members to detect open issues missing from the board
   try {
@@ -174,6 +168,33 @@ async function groupAndCreateIssues(failures) {
   };
 }
 
+/**
+ * Split the failures into those already tracked by an open issue, those whose issue was
+ * closed (a regression that would be reopened), and those with no issue at all.
+ *
+ * Keyed on the same generated title the create/reopen path uses, so the counts match what
+ * that path would do. Only issues carrying this tool's labels are considered, so a failure
+ * whose issue was relabelled by a triager is reported as new — the label-independent
+ * lookup is a per-failure search call, too expensive to run across a whole batch.
+ */
+function summarizeTracking(grouped, existingIssues) {
+  let knownCount = 0; let regressionCount = 0; let newCount = 0;
+
+  for (const failure of grouped.values()) {
+    const existing = existingIssues.get(githubClient._issueTitle(failure));
+
+    if (existing?.state === 'open') knownCount++;
+    else if (existing?.state === 'closed') regressionCount++;
+    else newCount++;
+  }
+
+  return {
+    knownCount,
+    regressionCount,
+    newCount
+  };
+}
+
 async function main() {
   const dryRun = process.env.DRY_RUN === 'true';
 
@@ -216,16 +237,46 @@ async function main() {
   const slackThreshold = parseInt(process.env.INSPECTOR_SLACK_THRESHOLD || '10', 10);
   const slackEnabled = (process.env.INSPECTOR_SLACK_NOTIFICATION || 'true').toLowerCase() !== 'false';
   const grouped = groupFailures(failures);
+  const overThreshold = grouped.size > slackThreshold;
 
-  if (grouped.size > slackThreshold) {
+  // Existing issues drive both the create/reopen path and the known-vs-new breakdown in
+  // the high-failure alert, so fetch once here and share the result. The alert path used
+  // to skip this fetch entirely, which is why the breakdown needs it hoisted above the
+  // threshold check rather than left inside groupAndCreateIssues().
+  let existingIssues = null;
+
+  if (overThreshold || !dryRun) {
+    console.log('  Fetching existing issues from GitHub...');
+    try {
+      existingIssues = await githubClient.fetchExistingIssues();
+      console.log(`  Found ${ existingIssues.size } existing tracked issues`);
+    } catch (e) {
+      // Below the threshold this is load-bearing: without it issues get duplicated, so
+      // fail loudly. On the alert path it only enriches the message, and an alert with no
+      // breakdown is far better than no alert at all.
+      if (!overThreshold) throw e;
+      console.warn(`  Warning: could not fetch existing issues — alert will omit the known/new breakdown: ${ e.message }`);
+    }
+  }
+
+  if (overThreshold) {
     console.log(`\nHigh failure count: ${ grouped.size } unique failures exceeds threshold of ${ slackThreshold }.`);
     console.log('Sending Slack alert and skipping issue creation.');
+
+    const breakdown = existingIssues ? summarizeTracking(grouped, existingIssues) : null;
+
+    if (breakdown) {
+      console.log(`  Known (open issue)   : ${ breakdown.knownCount }`);
+      console.log(`  Regressions (closed) : ${ breakdown.regressionCount }`);
+      console.log(`  Potentially new      : ${ breakdown.newCount }`);
+    }
 
     if (!dryRun && slackEnabled) {
       const sent = await sendHighFailureAlert({
         totalUnique:   grouped.size,
         batch,
         jenkinsJobUrl: `${ process.env.JENKINS_BASE_URL }/${ (process.env.JENKINS_JOB_PATH || '').split('/').map((p) => `job/${ p }`).join('/') }`,
+        ...(breakdown || {}),
       });
 
       if (sent) {
@@ -252,7 +303,7 @@ async function main() {
   }
 
   console.log('Step 2: Creating/updating GitHub issues...');
-  const result = await groupAndCreateIssues(failures);
+  const result = await groupAndCreateIssues(failures, existingIssues);
 
   console.log('');
 

--- a/cypress/jenkins/inspector/src/slack-client.js
+++ b/cypress/jenkins/inspector/src/slack-client.js
@@ -6,7 +6,9 @@
 
 const SLACK_API = 'https://slack.com/api/chat.postMessage';
 
-export async function sendHighFailureAlert({ totalUnique, batch, jenkinsJobUrl }) {
+export async function sendHighFailureAlert({
+  totalUnique, batch, jenkinsJobUrl, knownCount = null, regressionCount = 0, newCount = 0
+}) {
   const token = process.env.UI_QA_SLACK_BOT_TOKEN;
   const channel = process.env.UI_QA_SLACK_CHANNEL;
 
@@ -33,10 +35,22 @@ export async function sendHighFailureAlert({ totalUnique, batch, jenkinsJobUrl }
 
   const mention = groupId ? `<!subteam^${ groupId }>` : '';
 
+  // Tells the team at a glance whether a spike is env/infra noise against already-known
+  // failures, or a genuine wave of new ones. Omitted entirely when the GitHub lookup that
+  // produces the counts failed, so the alert itself is never blocked by it.
+  const breakdown = knownCount === null ? [] : [
+    ``,
+    `*Of these:*`,
+    `• *${ knownCount }* already have an open issue on the project board (known failures)`,
+    ...(regressionCount > 0 ? [`• *${ regressionCount }* have a closed issue and would be reopened (regressions)`] : []),
+    `• *${ newCount }* are not yet tracked (potentially new)`,
+  ];
+
   const message = [
     `${ mention }${ mention ? ' ' : '' }:alert: *High failure count detected — issue creation skipped*`,
     ``,
     `*${ totalUnique } unique test failure(s)* were found in today's Jenkins batch. This may indicate an environment or configuration issue rather than individual flaky tests.`,
+    ...breakdown,
     ``,
     `*Builds in batch:*`,
     buildLines,

--- a/cypress/jenkins/slack-notification.sh
+++ b/cypress/jenkins/slack-notification.sh
@@ -58,12 +58,28 @@ read_from_file() {
 }
 
 # Function to read value from notification_values.txt
+# Trims surrounding whitespace only — values such as build dates contain spaces.
+# Double quotes and backslashes are dropped because the value is interpolated into
+# the JSON payload, where they would otherwise produce a malformed request.
 read_notification_value() {
 	local key="$1"
 	local file_path="${WORKSPACE}/notification_values.txt"
 
 	if [ -f "$file_path" ]; then
-		grep "^${key}=" "$file_path" | cut -d'=' -f2- | tr -d '[:space:]'
+		grep "^${key}=" "$file_path" | head -1 | cut -d'=' -f2- |
+			sed 's/[\\"]//g; s/^[[:space:]]*//; s/[[:space:]]*$//'
+	fi
+}
+
+# Emit a "• *Label:* value" message line, or nothing when the value is unavailable.
+# Fields are skipped gracefully so the message stays correct as the playbook gains
+# or drops keys in notification_values.txt.
+append_field() {
+	local label="$1"
+	local value="$2"
+
+	if [ -n "$value" ] && [ "$value" != "Unknown" ]; then
+		printf '• *%s:* %s\\n' "$label" "$value"
 	fi
 }
 
@@ -74,13 +90,14 @@ send_jenkins_e2e_failure_notification() {
 	local build_number="${BUILD_NUMBER:-Unknown}"
 	local build_url="${BUILD_URL:-}"
 
-	# Job-specific variables from init.sh
+	# Job-specific variables from the playbook's notification_values.txt
 	local rancher_version=$(read_notification_value "RANCHER_VERSION")
 	local rancher_image_tag=$(read_notification_value "RANCHER_IMAGE_TAG")
 	local rancher_chart_url=$(read_notification_value "RANCHER_CHART_URL")
 	local rancher_helm_repo=$(read_notification_value "RANCHER_HELM_REPO")
-	local helm_repo_name=$(read_notification_value "HELM_REPO_NAME")
 	local cypress_tags=$(read_notification_value "CYPRESS_TAGS")
+	local kubernetes_version=$(read_notification_value "KUBERNETES_VERSION")
+	local dashboard_branch=$(read_notification_value "DASHBOARD_BRANCH")
 
 	# Get Slack bot token and channel from Secrets Manager
 	local slack_bot_token="${UI_SLACK_BOT_TOKEN:-}"
@@ -111,25 +128,21 @@ send_jenkins_e2e_failure_notification() {
 		message+="• *Build:* #$build_number\n"
 	fi
 
-	if [ -n "$rancher_version" ] && [ "$rancher_version" != "Unknown" ]; then
-		message+="• *Rancher Version:* $rancher_version\n"
+	# Test totals, published by the Jenkinsfile from the junit step's own summary
+	local test_summary=""
+
+	if [ -n "${TESTS_TOTAL:-}" ] && [ "${TESTS_TOTAL}" -gt 0 ] 2>/dev/null; then
+		test_summary="${TESTS_TOTAL} run, ${TESTS_FAILED:-0} failed"
 	fi
 
-	if [ -n "$rancher_image_tag" ] && [ "$rancher_image_tag" != "Unknown" ]; then
-		message+="• *Rancher Image:* $rancher_image_tag\n"
-	fi
-
-	if [ -n "$rancher_chart_url" ] && [ "$rancher_chart_url" != "Unknown" ]; then
-		message+="• *Chart URL:* $rancher_chart_url\n"
-	fi
-
-	if [ -n "$rancher_helm_repo" ] && [ "$rancher_helm_repo" != "Unknown" ]; then
-		message+="• *Helm Repo:* $rancher_helm_repo\n"
-	fi
-
-	if [ -n "$cypress_tags" ] && [ "$cypress_tags" != "Unknown" ]; then
-		message+="• *Cypress Tags:* $cypress_tags\n"
-	fi
+	message+=$(append_field "Tests" "$test_summary")
+	message+=$(append_field "Rancher Version" "$rancher_version")
+	message+=$(append_field "Rancher Image" "$rancher_image_tag")
+	message+=$(append_field "K8s Version" "$kubernetes_version")
+	message+=$(append_field "Chart URL" "$rancher_chart_url")
+	message+=$(append_field "Helm Repo" "$rancher_helm_repo")
+	message+=$(append_field "Dashboard Branch" "$dashboard_branch")
+	message+=$(append_field "Cypress Tags" "$cypress_tags")
 
 	message+="• *Timestamp:* $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2501 https://github.com/rancher/qa-tasks/issues/2500

Two related ui-qa Slack notification fixes
- **Daily E2E notification** — none of the build detail fields were rendering. Fixes the cause, then adds the test failure count, K8s version and dashboard branch.
- **CI Failure Inspector** — the high-failure alert now says how many failures are already tracked, so the team can tell an infra spike from a genuine wave of new failures.

Associated with https://github.com/rancher/qa-infra-automation/pull/196
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

**Jenkins E2E notification (#2501)**

The message had been reduced to Job, Build and Timestamp — every playbook-sourced field was silently dropped. Root cause: `init.sh` never exports `WORKSPACE` into the runner container, so the playbook's `workspace_dir` falls back to `playbook_dir` and writes `notification_values.txt` there, while `slack-notification.sh` reads it from the Jenkins workspace root. `init.sh` now copies the file across.

Fixing that alone restores Rancher Version, Rancher Image, Chart URL, Helm Repo and Cypress Tags. On top of it:

- **`Tests: <n> run, <n> failed`** — new. The `Jenkinsfile` already called `junit`, but discarded its return value; it now captures the `TestResultSummary` and passes the counts to the script via `withEnv`.
- **`K8s Version`** and **`Dashboard Branch`** — new, and require the companion playbook PR below.
- Field rendering moved to an `append_field` helper, replacing five near-identical `if` blocks. Missing, empty or `Unknown` values are skipped rather than rendered blank.
- Removed the unused `helm_repo_name` local.

**CI Failure Inspector (#2500)**

When the unique failure count exceeds `INSPECTOR_SLACK_THRESHOLD` the tool skips issue creation and alerts Slack. That alert only carried a total. It now adds:

```
*Of these:*
• *20* already have an open issue on the project board (known failures)
• *1* have a closed issue and would be reopened (regressions)
• *47* are not yet tracked (potentially new)
```

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
