### PR TITLE
Redesign the login page with better support for multiple auth providers

### DIFF
--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -40,12 +40,14 @@ export class LoginPagePo extends PagePo {
   }
 
   /**
-   * Local is offered from the provider list like any other provider. It is absent
-   * when local is the only way in, because the form is already on screen.
+   * The way through to the local form, wherever the page has put it: a card in
+   * the provider list, or a link where a single external provider makes a list
+   * of two unnecessary. Absent when local is the only way in, because the form
+   * is already on screen.
    */
   useLocal() {
     return this.self().then(($page) => {
-      const elements = $page.find(LoginPagePo.LOCAL_OPTION_SELECTOR);
+      const elements = $page.find(LoginPagePo.USE_LOCAL_SELECTOR);
 
       return elements?.[0];
     });
@@ -64,8 +66,9 @@ export class LoginPagePo extends PagePo {
   }
 
   /**
-   * The list of alternative providers. Rendered whenever there is more than one
-   * way in, counting local, so a single external provider still gets a list.
+   * The list of alternative providers. Rendered once there are several external
+   * providers to choose between; a single one alongside local is offered as a
+   * link instead.
    */
   providerList(): ComponentPo {
     return new ComponentPo('[data-testid="login-provider-list"]');
@@ -92,8 +95,9 @@ export class LoginPagePo extends PagePo {
   }
 
   /**
-   * The link that reveals the list again. Shown in place of the list while a
-   * username and password form has the panel.
+   * The link back off the local form: to the list where there is one, or
+   * straight to the single external provider where there is not. Shown in place
+   * of the list while a username and password form has the panel.
    */
   chooseDifferentProvider(): ComponentPo {
     return new ComponentPo('[data-testid="login-provider-choose"]');
@@ -109,6 +113,11 @@ export class LoginPagePo extends PagePo {
 
   static readonly LOCAL_OPTION_SELECTOR = '[data-testid="login-provider-option-local"]';
 
+  static readonly USE_LOCAL_SELECTOR = [
+    LoginPagePo.LOCAL_OPTION_SELECTOR,
+    '[data-testid="login-useLocal"]',
+  ].join(', ');
+
   /**
    * Selectors that indicate the login page has rendered past its loading spinner. Kept in sync with
    * the accessors above/below: welcomeMessage (.login-welcome), username, useLocal and
@@ -117,7 +126,7 @@ export class LoginPagePo extends PagePo {
   static readonly FORM_READY_SELECTOR = [
     '.login-welcome',
     '[data-testid="local-login-username"]',
-    LoginPagePo.LOCAL_OPTION_SELECTOR,
+    LoginPagePo.USE_LOCAL_SELECTOR,
     '[data-testid="login-confirmation-accept-button"]',
   ].join(', ');
 

--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -3,6 +3,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import PasswordPo from '@/cypress/e2e/po/components/password.po';
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import { MEDIUM_TIMEOUT_OPT } from '~/cypress/support/utils/timeouts';
 
 export class LoginPagePo extends PagePo {
@@ -38,9 +39,13 @@ export class LoginPagePo extends PagePo {
     return useLocal ? useLocal.click() : cy;
   }
 
+  /**
+   * Local is offered from the provider list like any other provider. It is absent
+   * when local is the only way in, because the form is already on screen.
+   */
   useLocal() {
     return this.self().then(($page) => {
-      const elements = $page.find('[data-testid="login-useLocal"]');
+      const elements = $page.find(LoginPagePo.LOCAL_OPTION_SELECTOR);
 
       return elements?.[0];
     });
@@ -50,9 +55,59 @@ export class LoginPagePo extends PagePo {
     return new AsyncButtonPo('[data-testid="login-submit"]', this.self());
   }
 
+  /**
+   * The primary "Log in with <provider>" button for the currently selected
+   * auth provider.
+   */
+  providerSubmitButton(): ComponentPo {
+    return new ComponentPo('[data-testid="login-provider-submit"]', this.self());
+  }
+
+  /**
+   * The list of alternative providers. Rendered whenever there is more than one
+   * way in, counting local, so a single external provider still gets a list.
+   */
+  providerList(): ComponentPo {
+    return new ComponentPo('[data-testid="login-provider-list"]');
+  }
+
+  /**
+   * The scrolling part of the list, which holds the external providers. Local
+   * sits outside it so that it is always in reach.
+   */
+  providerScrollList(): ComponentPo {
+    return new ComponentPo('[data-testid="login-provider-scroll"]');
+  }
+
+  /**
+   * A provider in the list, keyed by its authconfig name. The provider on the
+   * primary button is not repeated here.
+   */
+  providerOption(id: string): ComponentPo {
+    return new ComponentPo(`[data-testid="login-provider-option-${ id }"]`);
+  }
+
+  selectProvider(id: string): Cypress.Chainable {
+    return this.providerOption(id).self().click();
+  }
+
+  /**
+   * The link that reveals the list again. Shown in place of the list while a
+   * username and password form has the panel.
+   */
+  chooseDifferentProvider(): ComponentPo {
+    return new ComponentPo('[data-testid="login-provider-choose"]');
+  }
+
+  rememberProviderCheckbox(): CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="login-provider-remember"]');
+  }
+
   confirmationAcceptButton(): ComponentPo {
     return new ComponentPo('[data-testid="login-confirmation-accept-button"]', this.self());
   }
+
+  static readonly LOCAL_OPTION_SELECTOR = '[data-testid="login-provider-option-local"]';
 
   /**
    * Selectors that indicate the login page has rendered past its loading spinner. Kept in sync with
@@ -62,7 +117,7 @@ export class LoginPagePo extends PagePo {
   static readonly FORM_READY_SELECTOR = [
     '.login-welcome',
     '[data-testid="local-login-username"]',
-    '[data-testid="login-useLocal"]',
+    LoginPagePo.LOCAL_OPTION_SELECTOR,
     '[data-testid="login-confirmation-accept-button"]',
   ].join(', ');
 

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -81,6 +81,232 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
     });
   });
 
+  it('Shows the local login form without a provider list when local is the only provider', () => {
+    LoginPagePo.goTo();
+
+    const loginPage = new LoginPagePo();
+
+    loginPage.waitForPage();
+    loginPage.providerList().checkNotExists();
+  });
+
+  describe('Multiple authentication providers', () => {
+    // Several IDPs can't be configured from a test, so the public provider list
+    // is stubbed. Everything under test here is client side.
+    const stubProviders = () => {
+      cy.intercept('GET', '/v1-public/authproviders*', {
+        statusCode: 200,
+        body:       {
+          type: 'collection',
+          data: [
+            {
+              id: 'local', type: 'localProvider', _type: 'localProvider'
+            },
+            {
+              id: 'okta-corp', type: 'oktaProvider', _type: 'oktaProvider'
+            },
+            {
+              id:          'okta-partner',
+              type:        'oktaProvider',
+              _type:       'oktaProvider',
+              description: 'Partners and contractors.',
+            },
+            {
+              id: 'gh-community', type: 'githubProvider', _type: 'githubProvider'
+            },
+          ],
+        },
+      }).as('authProviders');
+    };
+
+    beforeEach(() => {
+      stubProviders();
+      LoginPagePo.goTo();
+      cy.wait('@authProviders');
+    });
+
+    it('Offers a provider list instead of one button per provider', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+      loginPage.providerSubmitButton().checkVisible();
+      loginPage.providerList().checkVisible();
+
+      // The old per-provider button stack is gone.
+      cy.get('[data-testid="login-provider-submit"]').should('have.length', 1);
+    });
+
+    it('Lists the remaining providers, plus local, on the page', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerOption('okta-corp').checkVisible();
+      loginPage.providerOption('okta-partner').checkVisible();
+      loginPage.providerOption('local').checkVisible();
+      // The provider on the primary button is not offered twice.
+      loginPage.providerOption('gh-community').checkNotExists();
+    });
+
+    it('Describes a provider with the words the admin gave it', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerOption('okta-partner').shouldContainText('Partners and contractors.');
+    });
+
+    // However many providers are configured, local must not scroll out of reach.
+    it('Keeps local out of the scrolling part of the list', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerScrollList().checkVisible();
+      loginPage.providerScrollList().self().find('[data-testid="login-provider-option-okta-corp"]').should('exist');
+      loginPage.providerScrollList().self().find('[data-testid="login-provider-option-local"]').should('not.exist');
+      loginPage.providerOption('local').checkVisible();
+    });
+
+    // Every option has to be reachable by keyboard. Asserted structurally rather
+    // than by driving the tab key: the options are natively focusable buttons in
+    // the order they are read out, so tab order follows from the DOM.
+    it('Puts every provider in the list in the keyboard tab order', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerList().self().find('[data-testid^="login-provider-option-"]').should(($options) => {
+        expect($options.toArray().map((el) => el.getAttribute('data-testid'))).to.deep.equal([
+          'login-provider-option-okta-corp',
+          'login-provider-option-okta-partner',
+          'login-provider-option-local',
+        ]);
+
+        $options.toArray().forEach((el) => {
+          expect(el.tagName, 'options are buttons').to.equal('BUTTON');
+          expect(el.getAttribute('tabindex'), 'options are not taken out of the tab order').not.to.equal('-1');
+          expect(el.hasAttribute('disabled'), 'options are not disabled').to.equal(false);
+        });
+      });
+
+      // Focus still lands where it is put, which is what the list's own focus()
+      // relies on when the page reveals it.
+      loginPage.providerOption('okta-corp').self().focus();
+      cy.focused().should('have.attr', 'data-testid', 'login-provider-option-okta-corp');
+    });
+
+    it('Changes the primary button when another provider is chosen', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('okta-partner');
+
+      loginPage.providerSubmitButton().shouldContainText('okta-partner');
+      // Choosing a provider must not log the user in on its own.
+      cy.url().should('include', '/auth/login');
+    });
+
+    it('Reveals the local form when local is chosen', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('local');
+
+      loginPage.username().checkVisible();
+      loginPage.password().checkVisible();
+      // The form owns the panel, so the list collapses to a link.
+      loginPage.providerList().checkNotExists();
+      loginPage.chooseDifferentProvider().checkVisible();
+    });
+
+    it('Brings the list back from the local form', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('local');
+      loginPage.chooseDifferentProvider().self().click();
+
+      loginPage.providerList().checkVisible();
+      // The form gives way to the provider the page opened on, and local goes
+      // back to being one of the options.
+      loginPage.providerSubmitButton().shouldContainText('gh-community');
+      loginPage.providerOption('local').checkVisible();
+
+      loginPage.selectProvider('okta-partner');
+      loginPage.providerSubmitButton().shouldContainText('okta-partner');
+    });
+
+    it('Reopens on the remembered provider', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('okta-partner');
+      loginPage.rememberProviderCheckbox().set();
+
+      stubProviders();
+      LoginPagePo.goTo();
+      cy.wait('@authProviders');
+
+      loginPage.providerSubmitButton().shouldContainText('okta-partner');
+    });
+
+    it('Falls back to the first provider once the choice is forgotten', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('okta-partner');
+      loginPage.rememberProviderCheckbox().set();
+      loginPage.rememberProviderCheckbox().set();
+
+      stubProviders();
+      LoginPagePo.goTo();
+      cy.wait('@authProviders');
+
+      loginPage.providerSubmitButton().shouldContainText('gh-community');
+    });
+  });
+
+  // Local is one of the ways in, so one external provider alongside it is still
+  // a choice, and it is made from the same list as any other.
+  describe('A single external authentication provider', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/v1-public/authproviders*', {
+        statusCode: 200,
+        body:       {
+          type: 'collection',
+          data: [
+            {
+              id: 'local', type: 'localProvider', _type: 'localProvider'
+            },
+            {
+              id: 'okta-corp', type: 'oktaProvider', _type: 'oktaProvider'
+            },
+          ],
+        },
+      }).as('authProviders');
+
+      LoginPagePo.goTo();
+      cy.wait('@authProviders');
+    });
+
+    it('Offers local from the list rather than from a link', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerSubmitButton().shouldContainText('okta-corp');
+      loginPage.providerList().checkVisible();
+      loginPage.providerOption('local').checkVisible();
+      cy.get('[data-testid="login-useLocal"]').should('not.exist');
+    });
+
+    it('Reveals the local form when local is chosen', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.selectProvider('local');
+
+      loginPage.username().checkVisible();
+      loginPage.password().checkVisible();
+      loginPage.chooseDifferentProvider().checkVisible();
+    });
+  });
+
   it('Cannot login with invalid credentials', () => {
     LoginPagePo.goTo();
 

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -262,8 +262,8 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
     });
   });
 
-  // Local is one of the ways in, so one external provider alongside it is still
-  // a choice, and it is made from the same list as any other.
+  // One external provider alongside local is a straight swap between two, which
+  // the page offers as a link rather than as a list of two cards.
   describe('A single external authentication provider', () => {
     beforeEach(() => {
       cy.intercept('GET', '/v1-public/authproviders*', {
@@ -285,25 +285,38 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
       cy.wait('@authProviders');
     });
 
-    it('Offers local from the list rather than from a link', () => {
+    it('Offers local from a link rather than from the list', () => {
       const loginPage = new LoginPagePo();
 
       loginPage.waitForPage();
 
       loginPage.providerSubmitButton().shouldContainText('okta-corp');
-      loginPage.providerList().checkVisible();
-      loginPage.providerOption('local').checkVisible();
-      cy.get('[data-testid="login-useLocal"]').should('not.exist');
+      loginPage.providerList().checkNotExists();
+      cy.get('[data-testid="login-useLocal"]').should('be.visible');
     });
 
-    it('Reveals the local form when local is chosen', () => {
+    it('Reveals the local form from that link', () => {
       const loginPage = new LoginPagePo();
 
-      loginPage.selectProvider('local');
+      loginPage.waitForPage();
+      cy.get('[data-testid="login-useLocal"]').click();
 
       loginPage.username().checkVisible();
       loginPage.password().checkVisible();
       loginPage.chooseDifferentProvider().checkVisible();
+    });
+
+    // The link back goes straight to the provider, there being no list to open.
+    it('Returns to the provider from the local form', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+      cy.get('[data-testid="login-useLocal"]').click();
+      loginPage.chooseDifferentProvider().self().click();
+
+      loginPage.providerSubmitButton().shouldContainText('okta-corp');
+      loginPage.username().checkNotExists();
+      loginPage.providerList().checkNotExists();
     });
 
     // With one provider there is no choice between providers to save.
@@ -312,7 +325,6 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
 
       loginPage.waitForPage();
 
-      loginPage.providerList().checkVisible();
       loginPage.rememberProviderCheckbox().checkNotExists();
     });
   });

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -305,6 +305,16 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
       loginPage.password().checkVisible();
       loginPage.chooseDifferentProvider().checkVisible();
     });
+
+    // With one provider there is no choice between providers to save.
+    it('Does not offer to remember the choice', () => {
+      const loginPage = new LoginPagePo();
+
+      loginPage.waitForPage();
+
+      loginPage.providerList().checkVisible();
+      loginPage.rememberProviderCheckbox().checkNotExists();
+    });
   });
 
   it('Cannot login with invalid credentials', () => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4581,15 +4581,12 @@ login:
   clientError: Invalid username or password. Please try again.
   userUnauthorized: You are not authorized to use this system.
   specificError: 'An error occurred logging in: {msg}'
-  useLocal: Use a local user
   loginWithProvider: Log in with {provider}
   username: Username
   password: Password
   loggingIn: Logging in...
   loggedIn: Logged in
   loginWithLocal: Log in with Local User
-  useProvider: Use a {provider} user
-  useNonLocal: Use a non-local user
   providers:
     heading: Choose how to sign in
     or: Or

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4590,6 +4590,17 @@ login:
   loginWithLocal: Log in with Local User
   useProvider: Use a {provider} user
   useNonLocal: Use a non-local user
+  providers:
+    heading: Choose how to sign in
+    or: Or
+    chooseDifferent: Choose a different provider
+    meta: "{vendor} · {protocol}"
+    remember: Remember my choice on this device
+    rememberHint: Applies to whichever provider you choose. Saved in this browser only.
+    local:
+      name: Local account
+      description: Sign into Rancher with a username and password.
+      meta: Username and password
   remember:
     label: Remember Username
   cli:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -8201,6 +8201,7 @@ model:
       genericsaml: Generic SAML
       keycloakoidc: Keycloak
       cognito: Amazon Cognito
+      oidc: OIDC
 
 
   cluster:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4591,6 +4591,7 @@ login:
     heading: Choose how to sign in
     or: Or
     chooseDifferent: Choose a different provider
+    useLocal: Log in as a local user
     meta: "{vendor} · {protocol}"
     remember: Remember my choice on this device
     rememberHint: Applies to whichever provider you choose. Saved in this browser only.

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3029,15 +3029,12 @@ login:
   error: 登录时发生错误，请重试。
   clientError: 无效的用户名或密码，请重试。
   specificError: '登录时发生错误：{msg}'
-  useLocal: 使用本地账号登录
   loginWithProvider: 使用 {provider} 登录
   username: 用户名
   password: 密码
   loggingIn: 登录中...
   loggedIn: 已登录
   loginWithLocal: 使用本地用户登录
-  useProvider: 使用 {provider} 用户
-  useNonLocal: 使用非本地用户
   remember:
     label: 记住用户名
 

--- a/shell/components/auth/AuthProviderLogo.vue
+++ b/shell/components/auth/AuthProviderLogo.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+/**
+ * The vendor mark for an auth provider. Used by the login provider menu and the
+ * auth provider list. Falls back to a padlock for the local auth provider.
+ *
+ * The mark is decorative so it is kept out of the accessibility tree.
+ */
+import { RcIcon } from '@components/RcIcon';
+
+defineProps<{
+  /** Vendor logo asset, or '' when the provider has none. */
+  icon?: string;
+}>();
+</script>
+
+<template>
+  <div class="auth-provider-logo">
+    <img
+      v-if="icon"
+      :src="icon"
+      alt=""
+      class="auth-provider-logo__mark"
+    >
+    <RcIcon
+      v-else
+      type="lock"
+      size="large"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "~shell/assets/styles/base/_color.scss";
+
+  .auth-provider-logo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+
+    box-sizing: border-box;
+    width: 42px;
+    height: 42px;
+
+    // Vendor marks are drawn for light backgrounds, so the tile keeps the same
+    // light surface in every theme
+    background-color: $gray003;
+    border-radius: var(--border-radius-lg);
+
+    &__mark {
+      width: 28px;
+      height: 28px;
+      object-fit: contain;
+    }
+
+    // Paired with the surface above, so it has to stay dark alongside it
+    .rc-icon {
+      color: $gray006;
+    }
+  }
+</style>

--- a/shell/components/auth/login/AuthProviderList.vue
+++ b/shell/components/auth/login/AuthProviderList.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import {
+  computed, nextTick, onBeforeUnmount, onMounted, ref, watch
+} from 'vue';
+import { useStore } from 'vuex';
+import { RcSeparator } from '@components/RcSeparator';
+import AuthProviderOption from '@shell/components/auth/login/AuthProviderOption.vue';
+import type { AuthProviderOption as Option } from '@shell/utils/auth-providers';
+
+const props = defineProps<{
+  options: Option[];
+  selectedId?: string | null;
+}>();
+
+defineEmits<{(e: 'select', option: Option): void }>();
+
+const store = useStore();
+const t = (key: string, args?: object) => store.getters['i18n/t'](key, args);
+
+const offered = computed(() => props.options.filter((option) => option.id !== props.selectedId));
+const externalOptions = computed(() => offered.value.filter((option) => !option.isLocal));
+const localOption = computed(() => offered.value.find((option) => option.isLocal));
+
+const list = ref<HTMLElement | null>(null);
+const scrollRegion = ref<HTMLElement | null>(null);
+const scrollbarWidth = ref(0);
+
+const measureScrollbar = () => {
+  const el = scrollRegion.value;
+
+  scrollbarWidth.value = el ? el.offsetWidth - el.clientWidth : 0;
+};
+
+const remeasure = () => nextTick(measureScrollbar);
+
+onMounted(() => {
+  measureScrollbar();
+  window.addEventListener('resize', remeasure);
+});
+
+onBeforeUnmount(() => window.removeEventListener('resize', remeasure));
+
+watch(externalOptions, remeasure);
+
+/** Lets the page hand focus over when the list is revealed. */
+const focus = () => list.value?.querySelector('button')?.focus();
+
+defineExpose({ focus });
+</script>
+
+<template>
+  <div
+    ref="list"
+    role="group"
+    class="auth-provider-list"
+    data-testid="login-provider-list"
+    :aria-label="t('login.providers.heading')"
+  >
+    <div
+      v-if="externalOptions.length"
+      ref="scrollRegion"
+      class="auth-provider-list__scroll"
+      data-testid="login-provider-scroll"
+    >
+      <AuthProviderOption
+        v-for="option in externalOptions"
+        :key="option.id"
+        :option="option"
+        @select="$emit('select', $event)"
+      />
+    </div>
+
+    <!-- Local stays out of the scrolling region so that it is always in reach. -->
+    <div
+      v-if="localOption"
+      class="auth-provider-list__local"
+      :style="{ paddingRight: `${ scrollbarWidth }px` }"
+    >
+      <RcSeparator
+        v-if="externalOptions.length"
+        :decorative="false"
+      />
+      <AuthProviderOption
+        :option="localOption"
+        @select="$emit('select', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .auth-provider-list {
+    --auth-provider-row-pitch: 90px;
+
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    padding: 0 2px;
+
+    > * {
+      flex: 0 0 auto;
+    }
+
+    &__scroll {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+
+      // Three rows at a time, and the rest scroll - any more and the list crowds
+      // the sign-in form off the page
+      max-height: min(calc(var(--auth-provider-row-pitch) * 3), 42vh);
+      overflow-y: auto;
+
+      margin: 0 -2px;
+      padding: 2px;
+
+      > * {
+        flex: 0 0 auto;
+      }
+    }
+
+    &__local {
+      display: flex;
+      flex-direction: column;
+    }
+
+    hr {
+      margin: 10px 0;
+    }
+  }
+</style>

--- a/shell/components/auth/login/AuthProviderOption.vue
+++ b/shell/components/auth/login/AuthProviderOption.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { RcButton } from '@components/RcButton';
+import { RcTag } from '@components/Pill';
+import AuthProviderLogo from '@shell/components/auth/AuthProviderLogo.vue';
+import type { AuthProviderOption } from '@shell/utils/auth-providers';
+
+defineProps<{ option: AuthProviderOption }>();
+
+defineEmits<{(e: 'select', option: AuthProviderOption): void }>();
+</script>
+
+<template>
+  <RcButton
+    type="button"
+    variant="ghost"
+    size="large"
+    class="auth-provider-option"
+    :data-testid="`login-provider-option-${ option.id }`"
+    @click="$emit('select', option)"
+  >
+    <template #before>
+      <AuthProviderLogo :icon="option.icon" />
+    </template>
+    <span class="auth-provider-option__text">
+      <span class="auth-provider-option__name">
+        {{ option.name }}
+      </span>
+      <span
+        v-if="option.description"
+        class="auth-provider-option__description"
+      >
+        {{ option.description }}
+      </span>
+      <RcTag
+        type="inactive"
+        class="auth-provider-option__tag"
+      >
+        <span class="auth-provider-option__meta">
+          {{ option.meta }}
+        </span>
+      </RcTag>
+    </span>
+  </RcButton>
+</template>
+
+<style lang="scss" scoped>
+@import "~shell/assets/styles/base/_variables.scss";
+
+  .rc-button.auth-provider-option {
+    --rc-button-padding: 12px 16px;
+
+    justify-content: flex-start;
+    align-items: center;
+    width: 100%;
+    text-align: left;
+
+    // The global button styles hold their label on one line, which would send a
+    // long name or description out past the row.
+    white-space: normal;
+
+    color: var(--body-text);
+    border-radius: var(--border-radius);
+    border-bottom: 1px solid var(--border);
+
+    &:hover {
+      // The global button styles turn text `--lightest` on hover, which would
+      // wash the name out against this background.
+      color: var(--body-text);
+      background-color: var(--dropdown-hover-bg);
+    }
+
+    .auth-provider-option__text {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 3px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .auth-provider-option__name {
+      max-width: 100%;
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 21px;
+      overflow-wrap: anywhere;
+    }
+
+    .auth-provider-option__description {
+      max-width: 100%;
+      color: var(--label-secondary);
+      font-size: 12px;
+      line-height: 18px;
+      overflow-wrap: anywhere;
+    }
+
+    .auth-provider-option__tag {
+      max-width: 100%;
+    }
+
+    .auth-provider-option__meta {
+      color: var(--label-secondary);
+
+      font-family: $mono-font;
+      font-size: 12px;
+      line-height: 18px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+</style>

--- a/shell/components/auth/login/OrDivider.vue
+++ b/shell/components/auth/login/OrDivider.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { useStore } from 'vuex';
+import { RcSeparator } from '@components/RcSeparator';
+
+const store = useStore();
+const t = (key: string, args?: object) => store.getters['i18n/t'](key, args);
+</script>
+
+<template>
+  <div class="or-divider">
+    <RcSeparator class="or-divider__rule" />
+    <span class="or-divider__label">
+      {{ t('login.providers.or') }}
+    </span>
+    <RcSeparator class="or-divider__rule" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .or-divider {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+
+    &__rule {
+      flex: 1;
+      margin: 0;
+    }
+
+    &__label {
+      color: var(--label-secondary);
+      font-size: 11px;
+      font-weight: 600;
+      line-height: 16px;
+      letter-spacing: 0.6px;
+      text-transform: uppercase;
+    }
+  }
+</style>

--- a/shell/components/auth/login/__tests__/AuthProviderList.test.ts
+++ b/shell/components/auth/login/__tests__/AuthProviderList.test.ts
@@ -1,0 +1,121 @@
+import { nextTick } from 'vue';
+import { shallowMount, VueWrapper } from '@vue/test-utils';
+import AuthProviderList from '@shell/components/auth/login/AuthProviderList.vue';
+import AuthProviderOption from '@shell/components/auth/login/AuthProviderOption.vue';
+import { RcSeparator } from '@components/RcSeparator';
+import type { AuthProviderOption as Option } from '@shell/utils/auth-providers';
+
+jest.mock('vuex', () => {
+  return {
+    ...jest.requireActual('vuex'),
+    useStore: () => ({ getters: { 'i18n/t': (key: string) => key } }),
+  };
+});
+
+const option = (id: string, isLocal = false): Option => ({
+  id,
+  type:        isLocal ? 'localProvider' : 'oktaProvider',
+  key:         isLocal ? 'local' : 'okta',
+  category:    isLocal ? '' : 'saml',
+  name:        id,
+  description: '',
+  meta:        isLocal ? 'Username and password' : 'Okta · SAML',
+  icon:        '',
+  isLocal,
+});
+
+const createWrapper = (options: Option[], selectedId: string | null = null) => shallowMount(AuthProviderList, {
+  props:  { options, selectedId },
+  global: { mocks: { t: (key: string) => key } },
+});
+
+describe('component: AuthProviderList', () => {
+  it('should offer every provider the page is not already showing', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh'), option('local', true)]);
+
+    const ids = wrapper.findAllComponents(AuthProviderOption).map((o) => o.props('option').id);
+
+    expect(ids).toStrictEqual(['okta-corp', 'gh', 'local']);
+  });
+
+  // The selected provider already has the primary button, so repeating it in
+  // the list would offer the same choice twice.
+  it('should leave out the selected provider', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh'), option('local', true)], 'okta-corp');
+
+    const ids = wrapper.findAllComponents(AuthProviderOption).map((o) => o.props('option').id);
+
+    expect(ids).toStrictEqual(['gh', 'local']);
+  });
+
+  // Local swaps the page over to a username and password form, so it sits apart
+  // from the external providers rather than among them.
+  it('should present local last, behind a separator', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('local', true)]);
+
+    const all = wrapper.findAllComponents(AuthProviderOption);
+
+    expect(wrapper.findComponent(RcSeparator).exists()).toBe(true);
+    expect(all[all.length - 1].props('option').isLocal).toBe(true);
+  });
+
+  // However many providers are configured, local must not scroll out of reach.
+  it('should keep local out of the scrolling region', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh'), option('local', true)]);
+
+    const scrolled = wrapper.find('.auth-provider-list__scroll').findAllComponents(AuthProviderOption);
+
+    expect(scrolled.map((o: VueWrapper<any>) => o.props('option').id)).toStrictEqual(['okta-corp', 'gh']);
+  });
+
+  it('should not open a scrolling region when local is all that is left to offer', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('local', true)], 'okta-corp');
+
+    expect(wrapper.find('.auth-provider-list__scroll').exists()).toBe(false);
+    expect(wrapper.findAllComponents(AuthProviderOption)[0].props('option').isLocal).toBe(true);
+  });
+
+  it('should omit local when it is not configured', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh')]);
+
+    expect(wrapper.findComponent(RcSeparator).exists()).toBe(false);
+    expect(wrapper.findAllComponents(AuthProviderOption).every((o) => !o.props('option').isLocal)).toBe(true);
+  });
+
+  it('should not open with a separator when local is all that is left to offer', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('local', true)], 'okta-corp');
+
+    expect(wrapper.findComponent(RcSeparator).exists()).toBe(false);
+    expect(wrapper.findAllComponents(AuthProviderOption)).toHaveLength(1);
+  });
+
+  // Local sits beside the scrollbar rather than behind it, so it has to leave
+  // the same gap as the rows above or it hangs over their edge.
+  it('should hold the scrollbar gutter open for the local option', async() => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh'), option('local', true)]);
+    const scroll = wrapper.find('.auth-provider-list__scroll').element;
+
+    Object.defineProperty(scroll, 'offsetWidth', { value: 362, configurable: true });
+    Object.defineProperty(scroll, 'clientWidth', { value: 354, configurable: true });
+
+    window.dispatchEvent(new Event('resize'));
+    await nextTick();
+    await nextTick();
+
+    expect(wrapper.find('.auth-provider-list__local').attributes('style')).toContain('padding-right: 8px');
+  });
+
+  it('should raise the chosen provider to the page', () => {
+    const wrapper = createWrapper([option('okta-corp'), option('gh')]);
+
+    wrapper.findAllComponents(AuthProviderOption)[1].vm.$emit('select', option('gh'));
+
+    expect(wrapper.emitted('select')?.[0][0]).toMatchObject({ id: 'gh' });
+  });
+
+  it('should name the list for screen readers', () => {
+    const wrapper = createWrapper([option('okta-corp')]);
+
+    expect(wrapper.attributes('aria-label')).toBe('login.providers.heading');
+  });
+});

