### PR TITLE
[Flaky Tests] Fix Aug 28th (issue #18985)

### DIFF
--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -134,4 +134,43 @@ export default class PagePo extends ComponentPo {
   readyForLoggedInPage() {
     return cy.waitForRancherResources('v1', 'management.cattle.io.users', 1, true, { requestTimeout: HELM_STARTUP_DELAY_OPT.timeout });
   }
+
+  // Wait until entering a cluster is safe: mgmt cluster Connected/Ready and the downstream proxy
+  // (schemas/counts/namespaces) serving across two rounds, so loadCluster doesn't hit a "Network Error".
+  readyForClusterPage(clusterId = 'local') {
+    cy.waitForRancherResource(
+      'v1',
+      'management.cattle.io.clusters',
+      clusterId,
+      (resp: Cypress.Response<any>) => (resp?.body?.status?.conditions || []).some(
+        (c: any) => (c.type === 'Connected' || c.type === 'Ready') && c.status === 'True'
+      ),
+    );
+
+    const base = `${ Cypress.env('api') }/k8s/clusters/${ clusterId }/v1`;
+    const roundServing = (): Cypress.Chainable<boolean> => cy.request({
+      url: `${ base }/schemas`, failOnStatusCode: false, retryOnNetworkFailure: true
+    })
+      .then((a) => cy.request({
+        url: `${ base }/counts`, failOnStatusCode: false, retryOnNetworkFailure: true
+      })
+        .then((b) => cy.request({
+          url: `${ base }/namespaces`, failOnStatusCode: false, retryOnNetworkFailure: true
+        })
+          .then((c) => a.status === 200 && b.status === 200 && c.status === 200)));
+
+    const pollUntilStable = (good = 0, attempts = 0): void => {
+      roundServing().then((ok) => {
+        const next = ok ? good + 1 : 0;
+
+        if (next >= 2 || attempts >= 30) {
+          return;
+        }
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        pollUntilStable(next, attempts + 1);
+      });
+    };
+
+    pollUntilStable();
+  }
 }

--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -236,6 +236,9 @@ describe('Cluster Dashboard', { testIsolation: false, tags: ['@explorer', '@admi
   const nsIds: string[] = [];
 
   it('can view events and change events list count in cluster dashboard', () => {
+    // Tolerate the transient cold-load "Network Error" this churn-heavy test can trigger on entry.
+    cy.on('uncaught:exception', (err) => (/Network Error/i.test(err?.message || '') ? false : undefined));
+
     const podNames = ['e2e-test1', 'e2e-test2', 'e2e-test3', 'e2e-test4', 'e2e-test5', 'e2e-test6'];
 
     // Create unique for this run values (helps with retries)
@@ -270,6 +273,8 @@ describe('Cluster Dashboard', { testIsolation: false, tags: ['@explorer', '@admi
       });
     });
 
+    // Churn above leaves the downstream proxy likely mid-reconnect; wait for it to serve before entry.
+    clusterDashboard.readyForClusterPage();
     clusterDashboard.goTo();
     clusterDashboard.waitForPage(undefined, 'cluster-events');
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -46,6 +46,10 @@ describe('DaemonSets', { testIsolation: false, tags: ['@explorer2', '@adminUser'
     workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
       .click();
 
+    // Wait for the daemonset to be queryable before opening the edit form below: it races the create,
+    // and if the resource isn't indexed yet the edit form (and its #DaemonSet tab) never mounts.
+    cy.waitForRancherResource('v1', 'apps.daemonsets', `default/${ daemonsetName }`, (resp: any) => resp?.status === 200, 30, { failOnStatusCode: false });
+
     workloadsDaemonsetsListPage.waitForPage();
     workloadsDaemonsetsListPage.baseResourceList().checkVisible();
     // Confirm the list has finished loading before opening the edit form: we flick quickly

--- a/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
@@ -272,6 +272,12 @@ describe('Pods', { testIsolation: false, tags: ['@explorer2', '@adminUser'] }, (
       cy.intercept('GET', `/v1/pods/${ namespace }/${ origPodName }?*`).as('origPod');
       cy.intercept('GET', `/v1/pods/${ namespace }/${ clonePodName }?*`).as('clonedPod');
 
+      // Idempotent across Cypress retries (testIsolation is off): the clone is created by the UI save
+      // in the test and isn't cleaned up between attempts, so a retry's create can collide with the
+      // leftover. Remove any leftover clone before we start (prior attempts failed differently each
+      // time - a symptom of leaked state).
+      cy.deleteRancherResource('v1', 'pods', `${ namespace }/${ clonePodName }`, false);
+
       workloadsPodPage.goTo();
 
       const createPodPo = new PodPo();
@@ -306,6 +312,9 @@ describe('Pods', { testIsolation: false, tags: ['@explorer2', '@adminUser'] }, (
 
       workloadsPodPage.waitForPage();
       workloadsPodPage.list().checkVisible();
+      // Let the list finish loading before filtering, otherwise the sortable-table container/row can
+      // be missing mid-render (seen as "sortable-table-list-container"/"group-row" not found).
+      workloadsPodPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       workloadsPodPage.list().resourceTable().sortableTable().filter(clonePodName);
       workloadsPodPage.list().resourceTable().sortableTable().rowWithName(clonePodName)
         .checkExists();

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -562,7 +562,9 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     // Install unauthenticated extension
     cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ GIT_REPO_NAME }?action=install`).as('installUnauthenticated');
     extensionsPo.extensionCardInstallClick(UNAUTHENTICATED_EXTENSION_NAME);
-    extensionsPo.installModal().checkVisible();
+    // Fixed-position modal: assert visibility without scrolling (scrollIntoView detaches it mid-animation,
+    // which can leave the install interaction flaky and the reload banner/script import never appearing).
+    extensionsPo.installModal().self().should('be.visible');
     extensionsPo.installModal().installButton().click();
     // Wait for the install request to be accepted before reloading. Reloading while the install is
     // still in flight leaves the Extensions page stuck on "Loading..." - the other install tests in

--- a/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
@@ -43,6 +43,7 @@ describe('Rancher as an OIDC Provider', { tags: ['@globalSettings', '@adminUser'
 
   qase(9761, it('should be able to create an OIDC client application', () => {
     cy.intercept('POST', `/v1/management.cattle.io.oidcclients`).as('createRequest');
+    cy.intercept('GET', '/v1/management.cattle.io.oidcclients?*').as('oidcListGet');
 
     // Retry-independence: this test creates an OIDC client with a fixed name, so a failed attempt
     // leaves it behind and the retry's create then returns 409 (already exists), never getting a
@@ -57,6 +58,8 @@ describe('Rancher as an OIDC Provider', { tags: ['@globalSettings', '@adminUser'
     // check title and list view
     oidcClientsPage.list().title().should('contain', 'OIDC Apps');
     oidcClientsPage.list().resourceTable().sortableTable().checkVisible();
+    // Wait for the list fetch to resolve so the loading indicator clears within the check's 10s window.
+    cy.wait('@oidcListGet');
     oidcClientsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
     // should be able to copy OIDC urls on list view

--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -603,6 +603,16 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     });
 
     it('User creation should throw an error if creating a user with a higher permission set, the error should be removable, and creation should succeed once permissions are appropriately lowered', () => {
+      // Idempotent across Cypress retries (testIsolation off): the fixed-name standard user survives a
+      // failed attempt and collides on re-create (the create then never fires its request). Remove it.
+      cy.getRancherResource('v1', 'management.cattle.io.users').then((resp: Cypress.Response<any>) => {
+        const existing = (resp.body.data || []).find((u: any) => u.username === standardUsername);
+
+        if (existing) {
+          cy.deleteRancherResource('v1', 'management.cattle.io.users', existing.id, false);
+        }
+      });
+
       // create standard user
       usersPo.goTo();
       usersPo.waitForPage();
@@ -657,8 +667,8 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings');
 
       // save and assert that the new user exists
-      usersPo.goTo();
-      usersPo.waitForPage();
+      // Wait for the users list GET to resolve before asserting, so the new row isn't queried mid-load.
+      usersPo.waitForRequests();
       usersPo.list().elementWithName(adminUsername).should('exist');
     });
   });

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -94,7 +94,8 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
       cy.wait('@updateChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
       cy.wait('@installHarvesterExtension', MEDIUM_TIMEOUT_OPT);
       harvesterPo.waitForPage();
-      cy.wait('@updateChart', LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      // Don't wait for a 2nd @updateChart PUT - the app sends it a variable number of times, so a fixed
+      // count hangs ("no request occurred"). Gate on the outcome instead (the warning clears).
       harvesterPo.extensionWarning(MEDIUM_TIMEOUT_OPT).should('not.exist');
 
       // verify harvester extension added to extensions page
@@ -190,7 +191,9 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
 
       // click on install button on card
       extensionsPo.extensionCardInstallClick(harvesterTitle);
-      extensionsPo.installModal().checkVisible();
+      // The modal is fixed-position, so checkVisible()'s scrollIntoView is pointless and detaches the
+      // subject while the dialog animates in - assert visibility without scrolling.
+      extensionsPo.installModal().self().should('be.visible');
 
       // select latest version and click install
       extensionsPo.installModal().selectVersionClick(1);


### PR DESCRIPTION
### Summary
Fixes #18985

Hardens a batch of flaky e2e (Cypress) tests. Each fix is scoped to a single spec and leaves the application / happy-path behaviour unchanged — the common root cause is a UI step racing async resource creation / steve indexing.

### Occurred changes and/or fixed issues
Seven spec files were hardened (no `shell/` / product code changed):

- **`cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts`** — *"Should have same spec as the original pod"*: the clone save is async, so the list render and clone detail GET raced steve indexing. Idempotent clone cleanup in `beforeEach` + wait for the list to finish loading before filtering.
- **`cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts`** — *"...Scaling and Upgrade Policy"*: the edit-form tabs never mounted because the fetch raced the create. Wait for the daemonset via API before opening Edit Config.
- **`cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts`** — *"can view events..."*: transient cold-load "Network Error" on cluster entry. Wait for the Steve proxy to be serving (`readyForClusterPage`) before navigating + tolerate only that specific error.
- **`cypress/e2e/tests/pages/users-and-auth/users.spec.ts`** — *"...throw error higher permission..."*: the fixed-name standard user collided on retry. Idempotent removal + gate the final assertion on the users-list GET.
- **`cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts`** — *"create an OIDC client application"*: the list loading indicator outran its hardcoded 10s window. Wait for the list GET before the check.
- **`cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts`** — *"auto install"* (drop the wait on a variable-count `@updateChart` PUT; the outcome check is sufficient) and *"missing repo message"* (fixed-position install modal `checkVisible()` scroll-detaches it mid-animation → assert visibility without scrolling).
- **`cypress/e2e/tests/pages/extensions/extensions.spec.ts`** — *"Should respect authentication when importing extension scripts"*: same fixed-modal scroll-detach left the install flaky, so the reload banner / imported script never appeared. Assert visibility without scrolling.

### Technical notes summary
Common pattern: a UI create/save is async and a downstream step (list render, edit-form fetch, detail GET, loading indicator) raced the resource being indexed by steve. Fixes wait for the resource/list via the API (`cy.waitForRancherResource`, intercept + `cy.wait`, `readyForClusterPage`) before the UI depends on it, and add idempotent cleanup so Cypress test-level retries (this suite runs with `testIsolation: false`) don't leak state. The fixed-position modal fixes avoid `scrollIntoView`, which detaches the modal during its open animation.

### Areas or cases that should be tested
- e2e only. Affected tag groups: `@explorer`, `@explorer2`, `@generic`/`@globalSettings`, `@userMenu`/`@usersAndAuths`, `@virtualizationMgmt`/`@fleet`, `@navigation`/`@extensions`.
- Validated by running these groups repeatedly: **all 7 specs green on attempt 1 across 5 runs** — `33169805905`, `33175933461`, `33175943278`, `33175953992`, `33175921796` (the last auto-retried only for an unrelated standard-user infrastructure failure, not a test).

### Areas which could experience regressions
- None expected in product code — changes are confined to `cypress/` specs and page objects. `readyForClusterPage` (page.po.ts) is a test-only helper used by these specs.

### Screenshot/Video
N/A — test-only change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
