### PR TITLE
Move kubernetes version management into a composable

### DIFF
--- a/shell/composables/useKubernetesVersions.test.ts
+++ b/shell/composables/useKubernetesVersions.test.ts
@@ -1,0 +1,307 @@
+import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
+
+const mockGetters: Record<string, any> = {};
+const mockDispatch = jest.fn();
+
+jest.mock('vuex', () => ({
+  useStore: () => ({
+    getters: new Proxy(mockGetters, {
+      get(target, prop: string) {
+        return target[prop];
+      }
+    }),
+    dispatch: mockDispatch,
+  }),
+}));
+
+const version = (id: string, overrides: Record<string, any> = {}) => ({
+  id, serverArgs: {}, agentArgs: {}, charts: {}, ...overrides
+});
+
+describe('composable: useKubernetesVersions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mockGetters).forEach((key) => delete mockGetters[key]);
+    mockGetters['i18n/t'] = (key: string) => key;
+  });
+
+  const baseProps = () => ({
+    mode: _CREATE, liveValue: { spec: {} }, value: { spec: {} }
+  });
+
+  describe('versionOptions', () => {
+    it('groups rke2 and k3s versions with a header when both are present', () => {
+      const { versionOptions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
+
+      rke2Versions.value = [version('v1.28.0+rke2r1')];
+      k3sVersions.value = [version('v1.28.0+k3s1')];
+
+      const options = versionOptions.value;
+
+      expect(options[0]).toStrictEqual({ kind: 'group', label: 'cluster.provider.rke2' });
+      expect(options.some((o: any) => o.value === 'v1.28.0+rke2r1')).toBe(true);
+      expect(options.some((o: any) => o.kind === 'group' && o.label === 'cluster.provider.k3s')).toBe(true);
+      expect(options.some((o: any) => o.value === 'v1.28.0+k3s1')).toBe(true);
+    });
+
+    it('omits the k3s group when only rke2 versions are present', () => {
+      const { versionOptions, rke2Versions } = useKubernetesVersions(baseProps());
+
+      rke2Versions.value = [version('v1.28.0+rke2r1')];
+
+      const options = versionOptions.value;
+
+      expect(options.some((o: any) => o.kind === 'group')).toBe(false);
+      expect(options).toHaveLength(1);
+      expect(options[0].value).toBe('v1.28.0+rke2r1');
+    });
+
+    it('excludes k3s versions in edit mode when the live version is rke2', () => {
+      const props = {
+        mode: _EDIT, liveValue: { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } }, value: { spec: {} }
+      };
+      const { versionOptions, rke2Versions, k3sVersions } = useKubernetesVersions(props);
+
+      rke2Versions.value = [version('v1.28.0+rke2r1'), version('v1.29.0+rke2r1')];
+      k3sVersions.value = [version('v1.28.0+k3s1')];
+
+      const options = versionOptions.value;
+
+      expect(options.some((o: any) => o.value?.includes('k3s'))).toBe(false);
+    });
+
+    it('filters out deprecated patch versions by default', () => {
+      const { versionOptions, rke2Versions, showDeprecatedPatchVersions } = useKubernetesVersions(baseProps());
+
+      showDeprecatedPatchVersions.value = false;
+      rke2Versions.value = [version('v1.28.0+rke2r1'), version('v1.28.1+rke2r1')];
+
+      const options = versionOptions.value;
+
+      expect(options.map((o: any) => o.value)).toStrictEqual(['v1.28.1+rke2r1']);
+    });
+
+    it('shows deprecated patch versions when opted in', () => {
+      const { versionOptions, rke2Versions, showDeprecatedPatchVersions } = useKubernetesVersions(baseProps());
+
+      showDeprecatedPatchVersions.value = true;
+      rke2Versions.value = [version('v1.28.0+rke2r1'), version('v1.28.1+rke2r1')];
+
+      const options = versionOptions.value;
+
+      expect(options.map((o: any) => o.value).sort()).toStrictEqual(['v1.28.0+rke2r1', 'v1.28.1+rke2r1']);
+    });
+  });
+
+  describe('selectedVersion', () => {
+    it('returns undefined when no kubernetesVersion is set', () => {
+      const { selectedVersion } = useKubernetesVersions(baseProps());
+
+      expect(selectedVersion.value).toBeUndefined();
+    });
+
+    it('finds the matching version option by kubernetesVersion', () => {
+      const props = {
+        mode: _CREATE, liveValue: { spec: {} }, value: { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } }
+      };
+      const { selectedVersion, rke2Versions } = useKubernetesVersions(props);
+
+      rke2Versions.value = [version('v1.28.0+rke2r1'), version('v1.29.0+rke2r1')];
+
+      expect(selectedVersion.value?.value).toBe('v1.28.0+rke2r1');
+    });
+
+    it('adds a "none" cni option once, without duplicating it on repeated access', () => {
+      const props = {
+        mode: _CREATE, liveValue: { spec: {} }, value: { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } }
+      };
+      const { selectedVersion, rke2Versions } = useKubernetesVersions(props);
+
+      rke2Versions.value = [version('v1.28.0+rke2r1', { serverArgs: { cni: { options: ['calico'] } } })];
+
+      // access twice
+      const first = selectedVersion.value;
+      const second = selectedVersion.value;
+
+      expect(first?.serverArgs.cni.options).toStrictEqual(['calico', 'none']);
+      expect(second?.serverArgs.cni.options).toStrictEqual(['calico', 'none']);
+    });
+  });
+
+  describe('chartVersions / serverArgs / agentArgs / haveArgInfo', () => {
+    it('returns the charts, server args and agent args of the selected version', () => {
+      const props = {
+        mode: _CREATE, liveValue: { spec: {} }, value: { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } }
+      };
+      const {
+        chartVersions, serverArgs, agentArgs, haveArgInfo, rke2Versions
+      } = useKubernetesVersions(props);
+
+      rke2Versions.value = [version('v1.28.0+rke2r1', {
+        charts: { 'rke2-ingress-nginx': { version: '1.0.0' } }, serverArgs: { cni: {} }, agentArgs: { foo: 'bar' }
+      })];
+
+      expect(chartVersions.value).toStrictEqual({ 'rke2-ingress-nginx': { version: '1.0.0' } });
+      expect(serverArgs.value).toStrictEqual({ cni: {} });
+      expect(agentArgs.value).toStrictEqual({ foo: 'bar' });
+      expect(haveArgInfo.value).toBe(true);
+    });
+
+    it('returns empty fallbacks when there is no selected version', () => {
+      const {
+        chartVersions, serverArgs, agentArgs, haveArgInfo
+      } = useKubernetesVersions(baseProps());
+
+      expect(chartVersions.value).toStrictEqual({});
+      expect(serverArgs.value).toStrictEqual({});
+      expect(agentArgs.value).toStrictEqual({});
+      expect(haveArgInfo.value).toBe(false);
+    });
+  });
+
+  describe('fetchRke2Versions', () => {
+    const buildDispatch = ({ channelResponses = {} as Record<string, any[]> } = {}) => {
+      return jest.fn((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (action === 'management/request') {
+          if (url === '/v1-rke2-release/releases') {
+            return Promise.resolve({ data: [{ id: 'v1.28.0+rke2r1', serverArgs: {} }] });
+          }
+          if (url === '/v1-k3s-release/releases') {
+            return Promise.resolve({ data: [{ id: 'v1.28.0+k3s1', serverArgs: {} }] });
+          }
+          if (url === '/v1-rke2-release/channels') {
+            return Promise.resolve({ data: channelResponses.rke2 || [] });
+          }
+          if (url === '/v1-k3s-release/channels') {
+            return Promise.resolve({ data: channelResponses.k3s || [] });
+          }
+        }
+
+        if (action === 'management/findAll') {
+          return Promise.resolve([]);
+        }
+
+        return Promise.resolve();
+      });
+    };
+
+    it('does nothing when versions are already loaded', async() => {
+      const { fetchRke2Versions, rke2Versions } = useKubernetesVersions(baseProps());
+
+      rke2Versions.value = [{ id: 'cached' }];
+
+      await fetchRke2Versions();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('populates versions and default versions from global settings when present', async() => {
+      mockDispatch.mockImplementation(buildDispatch());
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const {
+        fetchRke2Versions, rke2Versions, k3sVersions, defaultRke2, defaultK3s
+      } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+
+      expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
+      expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
+      expect(defaultRke2.value).toBe('v1.28.0+rke2r1');
+      expect(defaultK3s.value).toBe('v1.28.0+k3s1');
+    });
+
+    it('falls back to the default channel latest version when no setting value/default exists', async() => {
+      mockDispatch.mockImplementation(buildDispatch({
+        channelResponses: {
+          rke2: [{ id: 'default', latest: 'v1.29.0+rke2r1' }],
+          k3s:  [{ id: 'default', latest: 'v1.29.0+k3s1' }],
+        },
+      }));
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [];
+
+      const { fetchRke2Versions, defaultRke2, defaultK3s } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+
+      expect(defaultRke2.value).toBe('v1.29.0+rke2r1');
+      expect(defaultK3s.value).toBe('v1.29.0+k3s1');
+    });
+
+    it('throws when no version info is returned for either distro', async() => {
+      mockDispatch.mockImplementation((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (url?.includes('/releases') || url?.includes('/channels')) {
+          return Promise.resolve({ data: [] });
+        }
+
+        return Promise.resolve();
+      });
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [];
+
+      const { fetchRke2Versions } = useKubernetesVersions(baseProps());
+
+      await expect(fetchRke2Versions()).rejects.toThrow('No version info found in KDM');
+    });
+  });
+});
+
+describe('getDefaultVersion', () => {
+  it('prefers the version matching the defaultRke2 setting when present among version options', () => {
+    const result = getDefaultVersion({
+      store:             {},
+      versionOptions:    [{ value: 'v1.29.0+rke2r1' }, { value: 'v1.28.0+rke2r1' }],
+      defaultRke2:       'v1.28.0+rke2r1',
+      rke2Versions:      [],
+      isHarvesterDriver: false,
+    });
+
+    expect(result).toBe('v1.28.0+rke2r1');
+  });
+
+  it('falls back to the first version option when defaultRke2 is not among the options', () => {
+    const result = getDefaultVersion({
+      store:             {},
+      versionOptions:    [{ value: 'v1.29.0+rke2r1' }, { value: 'v1.28.0+rke2r1' }],
+      defaultRke2:       'v1.99.0+rke2r1',
+      rke2Versions:      [],
+      isHarvesterDriver: false,
+    });
+
+    expect(result).toBe('v1.29.0+rke2r1');
+  });
+
+  it('prefers the first Harvester-compatible rke2 version when on the Harvester driver', () => {
+    const result = getDefaultVersion({
+      store:             {},
+      versionOptions:    [{ value: 'v1.29.0+rke2r1' }],
+      defaultRke2:       '',
+      rke2Versions:      [version('v1.20.0+rke2r1'), version('v1.25.0+rke2r1')],
+      isHarvesterDriver: true,
+    });
+
+    expect(result).toBe('v1.25.0+rke2r1');
+  });
+
+  it('falls back to the preferred/first option when on the Harvester driver but no rke2 versions satisfy it', () => {
+    const result = getDefaultVersion({
+      store:             {},
+      versionOptions:    [{ value: 'v1.29.0+rke2r1' }],
+      defaultRke2:       '',
+      rke2Versions:      [version('v1.20.0+rke2r1')],
+      isHarvesterDriver: true,
+    });
+
+    expect(result).toBe('v1.29.0+rke2r1');
+  });
+});

