### PR TITLE
Stop copying state labels onto ported issues

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -85,7 +85,30 @@ jobs:
           if [[ $MILESTONE =~ (v[0-9]\.[0-9]+) ]]; then
               NEW_TITLE="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}"
           fi
-          ORIGINAL_LABELS=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json labels --jq '.labels[].name' | grep -v '^\[zube\]:' | paste -sd "," -)
+          # Labels that describe the state of the *original* issue rather than the
+          # problem itself must not be copied onto the port issue. Each entry is an
+          # extended regex matched against the full label name.
+          EXCLUDED_LABELS=(
+              '^\[zube\]:'                     # zube board columns
+              '^bot/'                          # agentic workflow state/instructions
+              '^status/backport-candidate$'    # only the root issue is the candidate
+              '^status/stale$'                 # a freshly created port is not stale
+              '^Stale$'
+              '^Stale/close$'
+              '^auto-close$'
+              '^status/duplicate$'             # resolutions of the original issue
+              '^status/wontfix$'
+              '^status/not-reproducible$'
+              '^status/needs-info$'            # info was requested on the original
+              '^needs-info$'
+              '^status/waiting-response$'
+              '^status/dev-validate$'          # progress state of the original fix
+              '^status/release-note-added$'    # the port needs its own release note
+              '^Epic$'                         # a port of an epic is not an epic
+              '^headline$'                     # tracked at the root issue only
+          )
+          EXCLUDE_PATTERN=$(IFS='|'; echo "${EXCLUDED_LABELS[*]}")
+          ORIGINAL_LABELS=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json labels --jq '.labels[].name' | grep -vE "${EXCLUDE_PATTERN}" | paste -sd "," -)
           if [ -n "$ORIGINAL_LABELS" ]; then
               additional_cmd+=("--label")
               additional_cmd+=("${ORIGINAL_LABELS}")


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the single zube filter with an explicit list of excluded label patterns.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Stop copying state labels onto ported issues

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The port issue workflow copied every label from the original issue apart from zube board columns. That carried `status/backport-candidate` onto each backport, so a chain of ported issues all claimed to still need porting and only the root issue should.

This changes also excludes the following label categories:

- the backport candidate marker 
- stale and close-reason
- pending-information
- in-flight progress
- bot state or instruction
- Epic and headline

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

We can test backporting a few issues with the offending tags attached.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The change could cause the port-issue workflow to fail, blocking our issue porting flow until fixed. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
