### PR TITLE
Repair the i18n store imports in the a11y tests

### DIFF
--- a/shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts
+++ b/shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import FleetGitRepoPaths, { Subpath, getRelevantPrefixes } from '@shell/components/fleet/FleetGitRepoPaths.vue';
-import { getters, state, mutations } from '@shell/store/i18n.js';
+import { getters, state, mutations, I18nState } from '@shell/store/i18n';
 
 // The i18n store imports the en-us yaml, which jest can't parse. The a11y tests below load the
 // small subset of translations they need explicitly, via `loadTranslations`.
@@ -291,7 +291,7 @@ describe('a11y: unique path row labels', () => {
 
   const store = createStore({
     state,
-    getters: { 'i18n/t': getters.t },
+    getters: { 'i18n/t': (s: I18nState) => getters.t(s) },
     mutations,
   });
 

--- a/shell/components/form/__tests__/KeyValue.test.ts
+++ b/shell/components/form/__tests__/KeyValue.test.ts
@@ -2,7 +2,7 @@ import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import KeyValue from '@shell/components/form/KeyValue.vue';
-import { getters, state, mutations } from '@shell/store/i18n.js';
+import { getters, state, mutations, I18nState } from '@shell/store/i18n';
 
 // The i18n store imports the en-us yaml, which jest can't parse. The tests below load the small
 // subset of translations they need explicitly, via `loadTranslations`.
@@ -371,7 +371,7 @@ describe('component: KeyValue', () => {
 
     const store = createStore({
       state,
-      getters: { 'i18n/t': getters.t },
+      getters: { 'i18n/t': (s: I18nState) => getters.t(s) },
       mutations,
     });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with the failing type check gates in master.
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Repair the i18n store imports in the a11y tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The type-check failures resolved by this change are:

```
  ✖ 2 new type error(s) introduced:
  
    shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts: error TS2322: Type '(state: I18nState, _getters?: VuexStoreGetters, rootState?: I18nGetterRootState) => (key: string, args?: Record<string, any>, language?: string) => string | undefined' is not assignable to type 'Getter<I18nState, I18nState>'.
    shell/components/form/__tests__/KeyValue.test.ts: error TS2322: Type '(state: I18nState, _getters?: VuexStoreGetters, rootState?: I18nGetterRootState) => (key: string, args?: Record<string, any>, language?: string) => string | undefined' is not assignable to type 'Getter<I18nState, I18nState>'.
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

All CI gates should pass.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA - this is fixing type check failures.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