--- a/shell/components/auth/login/__tests__/AuthProviderOption.test.ts
+++ b/shell/components/auth/login/__tests__/AuthProviderOption.test.ts
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils';
+import AuthProviderOption from '@shell/components/auth/login/AuthProviderOption.vue';
+import AuthProviderLogo from '@shell/components/auth/AuthProviderLogo.vue';
+import { RcTag } from '@components/Pill';
+import type { AuthProviderOption as Option } from '@shell/utils/auth-providers';
+
+const option: Option = {
+  id:          'okta-corp',
+  type:        'oktaProvider',
+  key:         'okta',
+  category:    'saml',
+  name:        'okta-corp',
+  description: 'Partners and contractors.',
+  meta:        'Okta · SAML',
+  icon:        'okta.svg',
+  isLocal:     false,
+};
+
+// Mounted in full rather than shallow, since what the option renders down to is
+// the point: a button the browser puts in the tab order on its own.
+const createWrapper = (props: Option = option) => mount(AuthProviderOption, { props: { option: props } });
+
+describe('component: AuthProviderOption', () => {
+  it('should be reachable with the tab key', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.element.tagName).toBe('BUTTON');
+    expect(wrapper.attributes('tabindex')).toBeUndefined();
+  });
+
+  it('should lead with the name the admin gave the config', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('.auth-provider-option__name').text()).toBe('okta-corp');
+    expect(wrapper.find('.auth-provider-option__description').text()).toBe('Partners and contractors.');
+    expect(wrapper.find('.auth-provider-option__meta').text()).toBe('Okta · SAML');
+  });
+
+  // Descriptions are the admin's to write, so most configs will not have one.
+  it('should close the gap when the config has no description', () => {
+    const wrapper = createWrapper({ ...option, description: '' });
+
+    expect(wrapper.find('.auth-provider-option__description').exists()).toBe(false);
+    expect(wrapper.find('.auth-provider-option__name').text()).toBe('okta-corp');
+  });
+
+  it('should present the vendor and protocol as a tag', () => {
+    const wrapper = createWrapper();
+
+    const tag = wrapper.findComponent(RcTag);
+
+    expect(tag.props('type')).toBe('inactive');
+    expect(tag.text()).toBe('Okta · SAML');
+  });
+
+  it('should show the vendor mark', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.findComponent(AuthProviderLogo).props('icon')).toBe('okta.svg');
+  });
+
+  it('should raise the option when clicked', async() => {
+    const wrapper = createWrapper();
+
+    await wrapper.trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]).toStrictEqual([option]);
+  });
+});

