### PR TITLE
Guard machine scale down against stale targets

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6013,6 +6013,8 @@ promptForceRemove:
 promptScaleMachineDown:
   attemptingToRemove: "You are attempting to delete {count} {type}"
   attemptingToScaleDown: "You are attempting to scale down {type}"
+  machineAlreadyDeleted: "Machine {name} is already being deleted or has been recreated. The machine pool was not scaled down."
+  machineDeleteAnnotationMissing: "Machine {name} could not be marked for deletion. The machine pool was not scaled down."
   retainedMachine1: At least one Machine must exist for roles Control Plane and Etcd.
   retainedMachine2: <b>{ name }</b> will remain
   scaling: |-

--- a/shell/dialog/ScaleMachineDownDialog.vue
+++ b/shell/dialog/ScaleMachineDownDialog.vue
@@ -114,6 +114,39 @@ export default {
       return [ignoredType, safeMachinesToDelete];
     },
 
+    async markMachineForDeletion(machine) {
+      machine.setAnnotation(CAPI_LABELS.DELETE_MACHINE, 'true');
+
+      await machine.save();
+
+      let liveMachine;
+
+      try {
+        liveMachine = await this.$store.dispatch('management/find', {
+          type: CAPI.MACHINE,
+          id:   machine.id,
+          opt:  {
+            force: true,
+            watch: false
+          }
+        });
+      } catch (e) {
+        if (e?._status === 404 || e?.status === 404) {
+          throw new Error(this.t('promptScaleMachineDown.machineAlreadyDeleted', { name: machine.nameDisplay }));
+        }
+
+        throw e;
+      }
+
+      if (!liveMachine || liveMachine.metadata?.deletionTimestamp) {
+        throw new Error(this.t('promptScaleMachineDown.machineAlreadyDeleted', { name: machine.nameDisplay }));
+      }
+
+      if (!liveMachine.metadata?.annotations?.[CAPI_LABELS.DELETE_MACHINE]) {
+        throw new Error(this.t('promptScaleMachineDown.machineDeleteAnnotationMissing', { name: machine.nameDisplay }));
+      }
+    },
+
     async remove() {
       if (!this.isRke2) {
         await Promise.all(this.safeMachinesToDelete.map((node) => {
@@ -134,15 +167,10 @@ export default {
       // Mark all machines for deletion and then scale down their pool to the new size
       const flatArray = Array.from(poolInfo.entries());
 
-      await Promise.all(flatArray.map(([pool, machines]) => {
-        return Promise
-          .all(machines.map((m) => {
-            m.setAnnotation(CAPI_LABELS.DELETE_MACHINE, 'true');
-
-            return m.save();
-          }))
-          .then(() => pool.scalePool(-machines.length, false));
-      }));
+      for (const [pool, machines] of flatArray) {
+        await Promise.all(machines.map((m) => this.markMachineForDeletion(m)));
+        pool.scalePool(-machines.length, false);
+      }
 
       // Pool scale info is kept in the cluster itself, so now we've made the changes we can save them
       await this.cluster.save();

--- a/shell/dialog/__tests__/ScaleMachineDownDialog.test.ts
+++ b/shell/dialog/__tests__/ScaleMachineDownDialog.test.ts
@@ -21,7 +21,7 @@ const defaultCluster = {
   save:     jest.fn()
 };
 
-const createResource = (overrides = {}) => {
+const createResource = (overrides: Record<string, any> = {}) => {
   const resource = {
     id:            'default/machine-1',
     cluster:       defaultCluster,
@@ -35,7 +35,7 @@ const createResource = (overrides = {}) => {
     nameDisplay: 'machine-1',
     namespace:   'default',
     schema:      'machine',
-    metadata:    { annotations: {} },
+    metadata:    { annotations: {} as Record<string, string> },
     ...overrides
   };
 
@@ -43,7 +43,7 @@ const createResource = (overrides = {}) => {
 };
 
 describe('component: ScaleMachineDownDialog', () => {
-  const createWrapper = (propsData = {}, mocks = {}) => {
+  const createWrapper = (propsData: { resources?: any[] } = {}, mocks = {}) => {
     const resources = propsData.resources || [createResource()];
 
     return shallowMount(ScaleMachineDownDialog, {
@@ -134,7 +134,7 @@ describe('component: ScaleMachineDownDialog', () => {
       const resource = createResource();
       const wrapper = createWrapper({ resources: [resource] });
 
-      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action: string) => {
         if (action === 'management/find') {
           return Promise.resolve(resource);
         }
@@ -162,9 +162,9 @@ describe('component: ScaleMachineDownDialog', () => {
       const resource = createResource();
       const wrapper = createWrapper({ resources: [resource] });
 
-      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action: string) => {
         if (action === 'management/find') {
-          return Promise.reject({ _status: 404 });
+          return Promise.reject(Object.assign(new Error('Not found'), { _status: 404 }));
         }
 
         return Promise.resolve([]);
@@ -187,7 +187,7 @@ describe('component: ScaleMachineDownDialog', () => {
       });
       const wrapper = createWrapper({ resources: [resource] });
 
-      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action: string) => {
         if (action === 'management/find') {
           return Promise.resolve(liveResource);
         }
@@ -205,7 +205,7 @@ describe('component: ScaleMachineDownDialog', () => {
       const liveResource = createResource({ metadata: { annotations: {} } });
       const wrapper = createWrapper({ resources: [resource] });
 
-      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action: string) => {
         if (action === 'management/find') {
           return Promise.resolve(liveResource);
         }

--- a/shell/dialog/__tests__/ScaleMachineDownDialog.test.ts
+++ b/shell/dialog/__tests__/ScaleMachineDownDialog.test.ts
@@ -1,6 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import ScaleMachineDownDialog from '@shell/dialog/ScaleMachineDownDialog.vue';
 import { CAPI as CAPI_LABELS } from '@shell/config/labels-annotations';
+import { CAPI } from '@shell/config/types';
 
 const defaultStubs = { GenericPrompt: true };
 
@@ -20,23 +21,34 @@ const defaultCluster = {
   save:     jest.fn()
 };
 
-const defaultResource = {
-  cluster:       defaultCluster,
-  isWorker:      true,
-  poolName:      'pool1',
-  pool:          { scalePool: jest.fn() },
-  save:          jest.fn(),
-  setAnnotation: jest.fn(),
-  nameDisplay:   'machine-1',
-  namespace:     'default',
-  schema:        'machine'
+const createResource = (overrides = {}) => {
+  const resource = {
+    id:            'default/machine-1',
+    cluster:       defaultCluster,
+    isWorker:      true,
+    poolName:      'pool1',
+    pool:          { scalePool: jest.fn() },
+    save:          jest.fn(),
+    setAnnotation: jest.fn((key, value) => {
+      resource.metadata.annotations[key] = value;
+    }),
+    nameDisplay: 'machine-1',
+    namespace:   'default',
+    schema:      'machine',
+    metadata:    { annotations: {} },
+    ...overrides
+  };
+
+  return resource;
 };
 
 describe('component: ScaleMachineDownDialog', () => {
   const createWrapper = (propsData = {}, mocks = {}) => {
+    const resources = propsData.resources || [createResource()];
+
     return shallowMount(ScaleMachineDownDialog, {
       propsData: {
-        resources: [defaultResource],
+        resources,
         ...propsData
       },
       global: {
@@ -73,12 +85,11 @@ describe('component: ScaleMachineDownDialog', () => {
         isRke2:   true,
         machines: [{ isControlPlane: true }]
       };
-      const resource = {
-        ...defaultResource,
+      const resource = createResource({
         cluster,
         isControlPlane: true,
         isWorker:       false
-      };
+      });
 
       const wrapper = createWrapper({ resources: [resource] });
 
@@ -91,12 +102,11 @@ describe('component: ScaleMachineDownDialog', () => {
         isRke2:   true,
         machines: [{ isControlPlane: true }, { isControlPlane: true }]
       };
-      const resource = {
-        ...defaultResource,
+      const resource = createResource({
         cluster,
         isControlPlane: true,
         isWorker:       false
-      };
+      });
 
       const wrapper = createWrapper({ resources: [resource] });
 
@@ -121,15 +131,91 @@ describe('component: ScaleMachineDownDialog', () => {
 
   describe('remove', () => {
     it('should perform RKE2 removal steps', async() => {
-      const wrapper = createWrapper();
-      const resource = (wrapper.vm as any).resources[0];
+      const resource = createResource();
+      const wrapper = createWrapper({ resources: [resource] });
+
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+        if (action === 'management/find') {
+          return Promise.resolve(resource);
+        }
+
+        return Promise.resolve([]);
+      });
 
       await (wrapper.vm as any).remove();
 
       expect(resource.setAnnotation).toHaveBeenCalledWith(CAPI_LABELS.DELETE_MACHINE, 'true');
       expect(resource.save).toHaveBeenCalledWith();
+      expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith('management/find', {
+        type: CAPI.MACHINE,
+        id:   'default/machine-1',
+        opt:  {
+          force: true,
+          watch: false
+        }
+      });
       expect(resource.pool.scalePool).toHaveBeenCalledWith(-1, false);
       expect(resource.cluster.save).toHaveBeenCalledWith();
+    });
+
+    it('should not scale down the pool if the machine is already deleted', async() => {
+      const resource = createResource();
+      const wrapper = createWrapper({ resources: [resource] });
+
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+        if (action === 'management/find') {
+          return Promise.reject({ _status: 404 });
+        }
+
+        return Promise.resolve([]);
+      });
+
+      await expect((wrapper.vm as any).remove()).rejects.toThrow('promptScaleMachineDown.machineAlreadyDeleted');
+      expect(resource.setAnnotation).toHaveBeenCalledWith(CAPI_LABELS.DELETE_MACHINE, 'true');
+      expect(resource.save).toHaveBeenCalledWith();
+      expect(resource.pool.scalePool).not.toHaveBeenCalled();
+      expect(resource.cluster.save).not.toHaveBeenCalled();
+    });
+
+    it('should not scale down the pool if the machine is already deleting', async() => {
+      const resource = createResource();
+      const liveResource = createResource({
+        metadata: {
+          annotations:       { [CAPI_LABELS.DELETE_MACHINE]: 'true' },
+          deletionTimestamp: '2026-08-27T00:00:00Z'
+        }
+      });
+      const wrapper = createWrapper({ resources: [resource] });
+
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+        if (action === 'management/find') {
+          return Promise.resolve(liveResource);
+        }
+
+        return Promise.resolve([]);
+      });
+
+      await expect((wrapper.vm as any).remove()).rejects.toThrow('promptScaleMachineDown.machineAlreadyDeleted');
+      expect(resource.pool.scalePool).not.toHaveBeenCalled();
+      expect(resource.cluster.save).not.toHaveBeenCalled();
+    });
+
+    it('should not scale down the pool if the delete annotation is missing after refresh', async() => {
+      const resource = createResource();
+      const liveResource = createResource({ metadata: { annotations: {} } });
+      const wrapper = createWrapper({ resources: [resource] });
+
+      (wrapper.vm as any).$store.dispatch.mockImplementation((action) => {
+        if (action === 'management/find') {
+          return Promise.resolve(liveResource);
+        }
+
+        return Promise.resolve([]);
+      });
+
+      await expect((wrapper.vm as any).remove()).rejects.toThrow('promptScaleMachineDown.machineDeleteAnnotationMissing');
+      expect(resource.pool.scalePool).not.toHaveBeenCalled();
+      expect(resource.cluster.save).not.toHaveBeenCalled();
     });
 
     it('should perform non-RKE2 removal steps', async() => {


### PR DESCRIPTION
### Summary
Fixes #18981

Prevents the RKE2 Machine row scale-down action from decrementing the machine pool quantity if the selected Machine is no longer a valid deletion target after it is marked with `cluster.x-k8s.io/delete-machine=true`.

Related to rancher/rancher#52041.

### Occurred changes and/or fixed issues
The RKE2 scale-down flow now refreshes each selected Machine after saving the delete annotation and before lowering the pool quantity.

If the selected Machine is gone, already deleting, or no longer has the delete annotation after refresh, the action fails and the pool quantity is not changed. This avoids a race where a failed provisioning Machine is deleted/recreated by Rancher while the UI is still processing the scale-down action, which could otherwise cause CAPI to delete another Machine from the pool.

Added focused unit tests for:
- successful RKE2 row scale-down with live Machine refresh
- selected Machine already deleted
- selected Machine already deleting
- delete annotation missing after refresh

### Technical notes summary
The existing row-level scale-down flow is still based on CAPI semantics:
- mark the selected Machine with `cluster.x-k8s.io/delete-machine=true`
- reduce the machine pool quantity
- save the provisioning cluster

The CAPI delete annotation is a priority signal, not an atomic guarantee that the selected Machine will be deleted. This PR does not change that CAPI behavior. It only prevents Dashboard from lowering the pool quantity when the selected Machine can no longer be verified as a valid annotated target immediately before the quantity change.

### Areas or cases that should be tested
Tested locally with:
- `yarn test:ci shell/dialog/__tests__/ScaleMachineDownDialog.test.ts`
- `yarn lint-l10n`
- `git diff --check`

Manual test suggestion:
1. Create an RKE2 downstream cluster with a worker machine pool.
2. Trigger a provisioning failure/retry for one Machine in the pool, for example by using invalid node-driver configuration in a test environment.
3. Start scale-down from the row action for that failed/reconciling Machine while it is being deleted/recreated.
4. Verify Dashboard shows an error and does not reduce the pool quantity if the selected Machine disappeared or is already deleting.
5. Verify normal row scale-down still works when the selected Machine is live and keeps the delete annotation after refresh.

Browser: not manually tested in browser; unit coverage added for the guarded code path.

### Areas which could experience regressions
RKE2 Machine row scale-down from the Machine Pools tab.

Non-RKE2 scale-down is unchanged. Pool-level scale-down is unchanged.

### Screenshot/Video
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
