### PR TITLE
Don't render configmap binary data

### DIFF
--- a/shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/__tests__/composables.test.ts
@@ -3,8 +3,9 @@ import { base64Encode } from '@shell/utils/crypto';
 
 describe('composables: ConfigMapDataTab', () => {
   const textData = 'This is textData';
-  const binaryData = 'This is binaryData';
-  const binaryDataBase64 = base64Encode(binaryData);
+  const asciiBinaryData = 'This is binaryData';
+  const asciiBinaryBase64 = base64Encode(asciiBinaryData);
+  const nonAsciiBinaryBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).toString('base64');
 
   it('should handle no data', () => {
     const props = useGetConfigMapDataTabProps({});
@@ -12,9 +13,9 @@ describe('composables: ConfigMapDataTab', () => {
     expect(props.rows).toHaveLength(0);
   });
 
-  it('should handle text and binary data at the same time', () => {
+  it('should show ascii-decodable binaryData as decoded text', () => {
     const data = { text: textData };
-    const bData = { binary: binaryDataBase64 };
+    const bData = { binary: asciiBinaryBase64 };
 
     const props = useGetConfigMapDataTabProps({ data, binaryData: bData });
 
@@ -23,7 +24,17 @@ describe('composables: ConfigMapDataTab', () => {
     expect(props.rows[0].binary).toStrictEqual(false);
 
     expect(props.rows[1].key).toStrictEqual('binary');
-    expect(props.rows[1].value).toStrictEqual(binaryData);
+    expect(props.rows[1].value).toStrictEqual(asciiBinaryData);
     expect(props.rows[1].binary).toStrictEqual(false);
+  });
+
+  it('should flag non-ascii binaryData as binary and keep the base64 value', () => {
+    const bData = { image: nonAsciiBinaryBase64 };
+
+    const props = useGetConfigMapDataTabProps({ binaryData: bData });
+
+    expect(props.rows[0].key).toStrictEqual('image');
+    expect(props.rows[0].value).toStrictEqual(nonAsciiBinaryBase64);
+    expect(props.rows[0].binary).toStrictEqual(true);
   });
 });

--- a/shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/composables.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/composables.ts
@@ -1,6 +1,7 @@
 import { Props } from '@shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/index.vue';
 import { computed } from 'vue';
 import { base64Decode } from '@shell/utils/crypto';
+import { asciiLike } from '@shell/utils/string';
 
 export const useGetConfigMapDataTabProps = (configMap: any): Props => {
   const rows = computed(() => {
@@ -15,12 +16,18 @@ export const useGetConfigMapDataTabProps = (configMap: any): Props => {
       });
     });
 
-    // we define the binary as false so that the ui doesn't display the size of the binary instead of the actual data...
+    // binaryData is base64-encoded per the Kubernetes ConfigMap spec. If it decodes to
+    // readable text, show the decoded content; otherwise flag it as binary so DetailText
+    // renders the size placeholder instead of unreadable bytes.
     Object.keys(binaryData).forEach((key) => {
+      const rawValue = binaryData[key];
+      const decoded = base64Decode(rawValue);
+      const isAscii = asciiLike(decoded);
+
       rows.push({
         key,
-        value:  base64Decode(binaryData[key]),
-        binary: false
+        value:  isAscii ? decoded : rawValue,
+        binary: !isAscii
       });
     });
 


### PR DESCRIPTION
### Summary
Fixes #7320

### Occurred changes and/or fixed issues
ConfigMap `binaryData` entries are now inspected after base64 decoding. Entries that decode to ASCII-like text are shown as decoded text (matching the previous behaviour for text-encoded binary values), while entries that decode to non-ASCII bytes are flagged as binary so `DetailText` renders the size placeholder instead of dumping unreadable bytes into the UI.

### Areas or cases that should be tested
- View a ConfigMap that only has `data` (text) entries — should render unchanged.
- View a ConfigMap with `binaryData` entries whose base64 payload decodes to readable text — should render the decoded text as before.
- View a ConfigMap with `binaryData` entries whose base64 payload decodes to true binary (e.g. a small PNG header) — the row should be flagged as binary and show the size placeholder rather than unreadable bytes.
- Tested locally in Chrome.

### Screenshot/Video

After:

<img width="1057" height="471" alt="image" src="https://github.com/user-attachments/assets/eb84e742-c91a-432d-95d4-589ccbebc4e6" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