--- a/shell/components/auth/login/__tests__/oidc.test.ts
+++ b/shell/components/auth/login/__tests__/oidc.test.ts
@@ -1,0 +1,43 @@
+import { shallowMount } from '@vue/test-utils';
+import Oidc from '@shell/components/auth/login/oidc.vue';
+
+const createWrapper = (props: { name: string, type: string }) => shallowMount(Oidc, {
+  props:  { focusOnMount: false, ...props },
+  global: {
+    mocks: {
+      t:      (key: string, args?: Record<string, string>) => (args ? `${ key }:${ args.provider }` : key),
+      $store: { dispatch: jest.fn() },
+    },
+  },
+});
+
+describe('component: oidc login', () => {
+  // The button used to name the protocol whatever the config was, so a Keycloak
+  // and a generic OIDC provider both offered "Log in with OIDC" while the list
+  // that led here told them apart.
+  it.each([
+    ['keycloakoidc', 'keyCloakOIDCProvider', 'model.authConfig.provider.keycloakoidc'],
+    ['genericoidc', 'genericOIDCProvider', 'model.authConfig.provider.genericoidc'],
+    ['cognito', 'cognitoProvider', 'model.authConfig.provider.cognito'],
+  ])('should name the provider behind a config named after it (%s)', (name, type, expected) => {
+    const wrapper = createWrapper({ name, type });
+
+    expect(wrapper.text()).toBe(`login.loginWithProvider:${ expected }`);
+  });
+
+  // Same rule as every other provider: a name the admin chose is the only thing
+  // telling one OIDC config from its siblings, so the button keeps it.
+  it('should name a config the admin named with that name', () => {
+    const wrapper = createWrapper({ name: 'okta-oidc', type: 'genericOIDCProvider' });
+
+    expect(wrapper.text()).toBe('login.loginWithProvider:okta-oidc');
+  });
+
+  it('should sign in against the config, not the provider', () => {
+    const wrapper = createWrapper({ name: 'okta-oidc', type: 'genericOIDCProvider' });
+
+    wrapper.vm.login();
+
+    expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith('auth/redirectTo', { provider: 'okta-oidc' });
+  });
+});

