### PR TITLE
[#17256] Store dynamic NavHeaderRight component with markRaw to avoid Vue reactive-component warning

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,4 +1,5 @@
 <script>
+import { markRaw } from 'vue';
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
 import { MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
@@ -295,7 +296,11 @@ export default {
           this.extensionHeaderActions = getApplicableExtensionEnhancements(this, ExtensionPoint.ACTION, ActionLocation.HEADER, neu);
           this.updateExtensionActionsEnabled();
 
-          this.navHeaderRight = this.$extension?.getDynamic('component', 'NavHeaderRight');
+          const navHeaderRight = this.$extension?.getDynamic('component', 'NavHeaderRight');
+
+          // Component definitions must not be made reactive, otherwise Vue warns and
+          // incurs unnecessary reactivity overhead when rendered via <component :is>.
+          this.navHeaderRight = navHeaderRight ? markRaw(navHeaderRight) : null;
         }
       },
       immediate: true,

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,5 +1,4 @@
 <script>
-import { markRaw } from 'vue';
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
 import { MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
@@ -296,11 +295,9 @@ export default {
           this.extensionHeaderActions = getApplicableExtensionEnhancements(this, ExtensionPoint.ACTION, ActionLocation.HEADER, neu);
           this.updateExtensionActionsEnabled();
 
-          const navHeaderRight = this.$extension?.getDynamic('component', 'NavHeaderRight');
-
-          // Component definitions must not be made reactive, otherwise Vue warns and
-          // incurs unnecessary reactivity overhead when rendered via <component :is>.
-          this.navHeaderRight = navHeaderRight ? markRaw(navHeaderRight) : null;
+          // getDynamic marks component definitions raw, so they stay out of the
+          // reactivity system (avoids the Vue reactive-component warning + overhead).
+          this.navHeaderRight = this.$extension?.getDynamic('component', 'NavHeaderRight') || null;
         }
       },
       immediate: true,

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import { isReactive } from 'vue';
+import { isReactive, markRaw } from 'vue';
 import Header from '@shell/components/nav/Header.vue';
 
 describe('component: Header', () => {
@@ -250,8 +250,10 @@ describe('component: Header', () => {
   });
 
   describe('navHeaderRight', () => {
-    it('should store the dynamic component non-reactively (markRaw) to avoid the Vue reactive-component warning', () => {
-      const navHeaderRightComponent = { name: 'NavHeaderRight', render: () => null };
+    it('should store the raw dynamic component from getDynamic without making it reactive', () => {
+      // getDynamic marks component definitions raw; the stored value must stay
+      // non-reactive so Vue does not warn / add overhead when rendering it.
+      const navHeaderRightComponent = markRaw({ name: 'NavHeaderRight', render: () => null });
       const wrapper = createWrapper({}, {}, { getDynamic: jest.fn(() => navHeaderRightComponent) });
 
       const stored = (wrapper.vm as any).navHeaderRight;

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import { isReactive } from 'vue';
 import Header from '@shell/components/nav/Header.vue';
 
 describe('component: Header', () => {
@@ -38,7 +39,7 @@ describe('component: Header', () => {
 
   const defaultConfigMock = { rancherEnv: 'web' };
 
-  function createWrapper(routeOverride = {}, storeOverride = {}) {
+  function createWrapper(routeOverride = {}, storeOverride = {}, extensionMock: any = { getDynamic: jest.fn() }) {
     const routeMock = {
       ...defaultRouteMock,
       ...routeOverride,
@@ -60,7 +61,7 @@ describe('component: Header', () => {
           $store:     storeMock,
           $route:     routeMock,
           $config:    defaultConfigMock,
-          $extension: { getDynamic: jest.fn() },
+          $extension: extensionMock,
         },
         stubs: {
           'router-link':        { template: '<a><slot /></a>' },
@@ -245,6 +246,24 @@ describe('component: Header', () => {
       );
 
       expect((wrapper.vm as any).showFilter).toBe(true);
+    });
+  });
+
+  describe('navHeaderRight', () => {
+    it('should store the dynamic component non-reactively (markRaw) to avoid the Vue reactive-component warning', () => {
+      const navHeaderRightComponent = { name: 'NavHeaderRight', render: () => null };
+      const wrapper = createWrapper({}, {}, { getDynamic: jest.fn(() => navHeaderRightComponent) });
+
+      const stored = (wrapper.vm as any).navHeaderRight;
+
+      expect(stored).toBe(navHeaderRightComponent);
+      expect(isReactive(stored)).toBe(false);
+    });
+
+    it('should be null when no dynamic component is registered', () => {
+      const wrapper = createWrapper({}, {}, { getDynamic: jest.fn(() => undefined) });
+
+      expect((wrapper.vm as any).navHeaderRight).toBeNull();
     });
   });
 });

--- a/shell/core/__tests__/extension-manager-impl.test.js
+++ b/shell/core/__tests__/extension-manager-impl.test.js
@@ -1,3 +1,4 @@
+import { reactive, isReactive } from 'vue';
 import { DEVELOPER_LOAD_NAME_SUFFIX, createExtensionManager } from '@shell/core/extension-manager-impl';
 
 // Mock external dependencies
@@ -132,6 +133,30 @@ describe('extension Manager', () => {
       const retrieved = manager.getDynamic('component', 'my-component');
 
       expect(retrieved).toBe(mockFn);
+    });
+
+    it('marks retrieved dynamic components as raw so they are never made reactive', () => {
+      const component = { name: 'MyComponent', render: () => null };
+
+      manager.register('component', 'my-component', component);
+
+      const retrieved = manager.getDynamic('component', 'my-component');
+
+      // Same definition is returned, but flagged raw so wrapping it in reactive
+      // state leaves it un-proxied (avoids the Vue reactive-component warning).
+      expect(retrieved).toBe(component);
+      expect(isReactive(reactive({ retrieved }).retrieved)).toBe(false);
+    });
+
+    it('does not markRaw non-component dynamic types', () => {
+      const model = { some: 'value' };
+
+      manager.register('models', 'my-model', model);
+
+      const retrieved = manager.getDynamic('models', 'my-model');
+
+      expect(retrieved).toBe(model);
+      expect(isReactive(reactive({ retrieved }).retrieved)).toBe(true);
     });
 
     it('unregisters a dynamic component', () => {

--- a/shell/core/extension-manager-impl.js
+++ b/shell/core/extension-manager-impl.js
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { productsLoaded } from '@shell/store/type-map';
 import { clearModelCache } from '@shell/plugins/dashboard-store/model-loader';
 import { EXT_IDS, Plugin } from './plugin';
@@ -422,7 +423,18 @@ export const createExtensionManager = (context) => {
     },
 
     getDynamic(typeName, name) {
-      return dynamic[typeName]?.[name];
+      const result = dynamic[typeName]?.[name];
+
+      // Component definitions must never be made reactive: storing one in reactive
+      // state makes Vue proxy it, which triggers a dev warning and adds needless
+      // reactivity overhead when rendered via <component :is>. Mark components raw
+      // centrally here so every call site is covered. Other dynamic types (models,
+      // l10n, provisioners, …) are not components and are returned untouched.
+      if (typeName === 'component' && result) {
+        return markRaw(result);
+      }
+
+      return result;
     },
 
     getValidator(name) {


### PR DESCRIPTION
### Summary
Fixes #17256

The dynamic `NavHeaderRight` extension component was assigned straight into the reactive `navHeaderRight` data property in `shell/components/nav/Header.vue`. Storing a component *definition* in reactive state makes Vue proxy it, and rendering it via `<component :is="navHeaderRight" />` triggers the dev warning *"Vue received a Component that was made a reactive object … mark the component with `markRaw` …"*. The fix marks the resolved component raw inside `$extension.getDynamic` (gated on the `component` type), keeping every dynamically-loaded component out of the reactivity system for all call sites, not just this one.

### Occurred changes and/or fixed issues
- `shell/core/extension-manager-impl.js` — `getDynamic` now wraps `component`-type entries in `markRaw` before returning them, so every call site retrieving a dynamic component gets a non-reactive definition; other dynamic types (models, l10n, provisioners, …) are returned untouched.
- `shell/components/nav/Header.vue` — assign the (now raw) component straight from `getDynamic` (removed the per-call-site `markRaw`).
- `shell/core/__tests__/extension-manager-impl.test.js` — assert `getDynamic('component', …)` returns a raw, non-reactive component and that non-component types are left untouched.
- `shell/components/nav/__tests__/Header.test.ts` — assert `navHeaderRight` stores the raw component from `getDynamic` without becoming reactive, and is `null` when nothing is registered.

### Technical notes summary
The Vue warning is a development-only (`__DEV__`-gated) diagnostic, so the console string itself is compiled out of production preview builds. The underlying root-cause condition it checks — whether the stored component is a reactive proxy — is observable in production and is exactly what `markRaw` changes (the stored object carries `__v_skip === true` after the fix).

### Areas or cases that should be tested
- Home page and cluster explorer load with no reactive-component warning in the console.
- Extensions that register a `NavHeaderRight` component still render it in the header region.
- Tested locally in Chromium; reviewer should verify in a different browser.

### Areas which could experience regressions
- Header rendering of the dynamic `NavHeaderRight` extension slot.

### Screenshot/Video
> 🔄 Recording + checks updated 2026-08-31 based on review feedback: `markRaw` moved into `getDynamic` (type-gated on `component`) so every dynamic-component call site is covered; re-verified in the real UI.

Verification recording (Playwright):

https://github.com/user-attachments/assets/8e3b3492-9100-4d7b-aca8-dfce73aa8740

**Acceptance checks performed** (video recorded, 1280×800):
1. **Home page loads with no reactive-component warning.** Logged in and opened `/dashboard/home`; the
   page rendered normally with no error masthead and **0** Vue "made a reactive object" warnings. (The
   warning is a development-only, `__DEV__`-gated diagnostic compiled out of the production preview build;
   the production-observable root-cause condition it checks is asserted in check 2.) — ✅ **PASS**
2. **Root cause fixed centrally in `getDynamic`, type-gated (the review request).** Registered a
   `NavHeaderRight` component via the real extension API (`$extension.register('component', …)`) and read it
   back with `$extension.getDynamic('component', 'NavHeaderRight')`. The returned object is the **same**
   definition, now flagged raw (`__v_skip === true`) so wrapping it in reactive state leaves it un-proxied
   (`isReactive === false`) — i.e. `markRaw` runs inside `getDynamic`, covering all component call sites. A
   **non-component** type (`getDynamic('models', …)`) is returned untouched (`__v_skip` absent → still
   reactive), confirming the type gate. — ✅ **PASS**
3. **No regression — `NavHeaderRight` still renders.** Drove a **client-side** route change to the `local`
   cluster explorer (no reload, so the registration is preserved) so `Header`'s `$route` watcher re-reads
   `getDynamic` and re-assigns `navHeaderRight`. The component renders in the header region
   (`.rd-header-right` → "NavHeaderRight ext demo"), the stored value stays raw (`__v_skip === true`), no
   error masthead, and **0** reactive-component warnings. — ✅ **PASS**

**Verdict:** **3/3 checks passed.** Moving `markRaw` into `getDynamic` (gated on the `component` type) keeps
every dynamically-loaded component out of the reactivity system — the exact condition behind the Vue
reactive-component warning — while non-component dynamic types are unchanged and the component still renders
correctly. Behavior matches the original fix, now applied centrally for all call sites.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher mixin-issue console by marcelo.fukumoto@suse.com.


