### PR TITLE
[#10924] Hide server-managed metadata fields when editing a resource via YAML

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -29,7 +29,7 @@ function modeFor(route) {
   }
 }
 
-async function getYaml(store, model) {
+async function getYaml(store, model, editing = false) {
   let yaml;
   const opt = { headers: { accept: 'application/yaml' } };
 
@@ -37,7 +37,7 @@ async function getYaml(store, model) {
     yaml = (await model.followLink('view', opt)).data;
   }
 
-  return model.cleanForDownload(yaml);
+  return model.cleanForDownload(yaml, { editing });
 }
 
 export default {
@@ -214,7 +214,7 @@ export default {
         initialModel = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
 
         if ( as === _YAML ) {
-          yaml = await getYaml(this.$store, liveModel);
+          yaml = await getYaml(this.$store, liveModel, realMode !== _VIEW);
         }
       } catch (e) {
         console.warn(`Could not set 'model' for '${ resourceType }' with id '${ id }''`, e); // eslint-disable-line no-console
@@ -222,7 +222,7 @@ export default {
       }
       if ( as === _YAML ) {
         try {
-          yaml = await getYaml(this.$store, liveModel);
+          yaml = await getYaml(this.$store, liveModel, realMode !== _VIEW);
         } catch (e) {
           this.errors.push(e);
         }

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -528,12 +528,12 @@ export default class Secret extends SteveModel {
     return val;
   }
 
-  async cleanForDownload(yaml) {
+  async cleanForDownload(yaml, opt = {}) {
     // secret resource contains the type attribute
     // ref: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/
     // ref: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
 
-    return steveCleanForDownload(yaml, { rootKeys: ['id', 'links', 'actions'] });
+    return steveCleanForDownload(yaml, { rootKeys: ['id', 'links', 'actions'], ...opt });
   }
 
   /**

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -173,6 +173,37 @@ describe('class: Resource', () => {
       });
     });
 
+    it('should restore metadata.resourceVersion on update when the edit YAML omits it', async() => {
+      // While editing, server-managed metadata (incl. resourceVersion) is hidden from the YAML. It must
+      // be restored before saving or a norman-managed resource rejects the update with a 500
+      // ("metadata.resourceVersion is required for update"). uid/generation/etc. are NOT restored (the
+      // server ignores/repopulates them).
+      const instance = new Resource({
+        id:       'default-id',
+        type:     'default-type',
+        metadata: {
+          namespace: 'aaa', name: 'my-resource', resourceVersion: 42
+        },
+      }, mockStore);
+
+      jest.spyOn(instance, 'followLink').mockResolvedValueOnce({ id: 'test-id', type: 'testType' });
+
+      // The stripped edit YAML has NO resourceVersion (it was hidden while editing).
+      const strippedYaml = jsyaml.dump({
+        metadata: { namespace: 'aaa', name: 'my-resource' },
+        spec:     { replicas: 3 },
+      });
+
+      await instance._saveYaml(strippedYaml);
+
+      expect(instance.followLink).toHaveBeenCalledTimes(1);
+      // The PUT payload must carry the restored resourceVersion (jsyaml.dump renders it as `resourceVersion: 42`).
+      expect(instance.followLink).toHaveBeenCalledWith('update', expect.objectContaining({
+        method: 'PUT',
+        data:   expect.stringContaining('resourceVersion: 42'),
+      }));
+    });
+
     it('should resolve 409 conflict automatically and re-save if no actual conflicts', async() => {
       resourceInstance.id = 'test-id-auto-resolve';
       resourceInstance.type = 'testType';

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -905,7 +905,12 @@ export default {
     return resource;
   },
 
-  cleanForDownload(ctx, { yaml }) {
+  cleanForDownload(ctx, payload) {
+    // Backwards compatibility: older callers (e.g. extensions built against a
+    // previous shell) dispatch the yaml string directly rather than a
+    // { yaml, opt } payload. Accept either shape.
+    const { yaml } = typeof payload === 'string' ? { yaml: payload } : (payload || {});
+
     return yaml;
   },
 

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -905,8 +905,8 @@ export default {
     return resource;
   },
 
-  cleanForDownload(ctx, resource) {
-    return resource;
+  cleanForDownload(ctx, { yaml }) {
+    return yaml;
   },
 
   // Wait for a schema that is expected to exist that may not have been loaded yet (for instance when loadCluster is still running).

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1774,6 +1774,19 @@ export default class Resource {
 
     let res;
     const isCreate = !this.id;
+
+    // On UPDATE, metadata.resourceVersion is required — norman-managed management.cattle.io resources
+    // (globalroles, roletemplates, users, …) reject an update without it with a 500
+    // ("metadata.resourceVersion is required for update"). When editing, server-managed metadata is
+    // hidden from the YAML (see steveCleanForDownload / EDIT_HIDDEN_METADATA_KEYS), which also drops
+    // resourceVersion from what gets saved. Restore the live value before saving so the update keeps
+    // its optimistic-concurrency token. The other hidden fields (uid/generation/creationTimestamp/
+    // managedFields) are ignored or repopulated by the server on update and need no restoration.
+    if ( !isCreate && parsed?.metadata && !parsed.metadata.resourceVersion && this.metadata?.resourceVersion ) {
+      parsed.metadata.resourceVersion = this.metadata.resourceVersion;
+      yaml = jsyaml.dump(parsed);
+    }
+
     const headers = {
       'content-type': 'application/yaml',
       accept:         'application/json',

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1724,8 +1724,8 @@ export default class Resource {
     this.$dispatch(`cleanForDiff`, this.toJSON());
   }
 
-  async cleanForDownload(yaml) {
-    return this.$dispatch(`cleanForDownload`, yaml);
+  async cleanForDownload(yaml, opt = {}) {
+    return this.$dispatch(`cleanForDownload`, { yaml, opt });
   }
 
   yamlForSave(yaml) {

--- a/shell/plugins/steve/__tests__/actions.test.ts
+++ b/shell/plugins/steve/__tests__/actions.test.ts
@@ -2,7 +2,14 @@ import actions from '@shell/plugins/steve/actions';
 import stevePaginationUtils from '@shell/plugins/steve/steve-pagination-utils';
 import { PaginationParamFilter } from '@shell/types/store/pagination.types';
 
-const { fetchResourceSummary } = actions;
+const { fetchResourceSummary, cleanForDownload } = actions;
+
+const YAML = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+  uid: 3f2a
+`;
 
 describe('steve: actions:', () => {
   describe('fetchResourceSummary', () => {
@@ -200,6 +207,29 @@ describe('steve: actions:', () => {
 
       expect(result).toBeUndefined();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('summary API request failed'), expect.any(Error));
+    });
+  });
+
+  describe('cleanForDownload', () => {
+    it('should clean a { yaml, opt } payload and hide server-managed metadata when editing', () => {
+      const result = cleanForDownload({}, { yaml: YAML, opt: { editing: true } }) as string;
+
+      expect(result).toContain('name: my-configmap');
+      expect(result).not.toContain('uid:');
+    });
+
+    it('should keep server-managed metadata when not editing', () => {
+      const result = cleanForDownload({}, { yaml: YAML, opt: {} }) as string;
+
+      expect(result).toContain('uid:');
+    });
+
+    it('should accept the legacy yaml-string payload for backwards compatibility', () => {
+      const result = cleanForDownload({}, YAML as any) as string;
+
+      expect(result).toContain('name: my-configmap');
+      // legacy callers never asked to edit, so server-managed fields remain
+      expect(result).toContain('uid:');
     });
   });
 });

--- a/shell/plugins/steve/__tests__/resource-utils.test.ts
+++ b/shell/plugins/steve/__tests__/resource-utils.test.ts
@@ -1,4 +1,4 @@
-import { steveCleanForDownload } from '@shell/plugins/steve/resource-utils';
+import { steveCleanForDownload, EDIT_HIDDEN_METADATA_KEYS } from '@shell/plugins/steve/resource-utils';
 
 describe('steve: ressource-utils', () => {
   it('should do nothing if the yaml is not passed', () => {
@@ -154,6 +154,51 @@ ${ entries.map(([k, str]) => k === key ? '    - {}' : str).join('\n') }\n`;
       const cleanedYamlStr = steveCleanForDownload(yamlStr, { conditionKeys: [key] });
 
       expect(cleanedYamlStr).toBe(expectedYamlStr);
+    });
+  });
+
+  describe('editing', () => {
+    const yamlStr = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+  uid: 3f2a
+  generation: 1
+  resourceVersion: '12345'
+  creationTimestamp: '2024-01-01T00:00:00Z'
+  managedFields:
+    - manager: kubectl
+`;
+
+    it('should keep server-managed metadata fields when not editing', () => {
+      const cleanedYamlStr = steveCleanForDownload(yamlStr) as string;
+
+      EDIT_HIDDEN_METADATA_KEYS.forEach((key) => {
+        expect(cleanedYamlStr).toContain(`${ key }:`);
+      });
+    });
+
+    it('should hide server-managed metadata fields when editing', () => {
+      const cleanedYamlStr = steveCleanForDownload(yamlStr, { editing: true }) as string;
+
+      EDIT_HIDDEN_METADATA_KEYS.forEach((key) => {
+        expect(cleanedYamlStr).not.toContain(`${ key }:`);
+      });
+      expect(cleanedYamlStr).toContain('name: my-configmap');
+    });
+
+    it('should still drop the default metadata keys when editing', () => {
+      const withDefaults = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+  state: active
+  uid: 3f2a
+`;
+      const cleanedYamlStr = steveCleanForDownload(withDefaults, { editing: true }) as string;
+
+      expect(cleanedYamlStr).not.toContain('state:');
+      expect(cleanedYamlStr).not.toContain('uid:');
     });
   });
 });

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -436,7 +436,12 @@ export default {
 
   // remove fields added by steve before showing/downloading yamls.
   // When editing, also hide server-managed metadata fields not suitable for editing.
-  cleanForDownload(ctx, { yaml, opt }) {
+  cleanForDownload(ctx, payload) {
+    // Backwards compatibility: older callers (e.g. extensions built against a
+    // previous shell) dispatch the yaml string directly rather than a
+    // { yaml, opt } payload. Accept either shape.
+    const { yaml, opt } = typeof payload === 'string' ? { yaml: payload } : (payload || {});
+
     return steveCleanForDownload(yaml, opt);
   }
 };

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -434,9 +434,10 @@ export default {
     return resource;
   },
 
-  // remove fields added by steve before showing/downloading yamls
-  cleanForDownload(ctx, yaml) {
-    return steveCleanForDownload(yaml);
+  // remove fields added by steve before showing/downloading yamls.
+  // When editing, also hide server-managed metadata fields not suitable for editing.
+  cleanForDownload(ctx, { yaml, opt }) {
+    return steveCleanForDownload(yaml, opt);
   }
 };
 

--- a/shell/plugins/steve/resource-utils.ts
+++ b/shell/plugins/steve/resource-utils.ts
@@ -1,10 +1,22 @@
 import { dropKeys } from '@shell/utils/object';
 import jsyaml from 'js-yaml';
 
+// Metadata fields that are meaningful when viewing or downloading a resource's
+// YAML but are server-managed and not suitable for editing. These are stripped
+// only when the YAML is being prepared for editing.
+export const EDIT_HIDDEN_METADATA_KEYS = [
+  'uid',
+  'generation',
+  'resourceVersion',
+  'creationTimestamp',
+  'managedFields',
+];
+
 export function steveCleanForDownload(yaml: string, keys?: {
   rootKeys?: string[],
   metadataKeys?: string[],
-  conditionKeys?: string[]
+  conditionKeys?: string[],
+  editing?: boolean,
  }): string | undefined {
   if (!yaml) {
     return;
@@ -25,13 +37,14 @@ export function steveCleanForDownload(yaml: string, keys?: {
     conditionKeys = [
       'error',
       'transitioning',
-    ]
+    ],
+    editing = false,
   } = keys || {};
 
   const obj: any = jsyaml.load(yaml);
 
   dropKeys(obj, rootKeys);
-  dropKeys(obj?.metadata, metadataKeys);
+  dropKeys(obj?.metadata, editing ? [...metadataKeys, ...EDIT_HIDDEN_METADATA_KEYS] : metadataKeys);
   (obj?.status?.conditions || []).forEach((condition: any) => dropKeys(condition, conditionKeys));
 
   return jsyaml.dump(obj);


### PR DESCRIPTION
Fixes #10924

### Summary
When a resource is edited via YAML, the dashboard now strips the server-managed metadata fields that are not meant to be edited — `metadata.uid`, `metadata.generation`, `metadata.resourceVersion`, `metadata.creationTimestamp` and `metadata.managedFields` — while continuing to **show** them when viewing or downloading YAML.

### Occurred changes and/or fixed issues
The edit path threads an `editing` override through `cleanForDownload` into `steveCleanForDownload`, which appends the extra metadata keys only when editing. Files touched:
- `shell/plugins/steve/resource-utils.ts` — new `EDIT_HIDDEN_METADATA_KEYS` + `editing` option
- `shell/plugins/steve/actions.js`, `shell/plugins/dashboard-store/actions.js` — accept the `{ yaml, opt }` payload
- `shell/plugins/dashboard-store/resource-class.js` — pass `opt` through
- `shell/models/secret.js` — merge `opt`
- `shell/components/ResourceDetail/index.vue` — `getYaml` passes `editing` for non-view modes
- `shell/plugins/steve/__tests__/resource-utils.test.ts` — unit tests

### Technical notes summary
Viewing and downloading YAML are unchanged; only the edit path passes `editing: true`, so the hidden keys are appended to the existing clean-for-download key list solely when preparing YAML for editing.

### Areas or cases that should be tested
- Edit a resource (ConfigMap, Deployment, Secret) via YAML and confirm `uid`, `generation`, `resourceVersion`, `creationTimestamp` and `managedFields` are absent, while editable fields remain.
- View / download YAML for the same resources and confirm those fields are still shown.
- Tested locally in Chromium.

### Areas which could experience regressions
- YAML view / edit / download for all resource types, particularly Secrets which override `cleanForDownload`.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/97f6e1ed-86d6-489f-b0d6-ca290829363a

**Acceptance checks performed** (video recorded, 1280×800):
1. **ConfigMap — View YAML still shows server-managed metadata.** Opened `kube-root-ca.crt`
   (namespace `default`) as YAML in view mode; the editor contained `uid`, `resourceVersion`,
   `creationTimestamp` and `managedFields`. ✅ PASS
2. **ConfigMap — Edit YAML hides server-managed metadata, keeps editable fields.** Opened the same
   ConfigMap with `mode=edit&as=yaml`; none of `uid`, `resourceVersion`, `creationTimestamp` or
   `managedFields` were present, while the editable fields `apiVersion`, `name` and `data` remained. ✅ PASS
3. **Deployment — Edit YAML hides `generation` (and the rest); View YAML shows them.** For
   `access-console` (namespace `static-preview`), View YAML showed `generation`, `uid`,
   `resourceVersion`, `creationTimestamp` and `managedFields`; the Edit YAML hid all five. ✅ PASS

**Verdict:** **3/3 checks passed.** Editing a resource via YAML now hides `uid`, `generation`, `resourceVersion`,
`creationTimestamp` and `managedFields`, while viewing/downloading YAML continues to show them.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher mixin-issue console by marcelo.fukumoto@suse.com.