--- a/shell/components/auth/login/__tests__/oidc.test.ts
+++ b/shell/components/auth/login/__tests__/oidc.test.ts
@@ -4,7 +4,10 @@ import Oidc from '@shell/components/auth/login/oidc.vue';
 const createWrapper = (props: { name: string, type: string }) => shallowMount(Oidc, {
   props:  { focusOnMount: false, ...props },
   global: {
-    mocks: {
+    // The label these tests are about lives in the button's default slot, which a
+    // stub drops, leaving nothing to read.
+    renderStubDefaultSlot: true,
+    mocks:                 {
       t:      (key: string, args?: Record<string, string>) => (args ? `${ key }:${ args.provider }` : key),
       $store: { dispatch: jest.fn() },
     },

--- a/shell/components/auth/login/github.vue
+++ b/shell/components/auth/login/github.vue
@@ -1,8 +1,10 @@
 <script>
+import { RcButton } from '@components/RcButton';
 import Login from '@shell/mixins/login';
 
 export default {
-  mixins: [Login],
+  components: { RcButton },
+  mixins:     [Login],
 
   methods: {
     login() {
@@ -13,11 +15,15 @@ export default {
 </script>
 
 <template>
-  <button
-    ref="btn"
-    class="btn role-primary"
-    @click="login"
-  >
-    Log In with GitHub
-  </button>
+  <div class="text-center">
+    <RcButton
+      ref="btn"
+      variant="primary"
+      size="large"
+      data-testid="login-provider-submit"
+      @click="login"
+    >
+      {{ t('login.loginWithProvider', {provider: displayName}) }}
+    </RcButton>
+  </div>
 </template>

--- a/shell/components/auth/login/github.vue
+++ b/shell/components/auth/login/github.vue
@@ -8,7 +8,7 @@ export default {
 
   methods: {
     login() {
-      this.$store.dispatch('auth/redirectTo', { provider: 'github' });
+      this.$store.dispatch('auth/redirectTo', { provider: this.name });
     },
   },
 };

--- a/shell/components/auth/login/ldap.vue
+++ b/shell/components/auth/login/ldap.vue
@@ -1,5 +1,6 @@
 <script>
 import { LabeledInput } from '@components/Form/LabeledInput';
+import { RcButton } from '@components/RcButton';
 import AsyncButton from '@shell/components/AsyncButton';
 import Login from '@shell/mixins/login';
 import loadPlugins from '@shell/plugins/plugin';
@@ -7,8 +8,10 @@ import loadPlugins from '@shell/plugins/plugin';
 export default {
   emits: ['error', 'showInputs'],
 
-  components: { LabeledInput, AsyncButton },
-  mixins:     [Login],
+  components: {
+    LabeledInput, RcButton, AsyncButton
+  },
+  mixins: [Login],
 
   props: {
     open: {
@@ -56,51 +59,46 @@ export default {
 <template>
   <form @submit.prevent>
     <template v-if="open">
-      <div class="span-6 offset-3">
-        <div class="mb-20">
-          <LabeledInput
-            v-model:value="username"
-            :label="t('login.username')"
-            autocomplete="username"
-          />
-        </div>
-        <div class="mb-20">
-          <LabeledInput
-            v-model:value="password"
-            type="password"
-            :label="t('login.password')"
-            autocomplete="current-password"
-          />
-        </div>
+      <div class="mb-20">
+        <LabeledInput
+          v-model:value="username"
+          :label="t('login.username')"
+          autocomplete="username"
+        />
       </div>
-      <div class="row">
-        <div class="col span-12 text-center">
-          <AsyncButton
-            ref="btn"
-            type="submit"
-            :action-label="t('login.loginWithProvider', {provider: displayName})"
-            :waiting-label="t('login.loggingIn')"
-            :success-label="t('login.loggedIn')"
-            :error-label="t('asyncButton.default.error')"
-            class="btn bg-primary"
-            style="font-size: 18px;"
-            @click="login"
-          />
-        </div>
+      <div class="mb-20">
+        <LabeledInput
+          v-model:value="password"
+          type="password"
+          :label="t('login.password')"
+          autocomplete="current-password"
+        />
       </div>
+      <AsyncButton
+        ref="btn"
+        type="submit"
+        data-testid="login-provider-submit"
+        :action-label="t('login.loginWithProvider', {provider: displayName})"
+        :waiting-label="t('login.loggingIn')"
+        :success-label="t('login.loggedIn')"
+        :error-label="t('asyncButton.default.error')"
+        @click="login"
+      />
     </template>
     <div
       v-else
       class="text-center"
     >
-      <button
-        style="font-size: 18px;"
+      <RcButton
+        ref="btn"
         type="button"
-        class="btn bg-primary"
+        variant="primary"
+        size="large"
+        data-testid="login-provider-submit"
         @click="$emit('showInputs')"
       >
         {{ t('login.loginWithProvider', {provider: displayName}) }}
-      </button>
+      </RcButton>
     </div>
   </form>
 </template>

--- a/shell/components/auth/login/oauth.vue
+++ b/shell/components/auth/login/oauth.vue
@@ -1,8 +1,10 @@
 <script>
+import { RcButton } from '@components/RcButton';
 import Login from '@shell/mixins/login';
 
 export default {
-  mixins: [Login],
+  components: { RcButton },
+  mixins:     [Login],
 
   methods: {
     login() {
@@ -14,13 +16,14 @@ export default {
 
 <template>
   <div class="text-center">
-    <button
+    <RcButton
       ref="btn"
-      class="btn bg-primary"
-      style="font-size: 18px;"
+      variant="primary"
+      size="large"
+      data-testid="login-provider-submit"
       @click="login"
     >
       {{ t('login.loginWithProvider', {provider: displayName}) }}
-    </button>
+    </RcButton>
   </div>
 </template>

--- a/shell/components/auth/login/oidc.vue
+++ b/shell/components/auth/login/oidc.vue
@@ -1,8 +1,10 @@
 <script>
+import { RcButton } from '@components/RcButton';
 import Login from '@shell/mixins/login';
 
 export default {
-  mixins: [Login],
+  components: { RcButton },
+  mixins:     [Login],
 
   computed: {
     uniqueDisplayName() {
@@ -25,13 +27,14 @@ export default {
 
 <template>
   <div class="text-center">
-    <button
+    <RcButton
       ref="btn"
-      class="btn bg-primary"
-      style="font-size: 18px;"
+      variant="primary"
+      size="large"
+      data-testid="login-provider-submit"
       @click="login"
     >
       {{ t('login.loginWithProvider', {provider: uniqueDisplayName}) }}
-    </button>
+    </RcButton>
   </div>
 </template>

--- a/shell/components/auth/login/oidc.vue
+++ b/shell/components/auth/login/oidc.vue
@@ -6,17 +6,6 @@ export default {
   components: { RcButton },
   mixins:     [Login],
 
-  computed: {
-    uniqueDisplayName() {
-      switch (this.name) {
-      case 'cognito':
-        return this.t('model.authConfig.description.cognito');
-      default:
-        return this.t('model.authConfig.description.oidc');
-      }
-    },
-  },
-
   methods: {
     login() {
       this.$store.dispatch('auth/redirectTo', { provider: this.name });
@@ -34,7 +23,7 @@ export default {
       data-testid="login-provider-submit"
       @click="login"
     >
-      {{ t('login.loginWithProvider', {provider: uniqueDisplayName}) }}
+      {{ t('login.loginWithProvider', {provider: displayName}) }}
     </RcButton>
   </div>
 </template>

--- a/shell/components/auth/login/saml.vue
+++ b/shell/components/auth/login/saml.vue
@@ -1,7 +1,9 @@
 <script>
+import { RcButton } from '@components/RcButton';
 import Login from '@shell/mixins/login';
 export default {
-  mixins: [Login],
+  components: { RcButton },
+  mixins:     [Login],
 
   methods: {
     async login() {
@@ -83,15 +85,16 @@ export default {
         </div>
       </template>
     </div>
-    <button
+    <RcButton
       v-if="!invalidCLILogin"
       ref="btn"
-      class="btn bg-primary"
-      style="font-size: 18px;"
+      variant="primary"
+      size="large"
+      data-testid="login-provider-submit"
       @click="login"
     >
       {{ t('login.loginWithProvider', {provider: displayName}) }}
-    </button>
+    </RcButton>
   </div>
 </template>
 <style lang="scss" scoped>

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -20,7 +20,7 @@ import { ActionLocation, ExtensionPoint } from '@shell/core/types';
 import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import IconOrSvg from '@shell/components/IconOrSvg';
 import { wait } from '@shell/utils/async';
-import { configType } from '@shell/models/management.cattle.io.authconfig';
+import { configTypeForProvider } from '@shell/models/management.cattle.io.authconfig';
 import HeaderPageActionMenu from './HeaderPageActionMenu.vue';
 import NotificationCenter from './NotificationCenter';
 import {
@@ -102,7 +102,7 @@ export default {
     sloAuthProviderEnabled() {
       const publicAuthProviders = this.$store.getters['rancher/all']('authProvider');
 
-      return publicAuthProviders.find((authProvider) => SLO_AUTH_PROVIDERS.includes(configType[authProvider?.id])) || {};
+      return publicAuthProviders.find((authProvider) => SLO_AUTH_PROVIDERS.includes(configTypeForProvider(authProvider?.type))) || {};
     },
 
     shouldShowSloLogoutModal() {

--- a/shell/mixins/__tests__/login.test.ts
+++ b/shell/mixins/__tests__/login.test.ts
@@ -1,0 +1,76 @@
+import { shallowMount } from '@vue/test-utils';
+import Login from '@shell/mixins/login';
+
+const Host = {
+  mixins:   [Login],
+  template: '<button ref="btn" />',
+};
+
+const mountHost = (props: { name: string, type: string, focusOnMount?: boolean }) => shallowMount(Host, {
+  props:  { focusOnMount: false, ...props },
+  // The mixin reads `t` off the component, which the i18n plugin provides.
+  global: { mocks: { t: (key: string) => key } },
+});
+
+describe('mixin: login', () => {
+  describe('displayName', () => {
+    it('should label a config named after its provider with the vendor name', () => {
+      const wrapper = mountHost({ name: 'github', type: 'githubProvider' });
+
+      expect(wrapper.vm.displayName).toBe('model.authConfig.provider.github');
+    });
+
+    // The public provider list spells a provider `githubProvider` where the
+    // config spells it `github`, so the two have to be compared on the key.
+    it('should match the name against the normalised provider', () => {
+      const wrapper = mountHost({ name: 'keycloakoidc', type: 'keyCloakOIDCProvider' });
+
+      expect(wrapper.vm.displayName).toBe('model.authConfig.provider.keycloakoidc');
+    });
+
+    it('should ignore the case of the config name', () => {
+      const wrapper = mountHost({ name: 'GitHub', type: 'githubProvider' });
+
+      expect(wrapper.vm.displayName).toBe('model.authConfig.provider.github');
+    });
+
+    // Otherwise every GitHub config would sign you in as "GitHub", with nothing
+    // on the button saying which of them it is.
+    it('should label a config the admin named with that name', () => {
+      const wrapper = mountHost({ name: 'gh-community', type: 'githubProvider' });
+
+      expect(wrapper.vm.displayName).toBe('gh-community');
+    });
+  });
+
+  describe('focus', () => {
+    it('should focus the control on mount when asked to', () => {
+      const wrapper = shallowMount(Host, {
+        props: {
+          focusOnMount: true, name: 'github', type: 'githubProvider'
+        },
+        global:   { mocks: { t: (key: string) => key } },
+        // `document.activeElement` only follows a focus call for an element that
+        // is in the document.
+        attachTo: document.body,
+      });
+
+      expect(document.activeElement).toBe(wrapper.vm.$refs.btn);
+
+      wrapper.unmount();
+    });
+
+    // SAML renders no control at all while it is rejecting a CLI login.
+    it('should not throw when there is no control to focus', () => {
+      const Empty = { mixins: [Login], template: '<div />' };
+      const wrapper = shallowMount(Empty, {
+        props: {
+          focusOnMount: false, name: 'github', type: 'githubProvider'
+        },
+        global: { mocks: { t: (key: string) => key } },
+      });
+
+      expect(() => (wrapper.vm as any).focus()).not.toThrow();
+    });
+  });
+});

--- a/shell/mixins/__tests__/login.test.ts
+++ b/shell/mixins/__tests__/login.test.ts
@@ -46,7 +46,9 @@ describe('mixin: login', () => {
     // read "Log in with undefined" for a provider nothing is translated for.
     it('should fall back to the provider key when there is no translation', () => {
       const wrapper = shallowMount(Host, {
-        props:  { focusOnMount: false, name: 'oidc', type: 'oidcProvider' },
+        props: {
+          focusOnMount: false, name: 'oidc', type: 'oidcProvider'
+        },
         global: { mocks: { t: () => undefined } },
       });
 

--- a/shell/mixins/__tests__/login.test.ts
+++ b/shell/mixins/__tests__/login.test.ts
@@ -41,6 +41,17 @@ describe('mixin: login', () => {
 
       expect(wrapper.vm.displayName).toBe('gh-community');
     });
+
+    // `t` yields undefined rather than the key, so the button would otherwise
+    // read "Log in with undefined" for a provider nothing is translated for.
+    it('should fall back to the provider key when there is no translation', () => {
+      const wrapper = shallowMount(Host, {
+        props:  { focusOnMount: false, name: 'oidc', type: 'oidcProvider' },
+        global: { mocks: { t: () => undefined } },
+      });
+
+      expect(wrapper.vm.displayName).toBe('oidc');
+    });
   });
 
   describe('focus', () => {

--- a/shell/mixins/login.js
+++ b/shell/mixins/login.js
@@ -1,3 +1,5 @@
+import { providerKey } from '@shell/models/management.cattle.io.authconfig';
+
 export default {
   props: {
     focusOnMount: {
@@ -5,15 +7,29 @@ export default {
       required: true,
     },
 
+    /** The authconfig's name, which an admin is free to choose. */
     name: {
       type:     String,
       required: true
+    },
+
+    /** The provider the config is for, e.g. `githubProvider`. */
+    type: {
+      type:     String,
+      required: true,
     }
   },
 
   computed: {
     displayName() {
-      return this.t(`model.authConfig.provider.${ this.name }`);
+      const key = providerKey(this.type);
+      const providerString = this.t(`model.authConfig.provider.${ key }`);
+
+      // A config named after its provider is the provider as far as anyone
+      // signing in is concerned, so it is labelled with the vendor's name. One
+      // an admin has named is labelled with the name they gave it, which is the
+      // only thing telling it apart from its siblings.
+      return this.name?.toLowerCase() === key ? providerString : this.name;
     }
   },
 
@@ -25,7 +41,8 @@ export default {
 
   methods: {
     focus() {
-      this.$refs.btn.focus();
+      // SAML's control is absent while a CLI login is being rejected.
+      this.$refs.btn?.focus();
     },
   },
 };

--- a/shell/mixins/login.js
+++ b/shell/mixins/login.js
@@ -23,7 +23,9 @@ export default {
   computed: {
     displayName() {
       const key = providerKey(this.type);
-      const providerString = this.t(`model.authConfig.provider.${ key }`);
+      // `t` yields undefined for a provider nothing has been translated for, so
+      // the key stands in - the same fallback the provider list is built with.
+      const providerString = this.t(`model.authConfig.provider.${ key }`) || key;
 
       // A config named after its provider is the provider as far as anyone
       // signing in is concerned, so it is labelled with the vendor's name. One

--- a/shell/models/__tests__/management.cattle.io.authconfig.test.ts
+++ b/shell/models/__tests__/management.cattle.io.authconfig.test.ts
@@ -1,0 +1,95 @@
+import { configTypeForProvider, providerIcon, providerKey } from '@shell/models/management.cattle.io.authconfig';
+import { requireAsset } from '@shell/utils/require-asset';
+
+jest.mock('@shell/utils/require-asset', () => {
+  return { requireAsset: jest.fn((path: string) => path) };
+});
+
+describe('fx: providerKey', () => {
+  // Rancher names the same provider two ways, and the casing isn't consistent
+  // between them -- `googleOauthConfig` becomes `googleOAuthProvider`.
+  const cases: [string | null | undefined, string][] = [
+    ['activeDirectoryConfig', 'activedirectory'],
+    ['activeDirectoryProvider', 'activedirectory'],
+    ['githubConfig', 'github'],
+    ['githubProvider', 'github'],
+    ['keyCloakOIDCConfig', 'keycloakoidc'],
+    ['keyCloakOIDCProvider', 'keycloakoidc'],
+    ['googleOauthConfig', 'googleoauth'],
+    ['googleOAuthProvider', 'googleoauth'],
+    ['localConfig', 'local'],
+    ['', ''],
+    [undefined, ''],
+    [null, ''],
+  ];
+
+  it.each(cases)('should normalise %p to %p', (input, expected) => {
+    expect(providerKey(input)).toBe(expected);
+  });
+});
+
+describe('fx: configTypeForProvider', () => {
+  const cases: [string | undefined, string | undefined][] = [
+    ['activeDirectoryProvider', 'ldap'],
+    ['githubProvider', 'oauth'],
+    ['githubAppProvider', 'oauth'],
+    ['googleOAuthProvider', 'oauth'],
+    ['keyCloakProvider', 'saml'],
+    ['keyCloakOIDCProvider', 'oidc'],
+    ['genericSAMLProvider', 'saml'],
+    ['localProvider', ''],
+    ['notAProvider', undefined],
+    [undefined, undefined],
+  ];
+
+  it.each(cases)('should resolve %p to %p', (input, expected) => {
+    expect(configTypeForProvider(input)).toBe(expected);
+  });
+
+  it('should resolve the config naming as well as the provider naming', () => {
+    expect(configTypeForProvider('githubConfig')).toBe('oauth');
+    expect(configTypeForProvider('githubProvider')).toBe('oauth');
+  });
+});
+
+describe('fx: providerIcon', () => {
+  // The login page reads raw `/v1-public/authproviders` rows, which use the
+  // `...Provider` naming rather than the `...Config` naming of the model.
+  it.each([
+    ['githubProvider', 'github'],
+    ['activeDirectoryProvider', 'activedirectory'],
+    ['oktaProvider', 'okta'],
+  ])('should derive the asset name from %p', (type: string, expected: string) => {
+    expect(providerIcon(type)).toBe(`~shell/assets/images/vendor/${ expected }.svg`);
+  });
+
+  it.each([
+    ['azureADProvider', 'entraid'],
+    ['genericOIDCProvider', 'openid'],
+    ['keyCloakOIDCProvider', 'keycloak'],
+    ['oidcProvider', 'openid'],
+  ])('should apply the override for %p', (type: string, expected: string) => {
+    expect(providerIcon(type)).toBe(`~shell/assets/images/vendor/${ expected }.svg`);
+  });
+
+  it('should resolve the config naming and the provider naming to one asset', () => {
+    expect(providerIcon('githubConfig')).toBe(providerIcon('githubProvider'));
+  });
+
+  it('should fall back to an empty string when the vendor has no logo', () => {
+    // `local` has no vendor SVG, so `requireAsset` throws for it.
+    jest.mocked(requireAsset).mockImplementationOnce(() => {
+      throw new Error('Asset not found');
+    });
+
+    expect(providerIcon('localProvider')).toBe('');
+  });
+
+  it.each([undefined, null, ''])('should not throw for %p', (type) => {
+    jest.mocked(requireAsset).mockImplementationOnce(() => {
+      throw new Error('Asset not found');
+    });
+
+    expect(providerIcon(type as any)).toBe('');
+  });
+});

--- a/shell/models/management.cattle.io.authconfig.js
+++ b/shell/models/management.cattle.io.authconfig.js
@@ -2,31 +2,65 @@ import { insertAt } from '@shell/utils/array';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { requireAsset } from '@shell/utils/require-asset';
 
+/**
+ * Normalises a provider identifier to a stable key.
+ *
+ * The same provider is named differently depending on where it is read from - an
+ * authconfig is `github`, the public provider list calls it `githubProvider` and
+ * the schema calls it `githubConfig`.
+ */
+export const providerKey = (type) => `${ type || '' }`.toLowerCase().replace(/(config|provider)$/, '');
+
+/**
+ * Auth provider categories, keyed by `providerKey()` so that either naming works.
+ */
 export const configType = {
   activedirectory: 'ldap',
-  azuread:         'oauth',
   openldap:        'ldap',
   freeipa:         'ldap',
-  ping:            'saml',
+  azuread:         'oauth',
+  googleoauth:     'oauth',
+  github:          'oauth',
+  githubapp:       'oauth',
   adfs:            'saml',
   keycloak:        'saml',
   okta:            'saml',
+  ping:            'saml',
   shibboleth:      'saml',
   genericsaml:     'saml',
-  googleoauth:     'oauth',
-  local:           '',
-  github:          'oauth',
-  githubapp:       'oauth',
-  keycloakoidc:    'oidc',
-  genericoidc:     'oidc',
   cognito:         'oidc',
+  genericoidc:     'oidc',
+  keycloakoidc:    'oidc',
+  oidc:            'oidc',
+  local:           '',
 };
+
+/**
+ * Look up a category from any provider identifier, e.g. `keyCloakOIDCProvider`.
+ */
+export const configTypeForProvider = (type) => configType[providerKey(type)];
 
 const imageOverrides = {
   azuread:      'entraid',
-  keycloakoidc: 'keycloak',
   genericoidc:  'openid',
   genericsaml:  'custom',
+  keycloakoidc: 'keycloak',
+  oidc:         'openid',
+};
+
+/**
+ * Resolve a provider's vendor logo from any provider identifier.
+ *
+ * @returns the asset URL, or an empty string when the vendor has no logo.
+ */
+export const providerIcon = (type) => {
+  try {
+    const key = providerKey(type);
+
+    return requireAsset(`~shell/assets/images/vendor/${ imageOverrides[key] || key }.svg`);
+  } catch (e) {
+    return '';
+  }
 };
 
 export default class AuthConfig extends SteveModel {
@@ -54,7 +88,7 @@ export default class AuthConfig extends SteveModel {
   }
 
   get configType() {
-    return configType[this.id];
+    return configTypeForProvider(this.id);
   }
 
   get sideLabel() {
@@ -62,11 +96,7 @@ export default class AuthConfig extends SteveModel {
   }
 
   get icon() {
-    try {
-      return requireAsset(`~shell/assets/images/vendor/${ imageOverrides[this.id] || this.id }.svg`);
-    } catch (e) {
-      return '';
-    }
+    return providerIcon(this.id);
   }
 
   get state() {

--- a/shell/pages/auth/__tests__/login.test.ts
+++ b/shell/pages/auth/__tests__/login.test.ts
@@ -1,0 +1,391 @@
+import { shallowMount } from '@vue/test-utils';
+import Login from '@shell/pages/auth/login.vue';
+import AuthProviderList from '@shell/components/auth/login/AuthProviderList.vue';
+import { Banner } from '@components/Banner';
+import { LOGGED_OUT, TIMED_OUT, _FLAGGED } from '@shell/config/query-params';
+import { REMEMBERED_PROVIDER_KEY } from '@shell/utils/auth-providers';
+
+jest.mock('@shell/utils/require-asset', () => {
+  return { requireAsset: jest.fn((path: string) => path) };
+});
+
+jest.mock('@shell/config/private-label', () => {
+  return {
+    getVendor: () => 'Rancher',
+    getBrand:  () => '',
+    setVendor: jest.fn(),
+    setBrand:  jest.fn(),
+  };
+});
+
+const LOCAL = { id: 'local', type: 'localProvider' };
+const OKTA_CORP = { id: 'okta-corp', type: 'oktaProvider' };
+const OKTA_PARTNER = { id: 'okta-partner', type: 'oktaProvider' };
+const GITHUB = { id: 'gh-community', type: 'githubProvider' };
+const AD = { id: 'ad-corp', type: 'activeDirectoryProvider' };
+
+const createWrapper = (drivers: object[], query: Record<string, string | null> = {}) => {
+  const dispatch = jest.fn((action: string) => {
+    if (action === 'auth/getAuthProviders') {
+      return Promise.resolve(drivers);
+    }
+
+    // The banners setting, whose value the page JSON-parses.
+    return Promise.resolve({ value: '{"loginError":{}}' });
+  });
+
+  const wrapper = shallowMount(Login, {
+    global: {
+      mocks: {
+        $store: {
+          dispatch,
+          getters: {
+            'i18n/t':                  (key: string) => key,
+            'i18n/withFallback':       (_key: string, _args: object | null, fallback: string) => fallback,
+            'i18n/hasMultipleLocales': false,
+            'cookies/get':             () => '',
+            'management/byId':         () => ({ value: 'false' }),
+            'management/brand':        '',
+            'type-map/importLogin':    () => ({ template: '<div />' }),
+            isSingleProduct:           undefined,
+          },
+        },
+        $route:      { query },
+        $router:     { applyQuery: jest.fn(), push: jest.fn() },
+        $fetchState: { pending: false },
+      },
+    },
+  });
+
+  return wrapper;
+};
+
+/** Runs the page's `fetch()` hook, which vue-test-utils does not invoke itself. */
+const runFetch = async(wrapper: any) => {
+  await (Login as any).fetch.call(wrapper.vm);
+  await wrapper.vm.$nextTick();
+};
+
+describe('page: login', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  describe('messages', () => {
+    it('should show an error message in an error banner', () => {
+      const wrapper = createWrapper([LOCAL], { err: 'Something went wrong' });
+      const banner = wrapper.findComponent(Banner);
+
+      expect(wrapper.vm.loginMessages).toStrictEqual([{ message: 'login.specificError', variant: 'error' }]);
+      expect(banner.props('color')).toBe('error');
+      expect(banner.props('label')).toBe('login.specificError');
+      expect(banner.props('role')).toBe('alert');
+    });
+
+    it('should show a logged-out message in a success banner', () => {
+      const wrapper = createWrapper([LOCAL], { [LOGGED_OUT]: _FLAGGED });
+      const banner = wrapper.findComponent(Banner);
+
+      expect(wrapper.vm.loginMessages).toStrictEqual([{ message: 'login.loggedOut', variant: 'success' }]);
+      expect(banner.props('color')).toBe('success');
+      expect(banner.props('label')).toBe('login.loggedOut');
+      expect(banner.props('role')).toBe('status');
+    });
+
+    it('should show a timed-out message in an error banner', () => {
+      const wrapper = createWrapper([LOCAL], { [TIMED_OUT]: _FLAGGED });
+      const banner = wrapper.findComponent(Banner);
+
+      expect(wrapper.vm.loginMessages).toStrictEqual([{ message: 'login.loginAgain', variant: 'error' }]);
+      expect(banner.props('color')).toBe('error');
+      expect(banner.props('label')).toBe('login.loginAgain');
+      expect(banner.props('role')).toBe('alert');
+    });
+  });
+
+  describe('provider selection', () => {
+    it('should offer the list once several providers are configured', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, OKTA_PARTNER]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showProviderList).toBe(true);
+    });
+
+    // Local is one of the ways in, so a single external provider alongside it is
+    // still a choice, and it is offered from the list like any other.
+    it('should offer the list for a single provider alongside local', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showProviderList).toBe(true);
+      expect(wrapper.vm.providerOptions.map((o: any) => o.id)).toStrictEqual(['okta-corp', 'local']);
+    });
+
+    // Nothing to choose between, so the page goes straight to that provider.
+    it('should not offer the list for a single provider without local', async() => {
+      const wrapper = createWrapper([OKTA_CORP]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showProviderList).toBe(false);
+      expect(wrapper.vm.selectedProviderId).toBe('okta-corp');
+    });
+
+    it('should not offer the list when only local is configured', async() => {
+      const wrapper = createWrapper([LOCAL]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showProviderList).toBe(false);
+    });
+
+    it('should list local alongside the external providers', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.providerOptions.map((o: any) => o.id)).toStrictEqual(['gh-community', 'okta-corp', 'local']);
+    });
+
+    it('should open on the first provider by default', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.selectedProviderId).toBe('gh-community');
+    });
+
+    it('should point the login component at the selected provider', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions[1]);
+
+      expect(wrapper.vm.selectedProviderId).toBe('okta-corp');
+      // `providerComponents` is built in step with `providers`, so the index has
+      // to land on the same provider.
+      expect(wrapper.vm.selectedProviderIndex).toBe(1);
+      expect((wrapper.vm.providers as any[])[1].id).toBe('okta-corp');
+    });
+
+    it('should reveal the local form when local is chosen', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      const local = wrapper.vm.providerOptions.find((o: any) => o.isLocal);
+
+      wrapper.vm.selectProvider(local);
+
+      expect(wrapper.vm.showLocal).toBe(true);
+    });
+
+    // A username and password form owns the panel, so the alternatives collapse
+    // to a "Choose a different provider" link until the user asks for them.
+    it('should collapse the list while the local form is showing', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.isLocal));
+
+      expect(wrapper.vm.isCredentialForm).toBe(true);
+      expect(wrapper.vm.hasProviderChoice).toBe(true);
+      expect(wrapper.vm.showProviderList).toBe(false);
+    });
+
+    it('should collapse the list for a directory provider, which asks for credentials too', async() => {
+      const wrapper = createWrapper([LOCAL, AD, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.id === 'ad-corp'));
+
+      expect(wrapper.vm.isCredentialForm).toBe(true);
+      expect(wrapper.vm.showProviderList).toBe(false);
+    });
+
+    it('should reveal the list when a different provider is asked for', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.isLocal));
+      wrapper.vm.expandProviderList();
+
+      expect(wrapper.vm.showProviderList).toBe(true);
+    });
+
+    // Leaving the form in place would sit it above the very list meant to
+    // replace it, so the panel drops back to the provider it opened on.
+    it('should step off the form when a different provider is asked for', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.isLocal));
+      wrapper.vm.expandProviderList();
+
+      expect(wrapper.vm.selectedProviderId).toBe('gh-community');
+      expect(wrapper.vm.showLocal).toBe(false);
+      expect(wrapper.vm.isCredentialForm).toBe(false);
+    });
+
+    // Remembering local and then asking for the list would otherwise land back
+    // on the form the user is trying to leave.
+    it('should skip the remembered provider when it is the one on screen', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.expandProviderList();
+
+      expect(wrapper.vm.selectedProviderId).toBe('gh-community');
+    });
+
+    // The page is choosing here, not the user.
+    it('should not overwrite the remembered provider when it steps off the form', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.expandProviderList();
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('local');
+    });
+
+    // Otherwise the list would stay open behind the next form.
+    it('should collapse the list again once a provider is chosen from it', async() => {
+      const wrapper = createWrapper([LOCAL, AD, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.isLocal));
+      wrapper.vm.expandProviderList();
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.id === 'ad-corp'));
+
+      expect(wrapper.vm.showProviderList).toBe(false);
+    });
+
+    it('should keep the list open for a provider that redirects away', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.id === 'okta-corp'));
+
+      expect(wrapper.vm.isCredentialForm).toBe(false);
+      expect(wrapper.vm.showProviderList).toBe(true);
+    });
+
+    it('should hide the local form when an external provider is chosen', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions.find((o: any) => o.isLocal));
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions[0]);
+
+      expect(wrapper.vm.showLocal).toBe(false);
+    });
+  });
+
+  describe('offering local', () => {
+    // Local used to be reached through a "Use a local user" link. It is a card in
+    // the list now, so the link is gone and the list has to carry local instead.
+    it.each([
+      ['a single external provider', [LOCAL, OKTA_CORP]],
+      ['several external providers', [LOCAL, OKTA_CORP, GITHUB]],
+    ])('should offer local from the list with %s', async(_label, drivers) => {
+      const wrapper = createWrapper(drivers);
+
+      await runFetch(wrapper);
+
+      const list = wrapper.findComponent(AuthProviderList);
+
+      expect(list.exists()).toBe(true);
+      expect((list.props('options') as any[]).some((o) => o.isLocal)).toBe(true);
+      expect(wrapper.find('[data-testid="login-useLocal"]').exists()).toBe(false);
+    });
+
+    it('should show the local form on its own when local is all there is', async() => {
+      const wrapper = createWrapper([LOCAL]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showLocal).toBe(true);
+      expect(wrapper.findComponent(AuthProviderList).exists()).toBe(false);
+    });
+  });
+
+  describe('remembering a provider', () => {
+    it('should open on the remembered provider', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'okta-corp');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.selectedProviderId).toBe('okta-corp');
+      expect(wrapper.vm.rememberProvider).toBe(true);
+    });
+
+    it('should open the local form when local is the remembered provider', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.showLocal).toBe(true);
+    });
+
+    // The admin can delete or rename a config out from under a saved choice.
+    it('should fall back when the remembered provider no longer exists', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'deleted-config');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.selectedProviderId).toBe('gh-community');
+    });
+
+    it('should not claim to remember a provider that no longer exists', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'deleted-config');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.rememberProvider).toBe(false);
+    });
+
+    it('should save the current provider when the box is ticked', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions[1]);
+      wrapper.vm.setRememberProvider(true);
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('okta-corp');
+    });
+
+    it('should follow later selections once the box is ticked', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.setRememberProvider(true);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions[1]);
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('okta-corp');
+    });
+
+    it('should forget the choice when the box is unticked', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'okta-corp');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.setRememberProvider(false);
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBeNull();
+    });
+
+    it('should not save anything while the box is unticked', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.selectProvider(wrapper.vm.providerOptions[1]);
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBeNull();
+    });
+  });
+});