--- a/shell/composables/useKubernetesVersions.test.ts
+++ b/shell/composables/useKubernetesVersions.test.ts
@@ -1,5 +1,6 @@
 import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
+import { MANAGEMENT } from '@shell/config/types';
 
 const mockGetters: Record<string, any> = {};
 const mockDispatch = jest.fn();
@@ -161,7 +162,7 @@ describe('composable: useKubernetesVersions', () => {
   });
 
   describe('fetchRke2Versions', () => {
-    const buildDispatch = ({ channelResponses = {} as Record<string, any[]> } = {}) => {
+    const buildDispatch = ({ channelResponses = {} as Record<string, any[]>, psas = [] as any[] } = {}) => {
       return jest.fn((action: string, args: any = {}) => {
         const { url } = args;
 
@@ -181,7 +182,7 @@ describe('composable: useKubernetesVersions', () => {
         }
 
         if (action === 'management/findAll') {
-          return Promise.resolve([]);
+          return Promise.resolve(psas);
         }
 
         return Promise.resolve();
@@ -234,6 +235,41 @@ describe('composable: useKubernetesVersions', () => {
 
       expect(defaultRke2.value).toBe('v1.29.0+rke2r1');
       expect(defaultK3s.value).toBe('v1.29.0+k3s1');
+    });
+
+    it('fetches all PSAs when management/canList allows listing PSA', async() => {
+      const psas = [{ id: 'psa-1' }, { id: 'psa-2' }];
+
+      mockDispatch.mockImplementation(buildDispatch({ psas }));
+      mockGetters['management/canList'] = jest.fn(() => true);
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const { fetchRke2Versions, allPSAs } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+
+      expect(mockGetters['management/canList']).toHaveBeenCalledWith(MANAGEMENT.PSA);
+      expect(mockDispatch).toHaveBeenCalledWith('management/findAll', { type: MANAGEMENT.PSA });
+      expect(allPSAs.value).toStrictEqual(psas);
+    });
+
+    it('does not fetch PSAs when management/canList disallows listing PSA', async() => {
+      mockDispatch.mockImplementation(buildDispatch({ psas: [{ id: 'psa-1' }] }));
+      mockGetters['management/canList'] = jest.fn(() => false);
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const { fetchRke2Versions, allPSAs } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('management/findAll', expect.anything());
+      expect(allPSAs.value).toStrictEqual([]);
     });
 
     it('throws when no version info is returned for either distro', async() => {

--- a/shell/composables/useKubernetesVersions.test.ts
+++ b/shell/composables/useKubernetesVersions.test.ts
@@ -189,14 +189,34 @@ describe('composable: useKubernetesVersions', () => {
       });
     };
 
-    it('does nothing when versions are already loaded', async() => {
-      const { fetchRke2Versions, rke2Versions } = useKubernetesVersions(baseProps());
+    it('does nothing when both distros are already loaded', async() => {
+      const { fetchRke2Versions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
 
       rke2Versions.value = [{ id: 'cached' }];
+      k3sVersions.value = [{ id: 'cached' }];
 
       await fetchRke2Versions();
 
       expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('retries when one distro loaded but the other is still null (e.g. it previously failed)', async() => {
+      mockDispatch.mockImplementation(buildDispatch());
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const { fetchRke2Versions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
+
+      rke2Versions.value = [{ id: 'cached' }];
+      // k3sVersions left null, as if a prior call's k3s request failed
+
+      await fetchRke2Versions();
+
+      expect(mockDispatch).toHaveBeenCalledWith('management/request', { url: '/v1-k3s-release/releases' });
+      expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
     });
 
     it('populates versions and default versions from global settings when present', async() => {
@@ -362,15 +382,17 @@ describe('composable: useKubernetesVersions', () => {
         { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
       ];
 
-      const { fetchRke2Versions, rke2Versions } = useKubernetesVersions(baseProps());
+      const { fetchRke2Versions, rke2Versions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
 
       await fetchRke2Versions();
       expect(rke2Versions.value).toBeNull();
+      expect(fetchVersionsErrors.value).toStrictEqual(['rke2 releases request failed']);
 
       rke2ReleasesShouldFail = false;
       await fetchRke2Versions();
 
       expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
+      expect(fetchVersionsErrors.value).toStrictEqual([]);
     });
   });
 });

--- a/shell/composables/useKubernetesVersions.test.ts
+++ b/shell/composables/useKubernetesVersions.test.ts
@@ -272,7 +272,7 @@ describe('composable: useKubernetesVersions', () => {
       expect(allPSAs.value).toStrictEqual([]);
     });
 
-    it('throws when no version info is returned for either distro', async() => {
+    it('records an error instead of throwing when no version info is returned for either distro', async() => {
       mockDispatch.mockImplementation((action: string, args: any = {}) => {
         const { url } = args;
 
@@ -285,9 +285,92 @@ describe('composable: useKubernetesVersions', () => {
       mockGetters['management/canList'] = () => false;
       mockGetters['management/all'] = () => [];
 
-      const { fetchRke2Versions } = useKubernetesVersions(baseProps());
+      const { fetchRke2Versions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
 
-      await expect(fetchRke2Versions()).rejects.toThrow('No version info found in KDM');
+      await expect(fetchRke2Versions()).resolves.toBeUndefined();
+      expect(fetchVersionsErrors.value).toStrictEqual(['No version info found in KDM']);
+    });
+
+    it('records a per-request error without losing data that loaded successfully from other requests', async() => {
+      mockDispatch.mockImplementation((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (action === 'management/request' && url === '/v1-rke2-release/releases') {
+          return Promise.reject(new Error('rke2 releases request failed'));
+        }
+
+        return buildDispatch()(action, args);
+      });
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const {
+        fetchRke2Versions, rke2Versions, k3sVersions, fetchVersionsErrors
+      } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+
+      expect(fetchVersionsErrors.value).toStrictEqual(['rke2 releases request failed']);
+      expect(rke2Versions.value).toBeNull();
+      expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
+    });
+
+    it('records an error without throwing when the PSA request fails', async() => {
+      mockDispatch.mockImplementation((action: string, args: any = {}) => {
+        if (action === 'management/findAll') {
+          return Promise.reject(new Error('PSA request failed'));
+        }
+
+        return buildDispatch()(action, args);
+      });
+      mockGetters['management/canList'] = jest.fn(() => true);
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const {
+        fetchRke2Versions, allPSAs, rke2Versions, fetchVersionsErrors
+      } = useKubernetesVersions(baseProps());
+
+      await expect(fetchRke2Versions()).resolves.toBeUndefined();
+
+      expect(fetchVersionsErrors.value).toStrictEqual(['PSA request failed']);
+      expect(allPSAs.value).toStrictEqual([]);
+      // the failure is isolated to the PSA request - version data still loads normally
+      expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
+    });
+
+    it('retries a previously failed request on the next call, rather than treating the failure as "loaded"', async() => {
+      let rke2ReleasesShouldFail = true;
+
+      mockDispatch.mockImplementation((action: string, args: any = {}) => {
+        const { url } = args;
+
+        if (action === 'management/request' && url === '/v1-rke2-release/releases' && rke2ReleasesShouldFail) {
+          return Promise.reject(new Error('rke2 releases request failed'));
+        }
+
+        return buildDispatch()(action, args);
+      });
+      mockGetters['management/canList'] = () => false;
+      mockGetters['management/all'] = () => [
+        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
+        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
+      ];
+
+      const { fetchRke2Versions, rke2Versions } = useKubernetesVersions(baseProps());
+
+      await fetchRke2Versions();
+      expect(rke2Versions.value).toBeNull();
+
+      rke2ReleasesShouldFail = false;
+      await fetchRke2Versions();
+
+      expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
     });
   });
 });

--- a/shell/composables/useKubernetesVersions.test.ts
+++ b/shell/composables/useKubernetesVersions.test.ts
@@ -1,6 +1,5 @@
 import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
-import { MANAGEMENT } from '@shell/config/types';
 
 const mockGetters: Record<string, any> = {};
 const mockDispatch = jest.fn();
@@ -161,8 +160,8 @@ describe('composable: useKubernetesVersions', () => {
     });
   });
 
-  describe('fetchRke2Versions', () => {
-    const buildDispatch = ({ channelResponses = {} as Record<string, any[]>, psas = [] as any[] } = {}) => {
+  describe('fetchK8sVersions', () => {
+    const buildDispatch = ({ channelResponses = {} as Record<string, any[]> } = {}) => {
       return jest.fn((action: string, args: any = {}) => {
         const { url } = args;
 
@@ -181,21 +180,17 @@ describe('composable: useKubernetesVersions', () => {
           }
         }
 
-        if (action === 'management/findAll') {
-          return Promise.resolve(psas);
-        }
-
         return Promise.resolve();
       });
     };
 
     it('does nothing when both distros are already loaded', async() => {
-      const { fetchRke2Versions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
+      const { fetchK8sVersions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
 
       rke2Versions.value = [{ id: 'cached' }];
       k3sVersions.value = [{ id: 'cached' }];
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(mockDispatch).not.toHaveBeenCalled();
     });
@@ -208,12 +203,12 @@ describe('composable: useKubernetesVersions', () => {
         { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
       ];
 
-      const { fetchRke2Versions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
+      const { fetchK8sVersions, rke2Versions, k3sVersions } = useKubernetesVersions(baseProps());
 
       rke2Versions.value = [{ id: 'cached' }];
       // k3sVersions left null, as if a prior call's k3s request failed
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(mockDispatch).toHaveBeenCalledWith('management/request', { url: '/v1-k3s-release/releases' });
       expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
@@ -228,10 +223,10 @@ describe('composable: useKubernetesVersions', () => {
       ];
 
       const {
-        fetchRke2Versions, rke2Versions, k3sVersions, defaultRke2, defaultK3s
+        fetchK8sVersions, rke2Versions, k3sVersions, defaultRke2, defaultK3s
       } = useKubernetesVersions(baseProps());
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
       expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
@@ -249,47 +244,12 @@ describe('composable: useKubernetesVersions', () => {
       mockGetters['management/canList'] = () => false;
       mockGetters['management/all'] = () => [];
 
-      const { fetchRke2Versions, defaultRke2, defaultK3s } = useKubernetesVersions(baseProps());
+      const { fetchK8sVersions, defaultRke2, defaultK3s } = useKubernetesVersions(baseProps());
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(defaultRke2.value).toBe('v1.29.0+rke2r1');
       expect(defaultK3s.value).toBe('v1.29.0+k3s1');
-    });
-
-    it('fetches all PSAs when management/canList allows listing PSA', async() => {
-      const psas = [{ id: 'psa-1' }, { id: 'psa-2' }];
-
-      mockDispatch.mockImplementation(buildDispatch({ psas }));
-      mockGetters['management/canList'] = jest.fn(() => true);
-      mockGetters['management/all'] = () => [
-        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
-        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
-      ];
-
-      const { fetchRke2Versions, allPSAs } = useKubernetesVersions(baseProps());
-
-      await fetchRke2Versions();
-
-      expect(mockGetters['management/canList']).toHaveBeenCalledWith(MANAGEMENT.PSA);
-      expect(mockDispatch).toHaveBeenCalledWith('management/findAll', { type: MANAGEMENT.PSA });
-      expect(allPSAs.value).toStrictEqual(psas);
-    });
-
-    it('does not fetch PSAs when management/canList disallows listing PSA', async() => {
-      mockDispatch.mockImplementation(buildDispatch({ psas: [{ id: 'psa-1' }] }));
-      mockGetters['management/canList'] = jest.fn(() => false);
-      mockGetters['management/all'] = () => [
-        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
-        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
-      ];
-
-      const { fetchRke2Versions, allPSAs } = useKubernetesVersions(baseProps());
-
-      await fetchRke2Versions();
-
-      expect(mockDispatch).not.toHaveBeenCalledWith('management/findAll', expect.anything());
-      expect(allPSAs.value).toStrictEqual([]);
     });
 
     it('records an error instead of throwing when no version info is returned for either distro', async() => {
@@ -305,9 +265,9 @@ describe('composable: useKubernetesVersions', () => {
       mockGetters['management/canList'] = () => false;
       mockGetters['management/all'] = () => [];
 
-      const { fetchRke2Versions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
+      const { fetchK8sVersions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
 
-      await expect(fetchRke2Versions()).resolves.toBeUndefined();
+      await expect(fetchK8sVersions()).resolves.toBeUndefined();
       expect(fetchVersionsErrors.value).toStrictEqual(['No version info found in KDM']);
     });
 
@@ -328,40 +288,14 @@ describe('composable: useKubernetesVersions', () => {
       ];
 
       const {
-        fetchRke2Versions, rke2Versions, k3sVersions, fetchVersionsErrors
+        fetchK8sVersions, rke2Versions, k3sVersions, fetchVersionsErrors
       } = useKubernetesVersions(baseProps());
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(fetchVersionsErrors.value).toStrictEqual(['rke2 releases request failed']);
       expect(rke2Versions.value).toBeNull();
       expect(k3sVersions.value).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
-    });
-
-    it('records an error without throwing when the PSA request fails', async() => {
-      mockDispatch.mockImplementation((action: string, args: any = {}) => {
-        if (action === 'management/findAll') {
-          return Promise.reject(new Error('PSA request failed'));
-        }
-
-        return buildDispatch()(action, args);
-      });
-      mockGetters['management/canList'] = jest.fn(() => true);
-      mockGetters['management/all'] = () => [
-        { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
-        { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
-      ];
-
-      const {
-        fetchRke2Versions, allPSAs, rke2Versions, fetchVersionsErrors
-      } = useKubernetesVersions(baseProps());
-
-      await expect(fetchRke2Versions()).resolves.toBeUndefined();
-
-      expect(fetchVersionsErrors.value).toStrictEqual(['PSA request failed']);
-      expect(allPSAs.value).toStrictEqual([]);
-      // the failure is isolated to the PSA request - version data still loads normally
-      expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
     });
 
     it('retries a previously failed request on the next call, rather than treating the failure as "loaded"', async() => {
@@ -382,14 +316,14 @@ describe('composable: useKubernetesVersions', () => {
         { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
       ];
 
-      const { fetchRke2Versions, rke2Versions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
+      const { fetchK8sVersions, rke2Versions, fetchVersionsErrors } = useKubernetesVersions(baseProps());
 
-      await fetchRke2Versions();
+      await fetchK8sVersions();
       expect(rke2Versions.value).toBeNull();
       expect(fetchVersionsErrors.value).toStrictEqual(['rke2 releases request failed']);
 
       rke2ReleasesShouldFail = false;
-      await fetchRke2Versions();
+      await fetchK8sVersions();
 
       expect(rke2Versions.value).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
       expect(fetchVersionsErrors.value).toStrictEqual([]);

--- a/shell/composables/useKubernetesVersions.ts
+++ b/shell/composables/useKubernetesVersions.ts
@@ -125,7 +125,7 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
   }
 
   async function fetchRke2Versions() {
-    if (rke2Versions.value) {
+    if (rke2Versions.value !== null && k3sVersions.value !== null) {
       return;
     }
 

--- a/shell/composables/useKubernetesVersions.ts
+++ b/shell/composables/useKubernetesVersions.ts
@@ -106,22 +106,55 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
    */
   const chartVersions = computed(() => selectedVersion.value?.charts || {});
 
+  const fetchVersionsErrors = ref<string[]>([]);
+
+  /**
+   * Each request is caught individually so that one failing endpoint (e.g. PSAs, or one distro's
+   * releases/channels) doesn't wipe out data that loaded successfully from the others, and doesn't
+   * abort the caller's fetch() - the caller reads `fetchVersionsErrors` afterward and displays it
+   * (e.g. via `this.errors`) instead of the whole page failing to load.
+   */
+  async function safeRequest(url: string) {
+    try {
+      return await store.dispatch('management/request', { url });
+    } catch (e: any) {
+      fetchVersionsErrors.value.push(e?.message || String(e));
+
+      return undefined;
+    }
+  }
+
   async function fetchRke2Versions() {
     if (rke2Versions.value) {
       return;
     }
 
+    fetchVersionsErrors.value = [];
+
     const hash: Record<string, any> = {
-      rke2Versions: store.dispatch('management/request', { url: '/v1-rke2-release/releases' }),
-      k3sVersions:  store.dispatch('management/request', { url: '/v1-k3s-release/releases' }),
+      rke2Versions: safeRequest('/v1-rke2-release/releases'),
+      k3sVersions:  safeRequest('/v1-k3s-release/releases'),
     };
 
+    let nextAllPSAs: any[] | undefined;
+
     if (store.getters['management/canList'](MANAGEMENT.PSA)) {
-      hash.allPSAs = await store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
+      try {
+        nextAllPSAs = await store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
+      } catch (e: any) {
+        fetchVersionsErrors.value.push(e?.message || String(e));
+      }
     }
 
     // Get the latest versions from the global settings if possible
-    const globalSettings = await store.getters['management/all'](MANAGEMENT.SETTING) || [];
+    let globalSettings: any[] = [];
+
+    try {
+      globalSettings = (await store.getters['management/all'](MANAGEMENT.SETTING)) || [];
+    } catch (e: any) {
+      fetchVersionsErrors.value.push(e?.message || String(e));
+    }
+
     const defaultRke2Setting = globalSettings.find((setting: any) => setting.id === 'rke2-default-version') || {};
     const defaultK3sSetting = globalSettings.find((setting: any) => setting.id === 'k3s-default-version') || {};
 
@@ -130,37 +163,42 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
 
     // RKE2: Use the channel if we can not get the version from the settings
     if (!nextDefaultRke2) {
-      hash.rke2Channels = store.dispatch('management/request', { url: '/v1-rke2-release/channels' });
+      hash.rke2Channels = safeRequest('/v1-rke2-release/channels');
     }
 
     // K3S: Use the channel if we can not get the version from the settings
     if (!nextDefaultK3s) {
-      hash.k3sChannels = store.dispatch('management/request', { url: '/v1-k3s-release/channels' });
+      hash.k3sChannels = safeRequest('/v1-k3s-release/channels');
     }
 
     const res = await allHash(hash);
 
-    const nextRke2Versions = res.rke2Versions.data || [];
-    const nextK3sVersions = res.k3sVersions.data || [];
+    const nextRke2Versions = res.rke2Versions?.data || [];
+    const nextK3sVersions = res.k3sVersions?.data || [];
 
-    allPSAs.value = res.allPSAs || [];
-    rke2Versions.value = nextRke2Versions;
-    k3sVersions.value = nextK3sVersions;
+    allPSAs.value = nextAllPSAs || [];
 
-    if (!nextDefaultRke2) {
+    if (res.rke2Versions) {
+      rke2Versions.value = nextRke2Versions;
+    }
+    if (res.k3sVersions) {
+      k3sVersions.value = nextK3sVersions;
+    }
+
+    if (!nextDefaultRke2 && res.rke2Channels) {
       const rke2Channels = res.rke2Channels.data || [];
 
       nextDefaultRke2 = rke2Channels.find((x: any) => x.id === 'default')?.latest;
     }
 
-    if (!nextDefaultK3s) {
+    if (!nextDefaultK3s && res.k3sChannels) {
       const k3sChannels = res.k3sChannels.data || [];
 
       nextDefaultK3s = k3sChannels.find((x: any) => x.id === 'default')?.latest;
     }
 
     if (!nextRke2Versions.length && !nextK3sVersions.length) {
-      throw new Error('No version info found in KDM');
+      fetchVersionsErrors.value.push('No version info found in KDM');
     }
 
     // Store default versions
@@ -182,6 +220,7 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
     agentArgs,
     chartVersions,
     fetchRke2Versions,
+    fetchVersionsErrors,
   };
 }
 

--- a/shell/composables/useKubernetesVersions.ts
+++ b/shell/composables/useKubernetesVersions.ts
@@ -12,6 +12,13 @@ export interface UseKubernetesVersionsProps {
   liveValue: any;
   value: any;
 }
+export interface KubernetesDistroVersion {
+  id: string;
+  serverArgs?: Record<string, any>;
+  agentArgs?: Record<string, any>;
+  charts?: Record<string, { repo: string; version: string }>;
+  [key: string]: any;
+}
 
 /**
  * Resolves the RKE2/K3s Kubernetes version list, the version currently selected on the cluster
@@ -21,11 +28,10 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
   const store = useStore();
   const { t } = useI18n(store);
 
-  const rke2Versions = ref<any[] | null>(null);
-  const k3sVersions = ref<any[] | null>(null);
+  const rke2Versions = ref<KubernetesDistroVersion[] | null>(null);
+  const k3sVersions = ref<KubernetesDistroVersion[] | null>(null);
   const defaultRke2 = ref('');
   const defaultK3s = ref('');
-  const allPSAs = ref<any[]>([]);
   const showDeprecatedPatchVersions = ref(false);
 
   const versionOptions = computed(() => {
@@ -109,7 +115,7 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
   const fetchVersionsErrors = ref<string[]>([]);
 
   /**
-   * Each request is caught individually so that one failing endpoint (e.g. PSAs, or one distro's
+   * Each request is caught individually so that one failing endpoint (one distro's
    * releases/channels) doesn't wipe out data that loaded successfully from the others, and doesn't
    * abort the caller's fetch() - the caller reads `fetchVersionsErrors` afterward and displays it
    * (e.g. via `this.errors`) instead of the whole page failing to load.
@@ -124,7 +130,7 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
     }
   }
 
-  async function fetchRke2Versions() {
+  async function fetchK8sVersions() {
     if (rke2Versions.value !== null && k3sVersions.value !== null) {
       return;
     }
@@ -135,16 +141,6 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
       rke2Versions: safeRequest('/v1-rke2-release/releases'),
       k3sVersions:  safeRequest('/v1-k3s-release/releases'),
     };
-
-    let nextAllPSAs: any[] | undefined;
-
-    if (store.getters['management/canList'](MANAGEMENT.PSA)) {
-      try {
-        nextAllPSAs = await store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
-      } catch (e: any) {
-        fetchVersionsErrors.value.push(e?.message || String(e));
-      }
-    }
 
     // Get the latest versions from the global settings if possible
     let globalSettings: any[] = [];
@@ -175,8 +171,6 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
 
     const nextRke2Versions = res.rke2Versions?.data || [];
     const nextK3sVersions = res.k3sVersions?.data || [];
-
-    allPSAs.value = nextAllPSAs || [];
 
     if (res.rke2Versions) {
       rke2Versions.value = nextRke2Versions;
@@ -211,7 +205,6 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
     k3sVersions,
     defaultRke2,
     defaultK3s,
-    allPSAs,
     showDeprecatedPatchVersions,
     versionOptions,
     selectedVersion,
@@ -219,7 +212,7 @@ export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
     serverArgs,
     agentArgs,
     chartVersions,
-    fetchRke2Versions,
+    fetchK8sVersions,
     fetchVersionsErrors,
   };
 }
@@ -228,7 +221,7 @@ export interface GetDefaultVersionOptions {
   store: any;
   versionOptions: any[];
   defaultRke2: string;
-  rke2Versions: any[] | null;
+  rke2Versions: KubernetesDistroVersion[] | null;
   /**
    * Kept as a plain boolean input rather than something this composable derives itself:
    * it's owned by an Options API computed on the consuming component (reads $route), and

--- a/shell/composables/useKubernetesVersions.ts
+++ b/shell/composables/useKubernetesVersions.ts
@@ -1,0 +1,232 @@
+import { ref, computed } from 'vue';
+import { useStore } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
+import { MANAGEMENT } from '@shell/config/types';
+import { _EDIT } from '@shell/config/query-params';
+import { findBy } from '@shell/utils/array';
+import { allHash } from '@shell/utils/promise';
+import { getAllOptionsAfterCurrentVersion, filterOutDeprecatedPatchVersions, isHarvesterSatisfiesVersion } from '@shell/utils/cluster';
+
+export interface UseKubernetesVersionsProps {
+  mode: string;
+  liveValue: any;
+  value: any;
+}
+
+/**
+ * Resolves the RKE2/K3s Kubernetes version list, the version currently selected on the cluster
+ * being edited, and the server/agent arg and chart metadata that come with that version.
+ */
+export function useKubernetesVersions(props: UseKubernetesVersionsProps) {
+  const store = useStore();
+  const { t } = useI18n(store);
+
+  const rke2Versions = ref<any[] | null>(null);
+  const k3sVersions = ref<any[] | null>(null);
+  const defaultRke2 = ref('');
+  const defaultK3s = ref('');
+  const allPSAs = ref<any[]>([]);
+  const showDeprecatedPatchVersions = ref(false);
+
+  const versionOptions = computed(() => {
+    const cur = props.liveValue?.spec?.kubernetesVersion || '';
+    const existingRke2 = props.mode === _EDIT && cur.includes('rke2');
+    const existingK3s = props.mode === _EDIT && cur.includes('k3s');
+
+    let allValidRke2Versions = getAllOptionsAfterCurrentVersion(store, rke2Versions.value, (existingRke2 ? cur : null), defaultRke2.value);
+    let allValidK3sVersions = getAllOptionsAfterCurrentVersion(store, k3sVersions.value, (existingK3s ? cur : null), defaultK3s.value);
+
+    if (!showDeprecatedPatchVersions.value) {
+      // Normally, we only want to show the most recent patch version
+      // for each Kubernetes minor version. However, if the user
+      // opts in to showing deprecated versions, we don't filter them.
+      allValidRke2Versions = filterOutDeprecatedPatchVersions(allValidRke2Versions, cur);
+      allValidK3sVersions = filterOutDeprecatedPatchVersions(allValidK3sVersions, cur);
+    }
+
+    const showRke2 = allValidRke2Versions.length && !existingK3s;
+    const showK3s = allValidK3sVersions.length && !existingRke2;
+    const out: any[] = [];
+
+    if (showRke2) {
+      if (showK3s) {
+        out.push({ kind: 'group', label: t('cluster.provider.rke2') });
+      }
+
+      out.push(...allValidRke2Versions);
+    }
+
+    if (showK3s) {
+      if (showRke2) {
+        out.push({ kind: 'group', label: t('cluster.provider.k3s') });
+      }
+
+      out.push(...allValidK3sVersions);
+    }
+
+    if (cur) {
+      const existing = out.find((x) => x.value === cur);
+
+      if (existing) {
+        existing.disabled = false;
+      }
+    }
+
+    return out;
+  });
+
+  const selectedVersion = computed(() => {
+    const str = props.value?.spec?.kubernetesVersion;
+
+    if (!str) {
+      return undefined;
+    }
+
+    const out = findBy(versionOptions.value, 'value', str);
+
+    // Adding the option 'none' to Container Network select (used in Basics component)
+    // https://github.com/rancher/dashboard/issues/10338
+    // there's an update loop on refresh that might include 'none'
+    // multiple times... Prevent that
+    if (out?.serverArgs?.cni?.options && !out.serverArgs?.cni?.options.includes('none')) {
+      out.serverArgs.cni.options.push('none');
+    }
+
+    return out;
+  });
+
+  const haveArgInfo = computed(() => Boolean(selectedVersion.value?.serverArgs && selectedVersion.value?.agentArgs));
+  const serverArgs = computed(() => selectedVersion.value?.serverArgs || {});
+  const agentArgs = computed(() => selectedVersion.value?.agentArgs || {});
+
+  /**
+   * The addons (charts) applicable for the selected k8s version
+   *
+   * { [chartName:string]: { repo: string, version: string } }
+   */
+  const chartVersions = computed(() => selectedVersion.value?.charts || {});
+
+  async function fetchRke2Versions() {
+    if (rke2Versions.value) {
+      return;
+    }
+
+    const hash: Record<string, any> = {
+      rke2Versions: store.dispatch('management/request', { url: '/v1-rke2-release/releases' }),
+      k3sVersions:  store.dispatch('management/request', { url: '/v1-k3s-release/releases' }),
+    };
+
+    if (store.getters['management/canList'](MANAGEMENT.PSA)) {
+      hash.allPSAs = await store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
+    }
+
+    // Get the latest versions from the global settings if possible
+    const globalSettings = await store.getters['management/all'](MANAGEMENT.SETTING) || [];
+    const defaultRke2Setting = globalSettings.find((setting: any) => setting.id === 'rke2-default-version') || {};
+    const defaultK3sSetting = globalSettings.find((setting: any) => setting.id === 'k3s-default-version') || {};
+
+    let nextDefaultRke2 = defaultRke2Setting?.value || defaultRke2Setting?.default;
+    let nextDefaultK3s = defaultK3sSetting?.value || defaultK3sSetting?.default;
+
+    // RKE2: Use the channel if we can not get the version from the settings
+    if (!nextDefaultRke2) {
+      hash.rke2Channels = store.dispatch('management/request', { url: '/v1-rke2-release/channels' });
+    }
+
+    // K3S: Use the channel if we can not get the version from the settings
+    if (!nextDefaultK3s) {
+      hash.k3sChannels = store.dispatch('management/request', { url: '/v1-k3s-release/channels' });
+    }
+
+    const res = await allHash(hash);
+
+    const nextRke2Versions = res.rke2Versions.data || [];
+    const nextK3sVersions = res.k3sVersions.data || [];
+
+    allPSAs.value = res.allPSAs || [];
+    rke2Versions.value = nextRke2Versions;
+    k3sVersions.value = nextK3sVersions;
+
+    if (!nextDefaultRke2) {
+      const rke2Channels = res.rke2Channels.data || [];
+
+      nextDefaultRke2 = rke2Channels.find((x: any) => x.id === 'default')?.latest;
+    }
+
+    if (!nextDefaultK3s) {
+      const k3sChannels = res.k3sChannels.data || [];
+
+      nextDefaultK3s = k3sChannels.find((x: any) => x.id === 'default')?.latest;
+    }
+
+    if (!nextRke2Versions.length && !nextK3sVersions.length) {
+      throw new Error('No version info found in KDM');
+    }
+
+    // Store default versions
+    defaultRke2.value = nextDefaultRke2;
+    defaultK3s.value = nextDefaultK3s;
+  }
+
+  return {
+    rke2Versions,
+    k3sVersions,
+    defaultRke2,
+    defaultK3s,
+    allPSAs,
+    showDeprecatedPatchVersions,
+    versionOptions,
+    selectedVersion,
+    haveArgInfo,
+    serverArgs,
+    agentArgs,
+    chartVersions,
+    fetchRke2Versions,
+  };
+}
+
+export interface GetDefaultVersionOptions {
+  store: any;
+  versionOptions: any[];
+  defaultRke2: string;
+  rke2Versions: any[] | null;
+  /**
+   * Kept as a plain boolean input rather than something this composable derives itself:
+   * it's owned by an Options API computed on the consuming component (reads $route), and
+   * setup() runs before Options API computed are initialized, so it can't be read from here.
+   */
+  isHarvesterDriver: boolean;
+}
+
+/**
+ * Picks the version to preselect for a new cluster: the first Harvester-compatible rke2
+ * version when on the Harvester driver, otherwise the configured default (falling back to
+ * the first available option).
+ */
+export function getDefaultVersion(options: GetDefaultVersionOptions): string | undefined {
+  const {
+    store, versionOptions, defaultRke2, rke2Versions, isHarvesterDriver
+  } = options;
+
+  const all = versionOptions.filter((x) => !!x.value);
+  const first = all[0]?.value;
+  const preferred = all.find((x) => x.value === defaultRke2)?.value;
+
+  const rke2 = getAllOptionsAfterCurrentVersion(store, rke2Versions, null);
+  const showRke2 = rke2.length;
+  let out;
+
+  if (isHarvesterDriver && showRke2) {
+    const satisfiesVersion = rke2.filter((v: any) => isHarvesterSatisfiesVersion(v.value)) || [];
+
+    if (satisfiesVersion.length > 0) {
+      out = satisfiesVersion[0]?.value;
+    }
+  }
+
+  if (!out) {
+    out = preferred || first;
+  }
+
+  return out;
+}

--- a/shell/composables/usePodSecurityAdmissionTemplates.test.ts
+++ b/shell/composables/usePodSecurityAdmissionTemplates.test.ts
@@ -1,0 +1,76 @@
+import { usePodSecurityAdmissionTemplates } from '@shell/composables/usePodSecurityAdmissionTemplates';
+import { MANAGEMENT } from '@shell/config/types';
+
+const mockGetters: Record<string, any> = {};
+const mockDispatch = jest.fn();
+
+jest.mock('vuex', () => ({
+  useStore: () => ({
+    getters: new Proxy(mockGetters, {
+      get(target, prop: string) {
+        return target[prop];
+      }
+    }),
+    dispatch: mockDispatch,
+  }),
+}));
+
+describe('composable: usePodSecurityAdmissionTemplates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mockGetters).forEach((key) => delete mockGetters[key]);
+  });
+
+  it('fetches all PSAs when management/canList allows listing PSA', async() => {
+    const psas = [{ id: 'psa-1' }, { id: 'psa-2' }];
+
+    mockDispatch.mockResolvedValue(psas);
+    mockGetters['management/canList'] = jest.fn(() => true);
+
+    const { allPSAs, fetchAllPSAs } = usePodSecurityAdmissionTemplates();
+
+    await fetchAllPSAs();
+
+    expect(mockGetters['management/canList']).toHaveBeenCalledWith(MANAGEMENT.PSA);
+    expect(mockDispatch).toHaveBeenCalledWith('management/findAll', { type: MANAGEMENT.PSA });
+    expect(allPSAs.value).toStrictEqual(psas);
+  });
+
+  it('does not fetch PSAs when management/canList disallows listing PSA', async() => {
+    mockDispatch.mockResolvedValue([{ id: 'psa-1' }]);
+    mockGetters['management/canList'] = jest.fn(() => false);
+
+    const { allPSAs, fetchAllPSAs } = usePodSecurityAdmissionTemplates();
+
+    await fetchAllPSAs();
+
+    expect(mockDispatch).not.toHaveBeenCalledWith('management/findAll', expect.anything());
+    expect(allPSAs.value).toStrictEqual([]);
+  });
+
+  it('records an error without throwing when the PSA request fails', async() => {
+    mockDispatch.mockRejectedValue(new Error('PSA request failed'));
+    mockGetters['management/canList'] = jest.fn(() => true);
+
+    const { allPSAs, fetchAllPSAs, psaErrors } = usePodSecurityAdmissionTemplates();
+
+    await expect(fetchAllPSAs()).resolves.toBeUndefined();
+
+    expect(psaErrors.value).toStrictEqual(['PSA request failed']);
+    expect(allPSAs.value).toStrictEqual([]);
+  });
+
+  it('clears prior errors at the start of each fetch', async() => {
+    mockGetters['management/canList'] = jest.fn(() => true);
+
+    const { fetchAllPSAs, psaErrors } = usePodSecurityAdmissionTemplates();
+
+    mockDispatch.mockRejectedValueOnce(new Error('PSA request failed'));
+    await fetchAllPSAs();
+    expect(psaErrors.value).toStrictEqual(['PSA request failed']);
+
+    mockDispatch.mockResolvedValueOnce([{ id: 'psa-1' }]);
+    await fetchAllPSAs();
+    expect(psaErrors.value).toStrictEqual([]);
+  });
+});

--- a/shell/composables/usePodSecurityAdmissionTemplates.ts
+++ b/shell/composables/usePodSecurityAdmissionTemplates.ts
@@ -1,0 +1,40 @@
+import { ref } from 'vue';
+import { useStore } from 'vuex';
+import { MANAGEMENT } from '@shell/config/types';
+
+export interface PodSecurityAdmissionTemplate {
+  id: string;
+  nameDisplay: string;
+  [key: string]: any;
+}
+
+/**
+ * Loads the cluster-scoped Pod Security Admission configuration templates used to populate the
+ * "Default Pod Security Admission" dropdown on the provisioning cluster form.
+ */
+export function usePodSecurityAdmissionTemplates() {
+  const store = useStore();
+
+  const allPSAs = ref<PodSecurityAdmissionTemplate[]>([]);
+  const psaErrors = ref<string[]>([]);
+
+  async function fetchAllPSAs() {
+    psaErrors.value = [];
+
+    if (!store.getters['management/canList'](MANAGEMENT.PSA)) {
+      return;
+    }
+
+    try {
+      allPSAs.value = await store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
+    } catch (e: any) {
+      psaErrors.value.push(e?.message || String(e));
+    }
+  }
+
+  return {
+    allPSAs,
+    fetchAllPSAs,
+    psaErrors,
+  };
+}

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -850,7 +850,7 @@ describe('component: rke2', () => {
   });
 
   // Characterization tests written ahead of extracting Kubernetes-version resolution
-  // (versionOptions/selectedVersion/chartVersions/defaultVersion/fetchRke2Versions/cloudProviderOptions)
+  // (versionOptions/selectedVersion/chartVersions/defaultVersion/fetchK8sVersions/cloudProviderOptions)
   // into a composable.
   describe('kubernetes version resolution', () => {
     const version = (id: string, overrides: Record<string, any> = {}) => ({

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -441,30 +441,6 @@ describe('component: rke2', () => {
       data: (() => ({
         credentialId:    'I am authenticated',
         userChartValues: chartValues,
-        rke2Versions:    [
-          {
-            id:                      'v1.32.3+rke2r1',
-            type:                    'release',
-            links:                   { self: 'https://127.0.0.1:8005/v1-rke2-release/releases/v1.32.3+rke2r1' },
-            version:                 'v1.32.3+rke2r1',
-            minChannelServerVersion: 'v2.11.0-alpha1',
-            maxChannelServerVersion: 'v2.11.99',
-            serverArgs:              {},
-            agentArgs:               {},
-            featureVersions:         { 'encryption-key-rotation': '2.0.0' },
-            charts:                  {
-              'rke2-ingress-nginx': {
-                repo:    'rancher-rke2-charts',
-                version: '4.12.100'
-              },
-              'rke2-metrics-server': {
-                repo:    'rancher-rke2-charts',
-                version: '3.12.200'
-              },
-              'rke2-traefik': {}
-            }
-          }
-        ]
       })) as any,
 
       global: {
@@ -477,6 +453,34 @@ describe('component: rke2', () => {
         stubs: defaultStubs,
       },
     });
+
+    // rke2Versions is owned by the useKubernetesVersions composable (exposed via setup()), not
+    // component data - the `data` mount option / wrapper.setData() only reach `$data`, so it has
+    // to be seeded directly through the instance proxy instead.
+    (wrapper.vm as any).rke2Versions = [
+      {
+        id:                      'v1.32.3+rke2r1',
+        type:                    'release',
+        links:                   { self: 'https://127.0.0.1:8005/v1-rke2-release/releases/v1.32.3+rke2r1' },
+        version:                 'v1.32.3+rke2r1',
+        minChannelServerVersion: 'v2.11.0-alpha1',
+        maxChannelServerVersion: 'v2.11.99',
+        serverArgs:              {},
+        agentArgs:               {},
+        featureVersions:         { 'encryption-key-rotation': '2.0.0' },
+        charts:                  {
+          'rke2-ingress-nginx': {
+            repo:    'rancher-rke2-charts',
+            version: '4.12.100'
+          },
+          'rke2-metrics-server': {
+            repo:    'rancher-rke2-charts',
+            version: '3.12.200'
+          },
+          'rke2-traefik': {}
+        }
+      }
+    ];
 
     rke2Vm(wrapper).applyChartValues(wrapper.vm.value.spec.rkeConfig);
 
@@ -523,14 +527,16 @@ describe('component: rke2', () => {
     it('should set ingress-controller to traefik by default for new clusters', async() => {
       const wrapper = createWrapper(_CREATE);
 
-      await wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+        charts:     mockCharts
+      }];
+
+      // The traefik default is set by the `selectedVersion` watcher (via initServerAgentArgs), which
+      // Vue flushes on the next tick rather than synchronously.
+      await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.value.spec.rkeConfig.machineGlobalConfig[INGRESS_CONTROLLER]).toBe(TRAEFIK);
     });
@@ -539,20 +545,18 @@ describe('component: rke2', () => {
       const wrapper = createWrapper();
       const newVersion = 'v1.26.0+rke2r1';
 
-      await wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [] } },
-          charts:     mockCharts
-        },
-        {
-          id:         newVersion,
-          version:    newVersion,
-          serverArgs: { disable: { options: [] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [] } },
+        charts:     mockCharts
+      },
+      {
+        id:         newVersion,
+        version:    newVersion,
+        serverArgs: { disable: { options: [] } },
+        charts:     mockCharts
+      }];
       wrapper.vm.value.spec.kubernetesVersion = newVersion;
       (wrapper.vm as any).handleKubernetesChange(newVersion);
       expect(wrapper.vm.value.spec.rkeConfig.machineGlobalConfig[INGRESS_CONTROLLER]).toBe(INGRESS_NONE);
@@ -561,14 +565,12 @@ describe('component: rke2', () => {
     it('should set ingress-controller to ingress-nginx on change when nginx is supported and not disabled', () => {
       const wrapper = createWrapper();
 
-      wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+        charts:     mockCharts
+      }];
 
       (wrapper.vm as any).handleEnabledSystemServicesChanged([]);
 
@@ -578,14 +580,12 @@ describe('component: rke2', () => {
     it('should set ingress-controller to None when nginx is supported but disabled', () => {
       const wrapper = createWrapper();
 
-      wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+        charts:     mockCharts
+      }];
 
       (wrapper.vm as any).handleEnabledSystemServicesChanged([RKE2_INGRESS_NGINX]);
 
@@ -595,14 +595,12 @@ describe('component: rke2', () => {
     it('should set ingress-controller for existing cluster to None when nginx is not supported', () => {
       const wrapper = createWrapper();
 
-      wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [] } },
+        charts:     mockCharts
+      }];
 
       (wrapper.vm as any).handleEnabledSystemServicesChanged([]);
 
@@ -612,14 +610,12 @@ describe('component: rke2', () => {
     it('should correctly update disable list in serverConfig', () => {
       const wrapper = createWrapper();
 
-      wrapper.setData({
-        rke2Versions: [{
-          id:         k8sVersion,
-          version:    k8sVersion,
-          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-          charts:     mockCharts
-        }]
-      });
+      (wrapper.vm as any).rke2Versions = [{
+        id:         k8sVersion,
+        version:    k8sVersion,
+        serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+        charts:     mockCharts
+      }];
       const disabledServices = ['other-service'];
 
       (wrapper.vm as any).handleEnabledSystemServicesChanged(disabledServices);
@@ -631,22 +627,20 @@ describe('component: rke2', () => {
       const wrapper = createWrapper();
       const newVersion = 'v1.26.0+rke2r1';
 
-      await wrapper.setData({
-        rke2Versions: [
-          {
-            id:         k8sVersion,
-            version:    k8sVersion,
-            serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-            charts:     mockCharts
-          },
-          {
-            id:         newVersion,
-            version:    newVersion,
-            serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
-            charts:     mockCharts
-          }
-        ]
-      });
+      (wrapper.vm as any).rke2Versions = [
+        {
+          id:         k8sVersion,
+          version:    k8sVersion,
+          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+          charts:     mockCharts
+        },
+        {
+          id:         newVersion,
+          version:    newVersion,
+          serverArgs: { disable: { options: [RKE2_INGRESS_NGINX] } },
+          charts:     mockCharts
+        }
+      ];
 
       wrapper.vm.value.spec.kubernetesVersion = newVersion;
       (wrapper.vm as any).handleKubernetesChange(newVersion);
@@ -878,108 +872,6 @@ describe('component: rke2', () => {
       t:                           (key: string) => key,
     };
 
-    describe('versionOptions', () => {
-      it('groups rke2 and k3s versions with a header when both are present', () => {
-        const vm = {
-          ...baseVm,
-          rke2Versions: [version('v1.28.0+rke2r1')],
-          k3sVersions:  [version('v1.28.0+k3s1')],
-        };
-
-        const options = (rke2.computed as any).versionOptions.call(vm);
-
-        expect(options[0]).toStrictEqual({ kind: 'group', label: 'cluster.provider.rke2' });
-        expect(options.some((o: any) => o.value === 'v1.28.0+rke2r1')).toBe(true);
-        expect(options.some((o: any) => o.kind === 'group' && o.label === 'cluster.provider.k3s')).toBe(true);
-        expect(options.some((o: any) => o.value === 'v1.28.0+k3s1')).toBe(true);
-      });
-
-      it('omits the k3s group when only rke2 versions are present', () => {
-        const vm = { ...baseVm, rke2Versions: [version('v1.28.0+rke2r1')] };
-
-        const options = (rke2.computed as any).versionOptions.call(vm);
-
-        expect(options.some((o: any) => o.kind === 'group')).toBe(false);
-        expect(options).toHaveLength(1);
-        expect(options[0].value).toBe('v1.28.0+rke2r1');
-      });
-
-      it('excludes k3s versions in edit mode when the live version is rke2', () => {
-        const vm = {
-          ...baseVm,
-          mode:         _EDIT,
-          liveValue:    { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
-          rke2Versions: [version('v1.28.0+rke2r1'), version('v1.29.0+rke2r1')],
-          k3sVersions:  [version('v1.28.0+k3s1')],
-        };
-
-        const options = (rke2.computed as any).versionOptions.call(vm);
-
-        expect(options.some((o: any) => o.value?.includes('k3s'))).toBe(false);
-      });
-
-      it('filters out deprecated patch versions by default', () => {
-        const vm = {
-          ...baseVm,
-          showDeprecatedPatchVersions: false,
-          rke2Versions:                [version('v1.28.0+rke2r1'), version('v1.28.1+rke2r1')],
-        };
-
-        const options = (rke2.computed as any).versionOptions.call(vm);
-
-        expect(options.map((o: any) => o.value)).toStrictEqual(['v1.28.1+rke2r1']);
-      });
-    });
-
-    describe('selectedVersion', () => {
-      it('returns undefined when no kubernetesVersion is set', () => {
-        const vm = {
-          ...baseVm, value: { spec: {} }, versionOptions: []
-        };
-
-        expect((rke2.computed as any).selectedVersion.call(vm)).toBeUndefined();
-      });
-
-      it('finds the matching version option by kubernetesVersion', () => {
-        const match = { value: 'v1.28.0+rke2r1', serverArgs: {} };
-        const vm = {
-          ...baseVm,
-          value:          { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
-          versionOptions: [match, { value: 'v1.29.0+rke2r1' }],
-        };
-
-        expect((rke2.computed as any).selectedVersion.call(vm)).toBe(match);
-      });
-
-      it('adds a "none" cni option once, without duplicating it on repeated access', () => {
-        const match = { value: 'v1.28.0+rke2r1', serverArgs: { cni: { options: ['calico'] } } };
-        const vm = {
-          ...baseVm,
-          value:          { spec: { kubernetesVersion: 'v1.28.0+rke2r1' } },
-          versionOptions: [match],
-        };
-
-        (rke2.computed as any).selectedVersion.call(vm);
-        (rke2.computed as any).selectedVersion.call(vm);
-
-        expect(match.serverArgs.cni.options).toStrictEqual(['calico', 'none']);
-      });
-    });
-
-    describe('chartVersions', () => {
-      it('returns the charts of the selected version', () => {
-        const vm = { selectedVersion: { charts: { 'rke2-ingress-nginx': { version: '1.0.0' } } } };
-
-        expect((rke2.computed as any).chartVersions.call(vm)).toStrictEqual({ 'rke2-ingress-nginx': { version: '1.0.0' } });
-      });
-
-      it('returns an empty object when there is no selected version', () => {
-        const vm = { selectedVersion: undefined };
-
-        expect((rke2.computed as any).chartVersions.call(vm)).toStrictEqual({});
-      });
-    });
-
     describe('defaultVersion', () => {
       it('prefers the version matching the defaultRke2 setting when present among version options', () => {
         const vm = {
@@ -1086,111 +978,6 @@ describe('component: rke2', () => {
 
         expect(options[0]).toStrictEqual({ label: 'legacy-provider (Current)', value: 'legacy-provider' });
       });
-    });
-  });
-
-  // Characterization tests written ahead of extracting fetchRke2Versions into a composable.
-  describe('methods: fetchRke2Versions', () => {
-    const buildStore = ({ canListPsa = false, settings = [] as any[], channelResponses = {} as Record<string, any[]> } = {}) => {
-      const dispatch = jest.fn((action: string, args: any = {}) => {
-        const { url } = args;
-
-        if (action === 'management/request') {
-          if (url === '/v1-rke2-release/releases') {
-            return Promise.resolve({ data: [{ id: 'v1.28.0+rke2r1', serverArgs: {} }] });
-          }
-          if (url === '/v1-k3s-release/releases') {
-            return Promise.resolve({ data: [{ id: 'v1.28.0+k3s1', serverArgs: {} }] });
-          }
-          if (url === '/v1-rke2-release/channels') {
-            return Promise.resolve({ data: channelResponses.rke2 || [] });
-          }
-          if (url === '/v1-k3s-release/channels') {
-            return Promise.resolve({ data: channelResponses.k3s || [] });
-          }
-        }
-
-        if (action === 'management/findAll') {
-          return Promise.resolve([]);
-        }
-
-        return Promise.resolve();
-      });
-
-      return {
-        dispatch,
-        getters: {
-          'management/canList': () => canListPsa,
-          'management/all':     () => settings,
-        },
-      };
-    };
-
-    it('does nothing when versions are already loaded', async() => {
-      const dispatch = jest.fn();
-      const vm = { rke2Versions: [{ id: 'cached' }], $store: { dispatch, getters: {} } } as any;
-
-      await (rke2.methods as any).fetchRke2Versions.call(vm);
-
-      expect(dispatch).not.toHaveBeenCalled();
-    });
-
-    it('populates versions and default versions from global settings when present', async() => {
-      const vm = {
-        rke2Versions: null,
-        k3sVersions:  null,
-        $store:       buildStore({
-          settings: [
-            { id: 'rke2-default-version', value: 'v1.28.0+rke2r1' },
-            { id: 'k3s-default-version', value: 'v1.28.0+k3s1' },
-          ],
-        }),
-      } as any;
-
-      await (rke2.methods as any).fetchRke2Versions.call(vm);
-
-      expect(vm.rke2Versions).toStrictEqual([{ id: 'v1.28.0+rke2r1', serverArgs: {} }]);
-      expect(vm.k3sVersions).toStrictEqual([{ id: 'v1.28.0+k3s1', serverArgs: {} }]);
-      expect(vm.defaultRke2).toBe('v1.28.0+rke2r1');
-      expect(vm.defaultK3s).toBe('v1.28.0+k3s1');
-    });
-
-    it('falls back to the default channel latest version when no setting value/default exists', async() => {
-      const vm = {
-        rke2Versions: null,
-        k3sVersions:  null,
-        $store:       buildStore({
-          settings:         [],
-          channelResponses: {
-            rke2: [{ id: 'default', latest: 'v1.29.0+rke2r1' }],
-            k3s:  [{ id: 'default', latest: 'v1.29.0+k3s1' }],
-          },
-        }),
-      } as any;
-
-      await (rke2.methods as any).fetchRke2Versions.call(vm);
-
-      expect(vm.defaultRke2).toBe('v1.29.0+rke2r1');
-      expect(vm.defaultK3s).toBe('v1.29.0+k3s1');
-    });
-
-    it('throws when no version info is returned for either distro', async() => {
-      const dispatch = jest.fn((action: string, args: any = {}) => {
-        const { url } = args;
-
-        if (url?.includes('/releases') || url?.includes('/channels')) {
-          return Promise.resolve({ data: [] });
-        }
-
-        return Promise.resolve();
-      });
-      const vm = {
-        rke2Versions: null,
-        k3sVersions:  null,
-        $store:       { dispatch, getters: { 'management/canList': () => false, 'management/all': () => [] } },
-      } as any;
-
-      await expect((rke2.methods as any).fetchRke2Versions.call(vm)).rejects.toThrow('No version info found in KDM');
     });
   });
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
+import { usePodSecurityAdmissionTemplates } from '@shell/composables/usePodSecurityAdmissionTemplates';
 import { normalizeName } from '@shell/utils/kube';
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
@@ -149,12 +150,17 @@ export default {
   },
 
   setup(props) {
-    return useKubernetesVersions(props);
+    return {
+      ...useKubernetesVersions(props),
+      ...usePodSecurityAdmissionTemplates(),
+    };
   },
 
   async fetch() {
-    await this.fetchRke2Versions();
+    await this.fetchK8sVersions();
     this.errors = this.errors.concat(this.fetchVersionsErrors);
+    await this.fetchAllPSAs();
+    this.errors = this.errors.concat(this.psaErrors);
     await this.initSpecs();
     await this.initAddons();
     await this.initRegistry();

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -5,6 +5,7 @@ import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
+import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
 import { normalizeName } from '@shell/utils/kube';
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
@@ -21,15 +22,12 @@ import {
 } from '@shell/config/types';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 
-import { findBy, removeObject, clear } from '@shell/utils/array';
+import { removeObject, clear } from '@shell/utils/array';
 import { createYaml } from '@shell/utils/create-yaml';
 import {
   clone, diff, set, get, isEmpty, mergeWithReplace
 } from '@shell/utils/object';
-import { allHash } from '@shell/utils/promise';
-import {
-  getAllOptionsAfterCurrentVersion, filterOutDeprecatedPatchVersions, isHarvesterSatisfiesVersion, labelForAddon, initSchedulingCustomization, addonConfigPreserve,
-} from '@shell/utils/cluster';
+import { labelForAddon, initSchedulingCustomization, addonConfigPreserve } from '@shell/utils/cluster';
 import { AGENT_CONFIGURATION_TYPES, SETTING } from '@shell/config/settings';
 
 import { BadgeState } from '@components/BadgeState';
@@ -150,6 +148,10 @@ export default {
     }
   },
 
+  setup(props) {
+    return useKubernetesVersions(props);
+  },
+
   async fetch() {
     await this.fetchRke2Versions();
     await this.initSpecs();
@@ -236,15 +238,10 @@ export default {
     return {
       loadedOnce:                      false,
       lastIdx:                         0,
-      allPSAs:                         [],
       credentialId:                    '',
       credential:                      null,
       initialMachinePoolsValues:       {},
       machinePools:                    null,
-      rke2Versions:                    null,
-      k3sVersions:                     null,
-      defaultRke2:                     '',
-      defaultK3s:                      '',
       s3Backup:                        false,
       /**
        * All info related to a specific version of the chart
@@ -255,7 +252,6 @@ export default {
        */
       versionInfo:                     {},
       membershipUpdate:                {},
-      showDeprecatedPatchVersions:     false,
       systemRegistry:                  null,
       registryHost:                    null,
       showCustomRegistryInput:         false,
@@ -393,97 +389,6 @@ export default {
       console.log(`Global: ${ global }, Kubelet Only: ${ kubeletOnly }, Other: ${ other }`);
 
       return (global > 1 || other > 0);
-    },
-
-    versionOptions() {
-      const cur = this.liveValue?.spec?.kubernetesVersion || '';
-      const existingRke2 = this.mode === _EDIT && cur.includes('rke2');
-      const existingK3s = this.mode === _EDIT && cur.includes('k3s');
-
-      let allValidRke2Versions = getAllOptionsAfterCurrentVersion(this.$store, this.rke2Versions, (existingRke2 ? cur : null), this.defaultRke2);
-      let allValidK3sVersions = getAllOptionsAfterCurrentVersion(this.$store, this.k3sVersions, (existingK3s ? cur : null), this.defaultK3s);
-
-      if (!this.showDeprecatedPatchVersions) {
-        // Normally, we only want to show the most recent patch version
-        // for each Kubernetes minor version. However, if the user
-        // opts in to showing deprecated versions, we don't filter them.
-        allValidRke2Versions = filterOutDeprecatedPatchVersions(allValidRke2Versions, cur);
-        allValidK3sVersions = filterOutDeprecatedPatchVersions(allValidK3sVersions, cur);
-      }
-
-      const showRke2 = allValidRke2Versions.length && !existingK3s;
-      const showK3s = allValidK3sVersions.length && !existingRke2;
-      const out = [];
-
-      if (showRke2) {
-        if (showK3s) {
-          out.push({ kind: 'group', label: this.t('cluster.provider.rke2') });
-        }
-
-        out.push(...allValidRke2Versions);
-      }
-
-      if (showK3s) {
-        if (showRke2) {
-          out.push({ kind: 'group', label: this.t('cluster.provider.k3s') });
-        }
-
-        out.push(...allValidK3sVersions);
-      }
-
-      if (cur) {
-        const existing = out.find((x) => x.value === cur);
-
-        if (existing) {
-          existing.disabled = false;
-        }
-      }
-
-      return out;
-    },
-
-    /**
-     * Kube Version
-     */
-    selectedVersion() {
-      const str = this.value.spec.kubernetesVersion;
-
-      if (!str) {
-        return;
-      }
-
-      const out = findBy(this.versionOptions, 'value', str);
-
-      // Adding the option 'none' to Container Network select (used in Basics component)
-      // https://github.com/rancher/dashboard/issues/10338
-      // there's an update loop on refresh that might include 'none'
-      // multiple times... Prevent that
-      if (out?.serverArgs?.cni?.options && !out.serverArgs?.cni?.options.includes('none')) {
-        out.serverArgs.cni.options.push('none');
-      }
-
-      return out;
-    },
-
-    haveArgInfo() {
-      return Boolean(this.selectedVersion?.serverArgs && this.selectedVersion?.agentArgs);
-    },
-
-    serverArgs() {
-      return this.selectedVersion?.serverArgs || {};
-    },
-
-    agentArgs() {
-      return this.selectedVersion?.agentArgs || {};
-    },
-
-    /**
-     * The addons (kube charts) applicable for the selected kube version
-     *
-     * { [chartName:string]: { repo: string, version: string } }
-     */
-    chartVersions() {
-      return this.selectedVersion?.charts || {};
     },
 
     needCredential() {
@@ -757,29 +662,13 @@ export default {
     },
 
     defaultVersion() {
-      const all = this.versionOptions.filter((x) => !!x.value);
-      const first = all[0]?.value;
-      const preferred = all.find((x) => x.value === this.defaultRke2)?.value;
-
-      const rke2 = getAllOptionsAfterCurrentVersion(this.$store, this.rke2Versions, null);
-      const showRke2 = rke2.length;
-      let out;
-
-      if (this.isHarvesterDriver && showRke2) {
-        const satisfiesVersion = rke2.filter((v) => {
-          return isHarvesterSatisfiesVersion(v.value);
-        }) || [];
-
-        if (satisfiesVersion.length > 0) {
-          out = satisfiesVersion[0]?.value;
-        }
-      }
-
-      if (!out) {
-        out = preferred || first;
-      }
-
-      return out;
+      return getDefaultVersion({
+        store:             this.$store,
+        versionOptions:    this.versionOptions,
+        defaultRke2:       this.defaultRke2,
+        rke2Versions:      this.rke2Versions,
+        isHarvesterDriver: this.isHarvesterDriver,
+      });
     },
 
     appsOSWarning() {
@@ -1200,66 +1089,6 @@ export default {
 
       await this.applyHooks(INIT_HOOKS, this.value);
       this.localValue = this.value;
-    },
-
-    /**
-     * Fetch RKE versions and their configurations to be mapped to the form
-     */
-    async fetchRke2Versions() {
-      if (!this.rke2Versions) {
-        const hash = {
-          rke2Versions: this.$store.dispatch('management/request', { url: '/v1-rke2-release/releases' }),
-          k3sVersions:  this.$store.dispatch('management/request', { url: '/v1-k3s-release/releases' }),
-        };
-
-        if (this.$store.getters['management/canList'](MANAGEMENT.PSA)) {
-          hash.allPSAs = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PSA });
-        }
-
-        // Get the latest versions from the global settings if possible
-        const globalSettings = await this.$store.getters['management/all'](MANAGEMENT.SETTING) || [];
-        const defaultRke2Setting = globalSettings.find((setting) => setting.id === 'rke2-default-version') || {};
-        const defaultK3sSetting = globalSettings.find((setting) => setting.id === 'k3s-default-version') || {};
-
-        let defaultRke2 = defaultRke2Setting?.value || defaultRke2Setting?.default;
-        let defaultK3s = defaultK3sSetting?.value || defaultK3sSetting?.default;
-
-        // RKE2: Use the channel if we can not get the version from the settings
-        if (!defaultRke2) {
-          hash.rke2Channels = this.$store.dispatch('management/request', { url: '/v1-rke2-release/channels' });
-        }
-
-        // K3S: Use the channel if we can not get the version from the settings
-        if (!defaultK3s) {
-          hash.k3sChannels = this.$store.dispatch('management/request', { url: '/v1-k3s-release/channels' });
-        }
-
-        const res = await allHash(hash);
-
-        this.allPSAs = res.allPSAs || [];
-        this.rke2Versions = res.rke2Versions.data || [];
-        this.k3sVersions = res.k3sVersions.data || [];
-
-        if (!defaultRke2) {
-          const rke2Channels = res.rke2Channels.data || [];
-
-          defaultRke2 = rke2Channels.find((x) => x.id === 'default')?.latest;
-        }
-
-        if (!defaultK3s) {
-          const k3sChannels = res.k3sChannels.data || [];
-
-          defaultK3s = k3sChannels.find((x) => x.id === 'default')?.latest;
-        }
-
-        if (!this.rke2Versions.length && !this.k3sVersions.length) {
-          throw new Error('No version info found in KDM');
-        }
-
-        // Store default versions
-        this.defaultRke2 = defaultRke2;
-        this.defaultK3s = defaultK3s;
-      }
     },
 
     setSchedulingCustomization({ event, agentType }) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -154,6 +154,7 @@ export default {
 
   async fetch() {
     await this.fetchRke2Versions();
+    this.errors = this.errors.concat(this.fetchVersionsErrors);
     await this.initSpecs();
     await this.initAddons();
     await this.initRegistry();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18940 
<!-- Define findings related to the feature or bug issue. -->
Moved kubernetes version management and pod security admissions management into their own composables. This decouples PSA fetching from version fetching.
As part of testing this PR, I noticed that we didn't have error handling for version fetch(page wouldn't display). Added missing error handling.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Change the Kubernetes Version on the Basics tab, then check the Server Args, Agent Config, and Add-Ons tabs actually re-render with values scoped to the new version
2.  Rapidly switch driver/provider selections before the version fetch resolves — confirm no race condition leaves the dropdown showing stale or mismatched options.
3. Trigger the version-fetch failure  — confirm the UI shows a reasonable error state; the unit test only covers "empty response," not an actual network/HTTP failure.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Testing should be mostly for regression. All v2prov and Harvester provisioning could be affected.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
