### PR TITLE
Let extensions add ESLint plugins to the legacy toolchain

### DIFF
--- a/docusaurus/docs/extensions/linting.md
+++ b/docusaurus/docs/extensions/linting.md
@@ -48,6 +48,20 @@ export default [
 
 You do **not** have to change anything to keep `yarn lint` / CI working — the launcher keeps your legacy `.eslintrc.*` on ESLint 7. Make sure your `lint` script points at the launcher (as above) so the selection happens.
 
+### Extra ESLint plugins
+
+The ESLint 7 toolchain ships a fixed set of plugins (Vue, TypeScript-ESLint, standard, import, node, promise, Cypress). If your `.eslintrc.*` references a plugin outside that set — for example `eslint-plugin-jest` — declare it in your `package.json` so the launcher installs it **into** the isolated toolchain, where it resolves against ESLint 7 (rather than the flat-config ESLint 10 hoisted in your project, which the legacy plugin cannot run against):
+
+```json
+"@rancher/shell": {
+  "eslintLegacyPackages": {
+    "eslint-plugin-jest": "^24"
+  }
+}
+```
+
+Pin a version compatible with ESLint 7 (e.g. `eslint-plugin-jest@^24` rather than the newer releases built for ESLint 8+). The launcher installs these the first time you lint and skips them once present.
+
 When you are ready to move to ESLint 10 / flat config:
 
 1. Delete `.eslintrc.*` and `.eslintignore`.

--- a/shell/scripts/lint
+++ b/shell/scripts/lint
@@ -72,6 +72,20 @@ function runFlat() {
   exit(spawnSync(process.execPath, [bin, ...args], { stdio: 'inherit', cwd }).status);
 }
 
+// Extra legacy ESLint packages an extension declares (plugins/configs its `.eslintrc.*` references
+// that the base toolchain doesn't ship), e.g. in its package.json:
+//   "@rancher/shell": { "eslintLegacyPackages": { "eslint-plugin-jest": "^24" } }
+function extraLegacyPackages(dir) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+    const extras = pkg['@rancher/shell'] && pkg['@rancher/shell'].eslintLegacyPackages;
+
+    return (extras && typeof extras === 'object') ? extras : {};
+  } catch (e) {
+    return {};
+  }
+}
+
 // Legacy `.eslintrc.*` -> the isolated ESLint 7 toolchain in `@rancher/shell/eslint-legacy`.
 function runLegacy() {
   const legacyDir = path.resolve(__dirname, '..', 'eslint-legacy');
@@ -89,6 +103,29 @@ function runLegacy() {
 
     if (install.status !== 0 || !fs.existsSync(legacyBin)) {
       fail('Could not prepare the legacy ESLint toolchain (see npm output above). This step needs network access and a writable node_modules.', install.status || 1);
+    }
+  }
+
+
+  // Install any extra packages the extension declared INTO the isolated toolchain, so they resolve
+  // against this ESLint 7 (not the flat-config ESLint 10 hoisted in the project, which would crash
+  // on the legacy eslintrc API). Kept out of the base package.json via --no-save; re-added on demand.
+  const extras = extraLegacyPackages(cwd);
+  const missing = Object.entries(extras)
+    .filter(([name]) => !fs.existsSync(path.join(legacyModules, ...name.split('/'))))
+    .map(([name, spec]) => `${ name }@${ spec }`);
+
+  if (missing.length) {
+    console.error(`[@rancher/shell lint] installing extension-declared legacy ESLint packages: ${ missing.join(', ') }`);
+
+    const add = spawnSync(
+      'npm',
+      ['install', '--no-save', '--no-audit', '--no-fund', '--legacy-peer-deps', '--loglevel=error', ...missing],
+      { stdio: 'inherit', cwd: legacyDir }
+    );
+
+    if (add.status !== 0) {
+      fail('Could not install the declared `eslintLegacyPackages` (see npm output above).', add.status || 1);
     }
   }
 


### PR DESCRIPTION
### Summary
Fixes #18989

The `@rancher/shell` ESLint launcher routes extensions still on a legacy `.eslintrc.*` config to an isolated ESLint 7 toolchain, but that toolchain ships a **fixed** plugin set. An extension whose config references a plugin outside that set — e.g. `eslint-plugin-jest` — could not lint after moving to the flat-config `@rancher/shell`, because the plugin resolved against the ESLint 10 hoisted in the project and crashed on the eslintrc API. This adds a way for extensions to declare those extra plugins so the launcher installs them into the isolated toolchain.

### Occurred changes and/or fixed issues
- `shell/scripts/lint`: the legacy launcher now reads `"@rancher/shell": { "eslintLegacyPackages": { … } }` from the linted project's `package.json` and installs any declared packages that are missing into `eslint-legacy/node_modules` (via `npm install --no-save`) before running ESLint 7. No-op for projects that don't declare the field.
- `docusaurus/docs/extensions/linting.md`: documents the new `eslintLegacyPackages` field under "Existing extensions".

### Technical notes summary
- The extras are installed **into the isolated toolchain** so both the plugin and its `require('eslint')` resolve to ESLint 7 — not the flat-config ESLint 10 hoisted in the project. That is why a plain `devDependency` / `resolutions` pin does not work: the plugin still loads against ESLint 10 and crashes on the removed eslintrc API.
- Installed with `--no-save` so `eslint-legacy`'s own `package.json` is untouched; missing extras are (re)installed on demand and skipped once present.
- Extensions should pin an ESLint-7-compatible version (e.g. `eslint-plugin-jest@^24`); newer majors target ESLint 8+.

### Areas or cases that should be tested
- Legacy `.eslintrc.*` extension that uses a plugin outside the bundled set (e.g. `plugin:jest/...`): declare it in `eslintLegacyPackages`, run `yarn lint` → the launcher installs it into `eslint-legacy` and lint passes.
- Extension that does **not** declare the field: `yarn lint` behaves exactly as before (no extra install).
- Flat-config (`eslint.config.mjs`) extension: unaffected — the field only applies to the legacy path.
- Validated locally against `harvester-ui-extension` (uses `plugin:jest/all`): declaring `eslint-plugin-jest@^24` makes `yarn lint` pass after bumping `@rancher/shell` to a flat-config version.

### Areas which could experience regressions
- Only the legacy ESLint 7 lint path. Extensions that do not set `eslintLegacyPackages` get no behavior change — the new code short-circuits on an empty declaration.

### Screenshot/Video
N/A — CLI-only tooling change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