--- a/shell/pages/auth/__tests__/login.test.ts
+++ b/shell/pages/auth/__tests__/login.test.ts
@@ -2,7 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import Login from '@shell/pages/auth/login.vue';
 import AuthProviderList from '@shell/components/auth/login/AuthProviderList.vue';
 import { Banner } from '@components/Banner';
-import { LOGGED_OUT, TIMED_OUT, _FLAGGED } from '@shell/config/query-params';
+import { LOCAL as LOCAL_QUERY, LOGGED_OUT, TIMED_OUT, _FLAGGED } from '@shell/config/query-params';
 import { REMEMBERED_PROVIDER_KEY } from '@shell/utils/auth-providers';
 
 jest.mock('@shell/utils/require-asset', () => {
@@ -23,6 +23,13 @@ const OKTA_CORP = { id: 'okta-corp', type: 'oktaProvider' };
 const OKTA_PARTNER = { id: 'okta-partner', type: 'oktaProvider' };
 const GITHUB = { id: 'gh-community', type: 'githubProvider' };
 const AD = { id: 'ad-corp', type: 'activeDirectoryProvider' };
+
+/**
+ * Held out here so the tests have something typed to assert on: `applyQuery` is
+ * bolted onto the router at runtime by `@shell/plugins/extend-router`, so it is
+ * not part of vue-router's own `Router` type.
+ */
+const applyQuery = jest.fn();
 
 const createWrapper = (drivers: object[], query: Record<string, string | null> = {}) => {
   const dispatch = jest.fn((action: string) => {
@@ -51,7 +58,7 @@ const createWrapper = (drivers: object[], query: Record<string, string | null> =
           },
         },
         $route:      { query },
-        $router:     { applyQuery: jest.fn(), push: jest.fn() },
+        $router:     { applyQuery, push: jest.fn() },
         $fetchState: { pending: false },
       },
     },
@@ -67,7 +74,10 @@ const runFetch = async(wrapper: any) => {
 };
 
 describe('page: login', () => {
-  beforeEach(() => window.localStorage.clear());
+  beforeEach(() => {
+    window.localStorage.clear();
+    applyQuery.mockClear();
+  });
 
   describe('messages', () => {
     it('should show an error message in an error banner', () => {
@@ -110,14 +120,15 @@ describe('page: login', () => {
       expect(wrapper.vm.showProviderList).toBe(true);
     });
 
-    // Local is one of the ways in, so a single external provider alongside it is
-    // still a choice, and it is offered from the list like any other.
-    it('should offer the list for a single provider alongside local', async() => {
+    // A list of two, one of which is local, says less than the pair of links the
+    // page has always shown for it.
+    it('should not offer the list for a single provider alongside local', async() => {
       const wrapper = createWrapper([LOCAL, OKTA_CORP]);
 
       await runFetch(wrapper);
 
-      expect(wrapper.vm.showProviderList).toBe(true);
+      expect(wrapper.vm.hasProviderChoice).toBe(true);
+      expect(wrapper.vm.showProviderList).toBe(false);
       expect(wrapper.vm.providerOptions.map((o: any) => o.id)).toStrictEqual(['okta-corp', 'local']);
     });
 
@@ -313,13 +324,10 @@ describe('page: login', () => {
   });
 
   describe('offering local', () => {
-    // Local used to be reached through a "Use a local user" link. It is a card in
-    // the list now, so the link is gone and the list has to carry local instead.
-    it.each([
-      ['a single external provider', [LOCAL, OKTA_CORP]],
-      ['several external providers', [LOCAL, OKTA_CORP, GITHUB]],
-    ])('should offer local from the list with %s', async(_label, drivers) => {
-      const wrapper = createWrapper(drivers);
+    // Once there are several external providers to weigh local against, it is a
+    // card in the list like any other of them.
+    it('should offer local from the list with several external providers', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
 
       await runFetch(wrapper);
 
@@ -328,6 +336,59 @@ describe('page: login', () => {
       expect(list.exists()).toBe(true);
       expect((list.props('options') as any[]).some((o) => o.isLocal)).toBe(true);
       expect(wrapper.find('[data-testid="login-useLocal"]').exists()).toBe(false);
+    });
+
+    // With one provider the page opens on it and offers local as the way round it.
+    it('should offer local from a link with a single external provider', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.findComponent(AuthProviderList).exists()).toBe(false);
+      expect(wrapper.find('[data-testid="login-useLocal"]').exists()).toBe(true);
+    });
+
+    it('should swap to the local form and back from that link', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+      await runFetch(wrapper);
+      wrapper.vm.toggleLocal();
+
+      expect(wrapper.vm.showLocal).toBe(true);
+      expect(wrapper.vm.selectedProviderId).toBe('local');
+
+      wrapper.vm.toggleLocal();
+
+      expect(wrapper.vm.showLocal).toBe(false);
+      expect(wrapper.vm.selectedProviderId).toBe('okta-corp');
+    });
+
+    // A reload should land back where the user left off, so the flag comes off
+    // the URL on the way out as well as going on on the way in.
+    it('should carry the swap in the query both ways', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+      await runFetch(wrapper);
+      wrapper.vm.toggleLocal();
+
+      expect(applyQuery).toHaveBeenCalledWith({ [LOCAL_QUERY]: true }, { [LOCAL_QUERY]: false });
+
+      wrapper.vm.toggleLocal();
+
+      expect(applyQuery).toHaveBeenCalledWith({ [LOCAL_QUERY]: false }, { [LOCAL_QUERY]: false });
+    });
+
+    // Coming back is the same request as it is from the list, so it reads the
+    // same way and answers to the same handle.
+    it('should offer the way back once the local form is showing', async() => {
+      const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+      await runFetch(wrapper);
+      wrapper.vm.toggleLocal();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="login-useLocal"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="login-provider-choose"]').exists()).toBe(true);
     });
 
     it('should show the local form on its own when local is all there is', async() => {
@@ -430,7 +491,7 @@ describe('page: login', () => {
 
         await runFetch(wrapper);
 
-        expect(wrapper.vm.canRememberProvider).toBe(false);
+        expect(wrapper.vm.hasProviderList).toBe(false);
         expect(wrapper.find('[data-testid="login-provider-remember"]').exists()).toBe(false);
       });
 
@@ -439,7 +500,7 @@ describe('page: login', () => {
 
         await runFetch(wrapper);
 
-        expect(wrapper.vm.canRememberProvider).toBe(true);
+        expect(wrapper.vm.hasProviderList).toBe(true);
         expect(wrapper.find('[data-testid="login-provider-remember"]').exists()).toBe(true);
       });
 

--- a/shell/pages/auth/__tests__/login.test.ts
+++ b/shell/pages/auth/__tests__/login.test.ts
@@ -249,6 +249,36 @@ describe('page: login', () => {
       expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('local');
     });
 
+    // The box is a statement about the provider on screen, so leaving it ticked
+    // against the one the page just stepped onto would claim a choice was saved
+    // that signing in from here would not honour.
+    it('should stop claiming to remember once it steps off the remembered provider', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+
+      expect(wrapper.vm.rememberProvider).toBe(true);
+
+      wrapper.vm.expandProviderList();
+
+      expect(wrapper.vm.selectedProviderId).toBe('gh-community');
+      expect(wrapper.vm.rememberProvider).toBe(false);
+    });
+
+    // Ticking the box from here is the user choosing, so it saves the provider
+    // they are actually looking at rather than the one they arrived on.
+    it('should save the stepped-onto provider when the box is ticked again', async() => {
+      window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+      const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+      await runFetch(wrapper);
+      wrapper.vm.expandProviderList();
+      wrapper.vm.setRememberProvider(true);
+
+      expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('gh-community');
+    });
+
     // Otherwise the list would stay open behind the next form.
     it('should collapse the list again once a provider is chosen from it', async() => {
       const wrapper = createWrapper([LOCAL, AD, GITHUB]);

--- a/shell/pages/auth/__tests__/login.test.ts
+++ b/shell/pages/auth/__tests__/login.test.ts
@@ -417,5 +417,44 @@ describe('page: login', () => {
 
       expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBeNull();
     });
+
+    // There is nothing to save unless the page is asking which external provider
+    // to use. One of them alongside local is answered the same way every time.
+    describe('with fewer than two external providers', () => {
+      it.each([
+        ['a single external provider alongside local', [LOCAL, OKTA_CORP]],
+        ['a single external provider on its own', [OKTA_CORP]],
+        ['only local', [LOCAL]],
+      ])('should not offer the box with %s', async(_label, drivers) => {
+        const wrapper = createWrapper(drivers);
+
+        await runFetch(wrapper);
+
+        expect(wrapper.vm.canRememberProvider).toBe(false);
+        expect(wrapper.find('[data-testid="login-provider-remember"]').exists()).toBe(false);
+      });
+
+      it('should offer the box once a second external provider is configured', async() => {
+        const wrapper = createWrapper([LOCAL, OKTA_CORP, GITHUB]);
+
+        await runFetch(wrapper);
+
+        expect(wrapper.vm.canRememberProvider).toBe(true);
+        expect(wrapper.find('[data-testid="login-provider-remember"]').exists()).toBe(true);
+      });
+
+      // The admin can remove a provider out from under a saved choice, leaving an
+      // entry the page no longer gives the user any way to clear.
+      it('should ignore a choice saved before the providers were reduced', async() => {
+        window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, 'local');
+        const wrapper = createWrapper([LOCAL, OKTA_CORP]);
+
+        await runFetch(wrapper);
+
+        expect(wrapper.vm.selectedProviderId).toBe('okta-corp');
+        expect(wrapper.vm.showLocal).toBe(false);
+        expect(wrapper.vm.rememberProvider).toBe(false);
+      });
+    });
   });
 });

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -111,6 +111,15 @@ export default {
       return this.providerOptions.length > 1;
     },
 
+    /**
+     * Saving a choice is only worth offering where there are several external
+     * providers to pick between. With one, the list is really just offering local
+     * as the way round it, and the page opens on that provider regardless.
+     */
+    canRememberProvider() {
+      return this.providers.length > 1;
+    },
+
     isCredentialForm() {
       return this.showLocal || this.selectedProvider?.category === 'ldap';
     },
@@ -226,13 +235,14 @@ export default {
     const hasLocal = providerOptions.some((x) => x.isLocal);
     const hasOthers = hasLocal && !!providers.length;
 
-    const rememberedId = getRememberedProviderId();
-    const initial = resolveInitialProvider(providerOptions, rememberedId);
-
     this.vendor = getVendor();
     this.providerOptions = providerOptions;
     this.providers = providers;
     this.hasLocal = hasLocal;
+
+    const rememberedId = this.rememberedProviderId();
+    const initial = resolveInitialProvider(providerOptions, rememberedId);
+
     this.selectedProviderId = initial?.id || null;
     // Only reflect the checkbox as ticked when the saved provider still exists;
     // a stale entry shouldn't claim the page is remembering something.
@@ -302,6 +312,15 @@ export default {
     },
 
     /**
+     * The saved choice, read only where the box that sets it is on offer. An entry
+     * left over from when more providers were configured must not steer a page
+     * that gives the user no way to clear it.
+     */
+    rememberedProviderId() {
+      return this.canRememberProvider ? getRememberedProviderId() : null;
+    },
+
+    /**
      * Picking a provider only changes what the page is offering -- the user still
      * confirms with the primary button, so SSO, LDAP and local all behave alike.
      */
@@ -321,7 +340,7 @@ export default {
 
     expandProviderList() {
       const alternatives = this.providerOptions.filter((option) => option.id !== this.selectedProviderId);
-      const fallback = resolveInitialProvider(alternatives, getRememberedProviderId());
+      const fallback = resolveInitialProvider(alternatives, this.rememberedProviderId());
 
       if (fallback) {
         // Deliberately not `selectProvider`: the page is choosing here, not the
@@ -608,7 +627,10 @@ export default {
               :selected-id="selectedProviderId"
               @select="selectProvider"
             />
-            <div class="login-remember mt-20">
+            <div
+              v-if="canRememberProvider"
+              class="login-remember mt-20"
+            >
               <Checkbox
                 :value="rememberProvider"
                 :label="t('login.providers.remember')"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -17,6 +17,7 @@ import Password from '@shell/components/form/Password';
 import { configTypeForProvider } from '@shell/models/management.cattle.io.authconfig';
 import AuthProviderList from '@shell/components/auth/login/AuthProviderList.vue';
 import OrDivider from '@shell/components/auth/login/OrDivider.vue';
+import { LOCAL_AUTH_ID } from '@shell/utils/auth';
 import {
   clearRememberedProviderId,
   getRememberedProviderId,
@@ -104,19 +105,20 @@ export default {
 
     /**
      * Counted over the options rather than the external providers, because local
-     * is one of the ways in and is offered from the list like any other. One
-     * external provider alongside local is still a choice to be made.
+     * is one of the ways in. One external provider alongside local is still a
+     * choice, even though the page offers it as a link rather than as a list.
      */
     hasProviderChoice() {
       return this.providerOptions.length > 1;
     },
 
     /**
-     * Saving a choice is only worth offering where there are several external
-     * providers to pick between. With one, the list is really just offering local
-     * as the way round it, and the page opens on that provider regardless.
+     * A list is how the page asks which external provider to use. One of them
+     * alongside local is a straight swap between two, which reads better as a
+     * link -- and leaves nothing worth remembering, since the page opens on that
+     * provider either way.
      */
-    canRememberProvider() {
+    hasProviderList() {
       return this.providers.length > 1;
     },
 
@@ -125,7 +127,7 @@ export default {
     },
 
     showProviderList() {
-      return this.hasProviderChoice && (!this.isCredentialForm || this.listExpanded);
+      return this.hasProviderList && (!this.isCredentialForm || this.listExpanded);
     },
 
     /**
@@ -317,7 +319,7 @@ export default {
      * that gives the user no way to clear it.
      */
     rememberedProviderId() {
-      return this.canRememberProvider ? getRememberedProviderId() : null;
+      return this.hasProviderList ? getRememberedProviderId() : null;
     },
 
     /**
@@ -332,6 +334,22 @@ export default {
       if (this.rememberProvider) {
         setRememberedProviderId(option.id);
       }
+
+      this.$nextTick(() => {
+        this.focusSomething();
+      });
+    },
+
+    /**
+     * The swap between the single external provider and local. There is no list
+     * to choose from with only two ways in, so the link moves the panel itself.
+     */
+    toggleLocal() {
+      this.showLocal = !this.showLocal;
+      this.selectedProviderId = this.showLocal ? LOCAL_AUTH_ID : this.providers[0]?.id || null;
+      // Carried in the URL so a reload lands back where the user left off, which
+      // means dropping the flag on the way out as well as setting it on the way in.
+      this.$router.applyQuery({ [LOCAL]: this.showLocal }, { [LOCAL]: false });
 
       this.$nextTick(() => {
         this.focusSomething();
@@ -607,41 +625,65 @@ export default {
           class="login-alternatives mt-20"
         >
           <OrDivider />
+          <!--
+            Several external providers are weighed up in a list. One alongside
+            local is a straight swap between two, offered as a link instead.
+          -->
+          <template v-if="hasProviderList">
+            <div
+              v-if="!showProviderList"
+              class="mt-20 text-center"
+            >
+              <RcButton
+                variant="link"
+                data-testid="login-provider-choose"
+                @click="expandProviderList"
+              >
+                {{ t('login.providers.chooseDifferent') }}
+              </RcButton>
+            </div>
+            <template v-else>
+              <AuthProviderList
+                ref="providerList"
+                class="mt-20"
+                :options="providerOptions"
+                :selected-id="selectedProviderId"
+                @select="selectProvider"
+              />
+              <div class="login-remember mt-20">
+                <Checkbox
+                  :value="rememberProvider"
+                  :label="t('login.providers.remember')"
+                  data-testid="login-provider-remember"
+                  @update:value="setRememberProvider"
+                />
+                <p class="login-remember__hint">
+                  {{ t('login.providers.rememberHint') }}
+                </p>
+              </div>
+            </template>
+          </template>
           <div
-            v-if="!showProviderList"
+            v-else
             class="mt-20 text-center"
           >
             <RcButton
+              v-if="showLocal"
               variant="link"
               data-testid="login-provider-choose"
-              @click="expandProviderList"
+              @click="toggleLocal"
             >
               {{ t('login.providers.chooseDifferent') }}
             </RcButton>
-          </div>
-          <template v-else>
-            <AuthProviderList
-              ref="providerList"
-              class="mt-20"
-              :options="providerOptions"
-              :selected-id="selectedProviderId"
-              @select="selectProvider"
-            />
-            <div
-              v-if="canRememberProvider"
-              class="login-remember mt-20"
+            <RcButton
+              v-else
+              variant="link"
+              data-testid="login-useLocal"
+              @click="toggleLocal"
             >
-              <Checkbox
-                :value="rememberProvider"
-                :label="t('login.providers.remember')"
-                data-testid="login-provider-remember"
-                @update:value="setRememberProvider"
-              />
-              <p class="login-remember__hint">
-                {{ t('login.providers.rememberHint') }}
-              </p>
-            </div>
-          </template>
+              {{ t('login.providers.useLocal') }}
+            </RcButton>
+          </div>
         </div>
         <div
           v-if="showLocaleSelector && hasMultipleLocales && !isHarvester"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -328,6 +328,11 @@ export default {
         // user, so it must not overwrite what they asked to be remembered.
         this.selectedProviderId = fallback.id;
         this.showLocal = fallback.isLocal;
+
+        // The box speaks for the provider on screen, and the page has just
+        // stepped onto one the user didn't ask for - so it stops claiming a
+        // choice is saved. Only the saved id survives, for them to come back to.
+        this.rememberProvider = false;
       }
 
       this.listExpanded = true;

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -1,5 +1,4 @@
 <script>
-import { removeObject } from '@shell/utils/array';
 import { USERNAME } from '@shell/config/cookies';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import AsyncButton from '@shell/components/AsyncButton';
@@ -13,9 +12,18 @@ import {
   IS_SLO, IS_SESSION_IDLE
 } from '@shell/config/query-params';
 import { Checkbox } from '@components/Form/Checkbox';
+import { RcButton } from '@components/RcButton';
 import Password from '@shell/components/form/Password';
-import { sortBy } from '@shell/utils/sort';
-import { configType } from '@shell/models/management.cattle.io.authconfig';
+import { configTypeForProvider } from '@shell/models/management.cattle.io.authconfig';
+import AuthProviderList from '@shell/components/auth/login/AuthProviderList.vue';
+import OrDivider from '@shell/components/auth/login/OrDivider.vue';
+import {
+  clearRememberedProviderId,
+  getRememberedProviderId,
+  resolveInitialProvider,
+  setRememberedProviderId,
+  toProviderOptions,
+} from '@shell/utils/auth-providers';
 import { mapGetters } from 'vuex';
 import { markRaw } from 'vue';
 import { MANAGEMENT, NORMAN, EXT } from '@shell/config/types';
@@ -36,7 +44,7 @@ import { getBrandMeta } from '@shell/utils/brand';
 export default {
   name:       'Login',
   components: {
-    LabeledInput, AsyncButton, Checkbox, BrandImage, Banner, InfoBox, CopyCode, Password, LocaleSelector, Loading, TabTitle
+    LabeledInput, AsyncButton, AuthProviderList, OrDivider, Checkbox, RcButton, BrandImage, Banner, InfoBox, CopyCode, Password, LocaleSelector, Loading, TabTitle
   },
 
   data() {
@@ -57,6 +65,10 @@ export default {
       showLocal:          false,
       providers:          [],
       providerComponents: [],
+      providerOptions:    [],
+      selectedProviderId: null,
+      rememberProvider:   false,
+      listExpanded:       false,
       customLoginError:   {},
       firstLogin:         false,
       vendor:             getVendor()
@@ -83,18 +95,40 @@ export default {
       return this.isSingleProduct?.productName === HARVESTER;
     },
 
-    singleProvider() {
-      return this.providers.length === 1 ? this.providers[0] : undefined;
+    /**
+     * The provider the primary login button acts on.
+     */
+    selectedProvider() {
+      return this.providerOptions.find((option) => option.id === this.selectedProviderId);
     },
 
-    nonLocalPrompt() {
-      if (this.singleProvider) {
-        const provider = this.displayName(this.singleProvider);
+    /**
+     * Counted over the options rather than the external providers, because local
+     * is one of the ways in and is offered from the list like any other. One
+     * external provider alongside local is still a choice to be made.
+     */
+    hasProviderChoice() {
+      return this.providerOptions.length > 1;
+    },
 
-        return this.t('login.useProvider', { provider });
-      }
+    isCredentialForm() {
+      return this.showLocal || this.selectedProvider?.category === 'ldap';
+    },
 
-      return this.t('login.useNonLocal');
+    showProviderList() {
+      return this.hasProviderChoice && (!this.isCredentialForm || this.listExpanded);
+    },
+
+    /**
+     * Index of the selected provider within `providers`, which `providerComponents`
+     * is built in step with.
+     */
+    selectedProviderIndex() {
+      return this.providers.findIndex((provider) => provider.id === this.selectedProviderId);
+    },
+
+    selectedProviderComponent() {
+      return this.providerComponents[this.selectedProviderIndex];
     },
 
     errorMessage() {
@@ -127,12 +161,28 @@ export default {
       return '';
     },
 
+    loginMessages() {
+      if (this.errorToDisplay) {
+        return [{ message: this.errorToDisplay, variant: 'error' }];
+      }
+
+      if (this.loggedOut) {
+        return [{ message: this.loggedOutSuccessMsg, variant: 'success' }];
+      }
+
+      if (this.timedOut) {
+        return [{ message: this.t('login.loginAgain'), variant: 'error' }];
+      }
+
+      return [];
+    },
+
     kubectlCmd() {
       return "kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{\"\\n\"}}'";
     },
 
     hasLoginMessage() {
-      return this.errorToDisplay || this.loggedOut || this.timedOut;
+      return this.loginMessages.length > 0;
     },
 
     customizations() {
@@ -165,25 +215,40 @@ export default {
     const { firstLoginSetting } = await this.loadInitialSettings();
     const { value } = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.BANNERS });
     const drivers = await this.$store.dispatch('auth/getAuthProviders');
-    const providers = sortBy(drivers.map((x) => x.id), ['id']);
-    const hasLocal = providers.includes('local');
-    const hasOthers = hasLocal && !!providers.find((x) => x !== 'local');
 
-    if ( hasLocal ) {
-      // Local is special and handled here so that it can be toggled
-      removeObject(providers, 'local');
-    }
+    // Carries local as well, since the list offers it alongside the external providers.
+    const providerOptions = toProviderOptions(drivers, {
+      t:            this.t,
+      withFallback: this.$store.getters['i18n/withFallback'],
+    });
+
+    const providers = providerOptions.filter((x) => !x.isLocal);
+    const hasLocal = providerOptions.some((x) => x.isLocal);
+    const hasOthers = hasLocal && !!providers.length;
+
+    const rememberedId = getRememberedProviderId();
+    const initial = resolveInitialProvider(providerOptions, rememberedId);
 
     this.vendor = getVendor();
+    this.providerOptions = providerOptions;
     this.providers = providers;
     this.hasLocal = hasLocal;
-    this.showLocal = hasLocal && (!hasOthers || (this.$route.query[LOCAL] === _FLAGGED));
+    this.selectedProviderId = initial?.id || null;
+    // Only reflect the checkbox as ticked when the saved provider still exists;
+    // a stale entry shouldn't claim the page is remembering something.
+    this.rememberProvider = !!rememberedId && initial?.id === rememberedId;
     this.customLoginError = JSON.parse(value).loginError;
     this.firstLogin = firstLoginSetting?.value === 'true';
     this.username = this.firstLogin ? 'admin' : this.username;
 
-    this.providerComponents = this.providers.map((name) => {
-      return markRaw(this.$store.getters['type-map/importLogin'](configType[name] || name));
+    this.showLocal = hasLocal && (
+      !hasOthers ||
+      this.$route.query[LOCAL] === _FLAGGED ||
+      !!initial?.isLocal
+    );
+
+    this.providerComponents = this.providers.map((x) => {
+      return markRaw(this.$store.getters['type-map/importLogin'](configTypeForProvider(x.type) || x.type));
     });
 
     this.$nextTick(() => {
@@ -236,16 +301,50 @@ export default {
       };
     },
 
-    displayName(provider) {
-      return this.t(`model.authConfig.provider.${ provider }`);
-    },
+    /**
+     * Picking a provider only changes what the page is offering -- the user still
+     * confirms with the primary button, so SSO, LDAP and local all behave alike.
+     */
+    selectProvider(option) {
+      this.selectedProviderId = option.id;
+      this.showLocal = option.isLocal;
+      this.listExpanded = false;
 
-    toggleLocal() {
-      this.showLocal = !this.showLocal;
-      this.$router.applyQuery({ [LOCAL]: _FLAGGED });
+      if (this.rememberProvider) {
+        setRememberedProviderId(option.id);
+      }
+
       this.$nextTick(() => {
         this.focusSomething();
       });
+    },
+
+    expandProviderList() {
+      const alternatives = this.providerOptions.filter((option) => option.id !== this.selectedProviderId);
+      const fallback = resolveInitialProvider(alternatives, getRememberedProviderId());
+
+      if (fallback) {
+        // Deliberately not `selectProvider`: the page is choosing here, not the
+        // user, so it must not overwrite what they asked to be remembered.
+        this.selectedProviderId = fallback.id;
+        this.showLocal = fallback.isLocal;
+      }
+
+      this.listExpanded = true;
+
+      this.$nextTick(() => {
+        this.$refs.providerList?.focus?.();
+      });
+    },
+
+    setRememberProvider(remember) {
+      this.rememberProvider = remember;
+
+      if (remember && this.selectedProviderId) {
+        setRememberedProviderId(this.selectedProviderId);
+      } else {
+        clearRememberedProviderId();
+      }
     },
 
     focusSomething() {
@@ -361,7 +460,7 @@ export default {
       {{ `${vendor} - ${t('login.login')}` }}
     </TabTitle>
     <div class="row gutless mb-20">
-      <div class="col span-6 p-20">
+      <div class="col span-6 p-20 login-panel">
         <p
           v-if="!brandLogo"
           class="text-center"
@@ -381,27 +480,14 @@ export default {
           class="login-messages"
           data-testid="login__messages"
           :class="{'login-messages--hasContent': hasLoginMessage}"
-          role="alert"
-          aria-live="assertive"
-          aria-atomic="true"
         >
           <Banner
-            v-if="errorToDisplay"
-            :label="errorToDisplay"
-            color="error"
+            v-for="message in loginMessages"
+            :key="message.variant"
+            :label="message.message"
+            :color="message.variant"
+            :role="message.variant === 'error' ? 'alert' : 'status'"
           />
-          <h4
-            v-else-if="loggedOut"
-            class="text-success text-center"
-          >
-            {{ loggedOutSuccessMsg }}
-          </h4>
-          <h4
-            v-else-if="timedOut"
-            class="text-error text-center"
-          >
-            {{ t('login.loginAgain') }}
-          </h4>
         </div>
         <div
           v-if="firstLogin"
@@ -426,16 +512,16 @@ export default {
         </div>
 
         <div
-          v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length"
+          v-if="(!hasLocal || (hasLocal && !showLocal)) && selectedProvider && !selectedProvider.isLocal"
+          class="login-column"
           :class="{'mt-30': !hasLoginMessage}"
         >
           <component
-            :is="providerComponents[idx]"
-            v-for="(name, idx) in providers"
-            :key="idx"
-            class="mb-10"
-            :focus-on-mount="(idx === 0 && !showLocal)"
-            :name="name"
+            :is="selectedProviderComponent"
+            :key="selectedProvider.id"
+            :focus-on-mount="!showLocal"
+            :name="selectedProvider.id"
+            :type="selectedProvider.type"
             :open="!showLocal"
             @showInputs="showLocal = false"
             @error="handleProviderError"
@@ -444,80 +530,92 @@ export default {
         <template v-if="hasLocal">
           <form
             v-if="showLocal"
+            class="login-column"
             :class="{'mt-30': !hasLoginMessage}"
             @submit.prevent
           >
-            <div class="span-6 offset-3">
-              <div class="mb-20">
-                <LabeledInput
-                  v-if="!firstLogin"
-                  ref="username"
-                  v-model:value.trim="username"
-                  data-testid="local-login-username"
-                  :label="t('login.username')"
-                  autocomplete="username"
-                />
-              </div>
-              <div class="">
-                <Password
-                  ref="password"
-                  v-model:value="password"
-                  data-testid="local-login-password"
-                  :label="t('login.password')"
-                  autocomplete="current-password"
-                />
-              </div>
+            <div class="mb-20">
+              <LabeledInput
+                v-if="!firstLogin"
+                ref="username"
+                v-model:value.trim="username"
+                data-testid="local-login-username"
+                :label="t('login.username')"
+                autocomplete="username"
+              />
             </div>
-            <div class="mt-20">
-              <div class="col span-12 text-center">
-                <AsyncButton
-                  id="submit"
-                  data-testid="login-submit"
-                  type="submit"
-                  :action-label="t('login.loginWithLocal')"
-                  :waiting-label="t('login.loggingIn')"
-                  :success-label="t('login.loggedIn')"
-                  :error-label="t('asyncButton.default.error')"
-                  @click="loginLocal"
+            <div>
+              <Password
+                ref="password"
+                v-model:value="password"
+                data-testid="local-login-password"
+                :label="t('login.password')"
+                autocomplete="current-password"
+              />
+            </div>
+            <div class="mt-20 text-center">
+              <AsyncButton
+                id="submit"
+                class="login-column__submit"
+                data-testid="login-submit"
+                type="submit"
+                :action-label="t('login.loginWithLocal')"
+                :waiting-label="t('login.loggingIn')"
+                :success-label="t('login.loggedIn')"
+                :error-label="t('asyncButton.default.error')"
+                @click="loginLocal"
+              />
+              <div
+                v-if="!firstLogin"
+                class="mt-20"
+              >
+                <Checkbox
+                  v-model:value="remember"
+                  :label="t('login.remember.label')"
+                  type="checkbox"
                 />
-                <div
-                  v-if="!firstLogin"
-                  class="mt-20"
-                >
-                  <Checkbox
-                    v-model:value="remember"
-                    :label="t('login.remember.label')"
-                    type="checkbox"
-                  />
-                </div>
               </div>
             </div>
           </form>
-          <div
-            v-if="hasLocal && !showLocal"
-            class="mt-20 text-center"
-          >
-            <a
-              id="login-useLocal"
-              data-testid="login-useLocal"
-              role="button"
-              @click="toggleLocal"
-            >
-              {{ t('login.useLocal') }}
-            </a>
-          </div>
-          <div
-            v-if="hasLocal && showLocal && providers.length"
-            class="mt-20 text-center"
-          >
-            <a
-              role="button"
-              @click="toggleLocal"
-            >
-              {{ nonLocalPrompt }}
-            </a>
-          </div>
         </template>
+        <div
+          v-if="hasProviderChoice"
+          class="login-alternatives mt-20"
+        >
+          <OrDivider />
+          <div
+            v-if="!showProviderList"
+            class="mt-20 text-center"
+          >
+            <RcButton
+              variant="link"
+              data-testid="login-provider-choose"
+              @click="expandProviderList"
+            >
+              {{ t('login.providers.chooseDifferent') }}
+            </RcButton>
+          </div>
+          <template v-else>
+            <AuthProviderList
+              ref="providerList"
+              class="mt-20"
+              :options="providerOptions"
+              :selected-id="selectedProviderId"
+              @select="selectProvider"
+            />
+            <div class="login-remember mt-20">
+              <Checkbox
+                :value="rememberProvider"
+                :label="t('login.providers.remember')"
+                data-testid="login-provider-remember"
+                @update:value="setRememberProvider"
+              />
+              <p class="login-remember__hint">
+                {{ t('login.providers.rememberHint') }}
+              </p>
+            </div>
+          </template>
+        </div>
         <div
           v-if="showLocaleSelector && hasMultipleLocales && !isHarvester"
           class="locale-selector"
@@ -540,6 +638,8 @@ export default {
 
 <style lang="scss" scoped>
   .login {
+    --login-column-width: 362px;
+
     overflow: hidden;
     position: relative;  // Used to keep the locale selector positioned correctly
 
@@ -564,22 +664,47 @@ export default {
     }
 
     .login-messages {
+      width: var(--login-column-width);
+      max-width: 100%;
+      align-self: center;
+
       display: flex;
       justify-content: center;
       align-items: center;
 
-      .banner {
-        margin: 5px;
-      }
-      h4 {
-        margin: 0;
-      }
       &--hasContent {
         min-height: 70px;
       }
 
-      .text-error, .banner {
-        max-width: 80%;
+      .banner {
+        width: 100%;
+        margin: 5px 0;
+      }
+    }
+
+    // The inputs, the submit button and the provider divider are one column, so
+    // they share a width rather than each being sized by its own content.
+    .login-column,
+    .login-alternatives {
+      width: var(--login-column-width);
+      max-width: 100%;
+      align-self: center;
+    }
+
+    // `.btn` is a flex row, so a full-width button needs telling where to put
+    // its label - it packs to the start otherwise.
+    .login-column__submit,
+    .login-column :deep([data-testid="login-provider-submit"]) {
+      width: 100%;
+      justify-content: center;
+    }
+
+    .login-remember {
+      &__hint {
+        margin-top: 2px;
+        color: var(--label-secondary);
+        font-size: 12px;
+        line-height: 18px;
       }
     }
 
@@ -604,8 +729,14 @@ export default {
       flex-direction: column;
       height: 100%;
       place-content: center;
+      justify-content: safe center;
     }
   }
+
+  .login-panel {
+    padding-bottom: 60px;
+  }
+
   .locale-selector {
     position: absolute;
     bottom: 30px;

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -1,12 +1,12 @@
 <script>
-import { configType } from '@shell/models/management.cattle.io.authconfig';
+import { configTypeForProvider } from '@shell/models/management.cattle.io.authconfig';
 import { SLO_AUTH_PROVIDERS } from '@shell/store/auth';
 
 export default {
   async fetch() {
     const publicAuthProviders = await this.$store.dispatch('auth/getAuthProviders');
 
-    const sloAuthProvider = publicAuthProviders.find((authProvider) => SLO_AUTH_PROVIDERS.includes(configType[authProvider?.id]));
+    const sloAuthProvider = publicAuthProviders.find((authProvider) => SLO_AUTH_PROVIDERS.includes(configTypeForProvider(authProvider?.type)));
 
     if (!!sloAuthProvider) {
       const { logoutAllSupported, logoutAllEnabled, logoutAllForced } = sloAuthProvider;

--- a/shell/utils/__tests__/auth-providers.test.ts
+++ b/shell/utils/__tests__/auth-providers.test.ts
@@ -1,0 +1,224 @@
+import {
+  REMEMBERED_PROVIDER_KEY,
+  clearRememberedProviderId,
+  getRememberedProviderId,
+  resolveInitialProvider,
+  setRememberedProviderId,
+  toProviderOptions,
+} from '@shell/utils/auth-providers';
+import type { AuthProviderDriver, AuthProviderOption } from '@shell/utils/auth-providers';
+
+jest.mock('@shell/utils/require-asset', () => {
+  return { requireAsset: jest.fn((path: string) => path) };
+});
+
+const labels: Record<string, string> = {
+  'model.authConfig.provider."okta"':            'Okta',
+  'model.authConfig.provider."github"':          'GitHub',
+  'model.authConfig.provider."azuread"':         'Microsoft Entra ID',
+  'model.authConfig.provider."activedirectory"': 'ActiveDirectory',
+  'model.authConfig.description."saml"':         'SAML',
+  'model.authConfig.description."oauth"':        'OAuth',
+  'model.authConfig.description."ldap"':         'LDAP',
+  'login.providers.local.name':                  'Local account',
+  'login.providers.local.description':           'Signs in with a username and password held by Rancher itself.',
+  'login.providers.local.meta':                  'Username and password',
+};
+
+const i18n = {
+  t: (key: string, args?: any) => {
+    if (key === 'login.providers.meta') {
+      return `${ args.vendor } · ${ args.protocol }`;
+    }
+
+    return labels[key] ?? key;
+  },
+  withFallback: (key: string, _args: object | null, fallback: string) => labels[key] ?? fallback,
+};
+
+const driver = (id: string, type: string, description?: string): AuthProviderDriver => ({
+  id, type, description
+});
+
+const option = (id: string, extra: Partial<AuthProviderOption> = {}): AuthProviderOption => ({
+  id,
+  type:        'oktaProvider',
+  key:         'okta',
+  category:    'saml',
+  name:        id,
+  description: '',
+  meta:        'Okta · SAML',
+  icon:        '',
+  isLocal:     false,
+  ...extra,
+});
+
+describe('fx: toProviderOptions', () => {
+  it('should label a provider with the name the admin chose', () => {
+    const [result] = toProviderOptions([driver('Okta — Corporate SSO', 'oktaProvider')], i18n);
+
+    expect(result.name).toBe('Okta — Corporate SSO');
+    expect(result.meta).toBe('Okta · SAML');
+  });
+
+  // Multi-IDP: two configs of one provider are distinguishable only by name.
+  it('should keep configs of the same provider distinct', () => {
+    const results = toProviderOptions([
+      driver('Okta — Corporate SSO', 'oktaProvider'),
+      driver('Okta — Partner tenant', 'oktaProvider'),
+    ], i18n);
+
+    expect(results.map((r) => r.name)).toStrictEqual(['Okta — Corporate SSO', 'Okta — Partner tenant']);
+    expect(results.map((r) => r.meta)).toStrictEqual(['Okta · SAML', 'Okta · SAML']);
+  });
+
+  // Installs predating multi-IDP named their single config after the provider.
+  it('should fall back to the vendor label when the name is just the provider key', () => {
+    const [result] = toProviderOptions([driver('okta', 'oktaProvider')], i18n);
+
+    expect(result.name).toBe('Okta');
+  });
+
+  it('should treat the vendor name case-insensitively when falling back', () => {
+    const [result] = toProviderOptions([driver('GitHub', 'githubProvider')], i18n);
+
+    expect(result.name).toBe('GitHub');
+  });
+
+  // The row keeps a place for the admin's own words about the config, so that
+  // two tenants of one provider can be told apart by more than their names.
+  it('should carry the description the admin gave the config', () => {
+    const [result] = toProviderOptions([driver('Okta — Partner tenant', 'oktaProvider', 'Partners and contractors.')], i18n);
+
+    expect(result.description).toBe('Partners and contractors.');
+  });
+
+  it('should leave the description empty when the config has none', () => {
+    const [result] = toProviderOptions([driver('okta', 'oktaProvider')], i18n);
+
+    expect(result.description).toBe('');
+  });
+
+  it('should resolve the vendor logo', () => {
+    const [result] = toProviderOptions([driver('gh', 'githubProvider')], i18n);
+
+    expect(result.icon).toBe('~shell/assets/images/vendor/github.svg');
+  });
+
+  it('should carry the normalised key and protocol category', () => {
+    const [result] = toProviderOptions([driver('ad', 'activeDirectoryProvider')], i18n);
+
+    expect(result.key).toBe('activedirectory');
+    expect(result.category).toBe('ldap');
+    expect(result.meta).toBe('ActiveDirectory · LDAP');
+  });
+
+  it('should sort by provider then name so configs of one provider sit together', () => {
+    const results = toProviderOptions([
+      driver('zeta', 'githubProvider'),
+      driver('beta', 'oktaProvider'),
+      driver('alpha', 'githubProvider'),
+    ], i18n);
+
+    expect(results.map((r) => r.id)).toStrictEqual(['alpha', 'zeta', 'beta']);
+  });
+
+  describe('local', () => {
+    it('should append local last, after the external providers', () => {
+      const results = toProviderOptions([
+        driver('local', 'localProvider'),
+        driver('gh', 'githubProvider'),
+      ], i18n);
+
+      expect(results.map((r) => r.id)).toStrictEqual(['gh', 'local']);
+      expect(results[1].isLocal).toBe(true);
+    });
+
+    it('should describe local without a vendor', () => {
+      const [result] = toProviderOptions([driver('local', 'localProvider')], i18n);
+
+      expect(result.name).toBe('Local account');
+      expect(result.description).toBe('Signs in with a username and password held by Rancher itself.');
+      expect(result.meta).toBe('Username and password');
+      expect(result.icon).toBe('');
+    });
+
+    it('should omit local when it is not configured', () => {
+      const results = toProviderOptions([driver('gh', 'githubProvider')], i18n);
+
+      expect(results.some((r) => r.isLocal)).toBe(false);
+    });
+  });
+
+  it('should return nothing for an empty driver list', () => {
+    expect(toProviderOptions([], i18n)).toStrictEqual([]);
+  });
+});
+
+describe('fx: resolveInitialProvider', () => {
+  const options = [option('okta-corp'), option('okta-partner')];
+
+  it('should open on the remembered provider', () => {
+    expect(resolveInitialProvider(options, 'okta-partner')?.id).toBe('okta-partner');
+  });
+
+  it('should open on the first provider when nothing is remembered', () => {
+    expect(resolveInitialProvider(options, null)?.id).toBe('okta-corp');
+  });
+
+  // The admin can delete or rename a config out from under a saved choice.
+  it('should fall back when the remembered provider no longer exists', () => {
+    expect(resolveInitialProvider(options, 'deleted-config')?.id).toBe('okta-corp');
+  });
+
+  it('should be undefined when there are no providers at all', () => {
+    expect(resolveInitialProvider([], 'okta-corp')).toBeUndefined();
+  });
+});
+
+describe('remembered provider storage', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('should round-trip the provider name', () => {
+    setRememberedProviderId('okta-corp');
+
+    expect(getRememberedProviderId()).toBe('okta-corp');
+    expect(window.localStorage.getItem(REMEMBERED_PROVIDER_KEY)).toBe('okta-corp');
+  });
+
+  it('should report nothing when no choice has been saved', () => {
+    expect(getRememberedProviderId()).toBeNull();
+  });
+
+  it('should forget the saved choice', () => {
+    setRememberedProviderId('okta-corp');
+    clearRememberedProviderId();
+
+    expect(getRememberedProviderId()).toBeNull();
+  });
+
+  // A login page that cannot render is far worse than one that forgets a preference.
+  describe('when storage is unavailable', () => {
+    const boom = () => {
+      throw new Error('QuotaExceededError');
+    };
+
+    it('should read as nothing remembered rather than throwing', () => {
+      jest.spyOn(Storage.prototype, 'getItem').mockImplementationOnce(boom);
+
+      expect(getRememberedProviderId()).toBeNull();
+    });
+
+    it('should swallow a failed write', () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(boom);
+
+      expect(() => setRememberedProviderId('okta-corp')).not.toThrow();
+    });
+
+    it('should swallow a failed clear', () => {
+      jest.spyOn(Storage.prototype, 'removeItem').mockImplementationOnce(boom);
+
+      expect(() => clearRememberedProviderId()).not.toThrow();
+    });
+  });
+});

--- a/shell/utils/auth-providers.ts
+++ b/shell/utils/auth-providers.ts
@@ -1,0 +1,120 @@
+import { configTypeForProvider, providerIcon, providerKey } from '@shell/models/management.cattle.io.authconfig';
+import { LOCAL_AUTH_ID } from '@shell/utils/auth';
+import { sortBy } from '@shell/utils/sort';
+
+export const LOCAL_PROVIDER = 'localProvider';
+export const REMEMBERED_PROVIDER_KEY = 'rancher-login-provider';
+
+export interface AuthProviderDriver {
+  id: string;
+  type: string;
+  /** Free text the admin gave the config, when the server has one for it. */
+  description?: string;
+}
+
+export interface AuthProviderOption {
+  id: string;
+  type: string;
+  key: string;
+  category?: string;
+  name: string;
+  description: string;
+  meta: string;
+  icon: string;
+  isLocal: boolean;
+}
+
+interface I18n {
+  t: (key: string, args?: object) => string;
+  withFallback: (key: string, args: object | null, fallback: string) => string;
+}
+
+const displayNameFor = (id: string, key: string, vendorLabel: string): string => {
+  return id.toLowerCase() === key ? vendorLabel : id;
+};
+
+/**
+ * The providers to offer on the login page, in the order they are offered.
+ *
+ * Built from `/v1-public/authproviders`, which is all an unauthenticated visitor
+ * can see: an id, a provider type, and whatever the admin wrote about the config.
+ */
+export const toProviderOptions = (drivers: AuthProviderDriver[], i18n: I18n): AuthProviderOption[] => {
+  const { t, withFallback } = i18n;
+
+  const external = sortBy(
+    drivers.filter((driver) => driver.type !== LOCAL_PROVIDER),
+    ['type', 'id']
+  ).map((driver: AuthProviderDriver): AuthProviderOption => {
+    const key = providerKey(driver.type);
+    const category = configTypeForProvider(driver.type);
+    const vendorLabel = withFallback(`model.authConfig.provider."${ key }"`, null, key);
+    const protocolLabel = category ? withFallback(`model.authConfig.description."${ category }"`, null, category.toUpperCase()) : '';
+
+    return {
+      id:          driver.id,
+      type:        driver.type,
+      key,
+      category,
+      name:        displayNameFor(driver.id, key, vendorLabel),
+      description: driver.description || '',
+      meta:        protocolLabel ? t('login.providers.meta', { vendor: vendorLabel, protocol: protocolLabel }) : vendorLabel,
+      icon:        providerIcon(driver.type),
+      isLocal:     false,
+    };
+  });
+
+  const hasLocal = drivers.some((driver) => driver.type === LOCAL_PROVIDER);
+
+  if (!hasLocal) {
+    return external;
+  }
+
+  return [
+    ...external,
+    {
+      id:          LOCAL_AUTH_ID,
+      type:        LOCAL_PROVIDER,
+      key:         LOCAL_AUTH_ID,
+      category:    '',
+      name:        t('login.providers.local.name'),
+      description: t('login.providers.local.description'),
+      meta:        t('login.providers.local.meta'),
+      icon:        '',
+      isLocal:     true,
+    },
+  ];
+};
+
+export const getRememberedProviderId = (): string | null => {
+  try {
+    return window.localStorage.getItem(REMEMBERED_PROVIDER_KEY);
+  } catch (e) {
+    return null;
+  }
+};
+
+export const setRememberedProviderId = (id: string): void => {
+  try {
+    window.localStorage.setItem(REMEMBERED_PROVIDER_KEY, id);
+  } catch (e) {}
+};
+
+export const clearRememberedProviderId = (): void => {
+  try {
+    window.localStorage.removeItem(REMEMBERED_PROVIDER_KEY);
+  } catch (e) {}
+};
+
+/**
+ * The provider the page should open on: the one the visitor asked to be
+ * remembered, or the first on offer when there is no usable saved choice.
+ */
+export const resolveInitialProvider = (
+  options: AuthProviderOption[],
+  rememberedId: string | null
+): AuthProviderOption | undefined => {
+  const remembered = rememberedId ? options.find((option) => option.id === rememberedId) : undefined;
+
+  return remembered || options[0];
+};

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -97,6 +97,12 @@ export function returnTo(opt, vm) {
 }
 
 /**
+ * The local authconfig, which is always present and is managed separately from the
+ * external providers.
+ */
+export const LOCAL_AUTH_ID = 'local';
+
+/**
  * Determines common auth provider info as those that are available (non-local) and the location of the enabled provider
  */
 export const authProvidersInfo = async(store) => {
@@ -113,7 +119,7 @@ export const authProvidersInfo = async(store) => {
  * Parses auth provider's info to return if there's an auth provider enabled
  */
 export function parseAuthProvidersInfo(rows) {
-  const nonLocal = rows.filter((x) => x.name !== 'local');
+  const nonLocal = rows.filter((x) => x.name !== LOCAL_AUTH_ID);
   const enabled = nonLocal.filter((x) => x.enabled === true );
 
   const supportedNonLocal = nonLocal.filter((x) => x.id !== 'oidc');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This redesigns the login page with better support for multiple auth providers. The user is shown a list of all available providers to choose from, rather than a single provider button with a "use local" toggle.

contributes to #17295
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

> 📋 Note: Only a single auth provider can currently be configured. Multiple auth providers are not supported in Rancher at this time.  

- The login page now lists all enabled auth providers from `/v1-public/authproviders` as selectable options
- A "remember this provider" option persists the user's choice and pre-selects it on
 the next visit; a stale/removed provider falls back gracefully
- The chosen provider's authconfig name is now sent with the login request, so the server knows which config to sign the user in with
- Login page buttons were migrated to `RcButton`; new `AuthProviderList`, `AuthProviderOption`, `AuthProviderLogo` and `OrDivider` components
- Login status messages are shown as banners

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Auth provider identifiers are normalized via a new `providerKey()` helper in `shell/models/management.cattle.io.authconfig.js`
- `shell/utils/auth-providers.ts` builds the ordered list of provider options and resolves the initial provider from the remembered value
- The `login.js` mixin now receives the provider `type` as well as the config `name`; a config named after its provider (e.g. `github`) is labelled with the vendor name, while an admin-renamed config is labelled with the name the admin chose — that name is the only thing distinguishing sibling configs of the same type

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Single provider configured (no local): login page shows only that provider's form/button as before
- Single external provider + local enabled: provider list is offered; picking local shows the local username/password form; local still reachable via the `?local=true` query param
- "Remember this provider": tick it, log out and reload, the same provider is preselected back to a sensible default without error
- Logout page and first-login flows still work
- Verify light and dark mode styling of the provider list, logos and divider

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- All existing login paths for single-provider setups behavior should be unchanged for single-provider installs
- Branded/first-login (Harvester, RKE2 bootstrap) login pages

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/0f3c0a93-e072-4ff8-b207-871fd1b86758

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
