### PR TITLE
[#16720] Show secret Type (sub-type) in list column and detail summary

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7232,7 +7232,7 @@ tableHeaders:
   storageClass: Storage Class
   source: Source
   subject: Subject
-  subType: Kind
+  subType: Type
   success: Success
   summary: Summary
   subobject: Subobject

--- a/shell/models/__tests__/secret.test.ts
+++ b/shell/models/__tests__/secret.test.ts
@@ -587,14 +587,15 @@ describe('class Secret', () => {
       getters:     { schemaFor: () => ({ id: 'secret' }) },
       rootGetters: {
         'type-map/labelFor': () => 'Secret',
-        'i18n/t':            (key: string) => key
+        'i18n/t':            (key: string) => key,
+        'i18n/withFallback': (_key: string, _args: any, fallback: string) => fallback
       }
     };
 
-    it('includes only the type by default', () => {
+    it('includes the secret sub-type (not the kind) by default', () => {
       const secret = new Secret({ _type: TYPES.OPAQUE, metadata: {} }, ctx);
 
-      expect(secret.details).toStrictEqual([{ label: 'secret.type', content: 'Secret' }]);
+      expect(secret.details).toStrictEqual([{ label: 'secret.type', content: 'Opaque' }]);
     });
 
     it('includes a Service Account link for service account secrets', () => {

--- a/shell/models/__tests__/secret.test.ts
+++ b/shell/models/__tests__/secret.test.ts
@@ -592,10 +592,17 @@ describe('class Secret', () => {
       }
     };
 
-    it('includes the secret sub-type (not the kind) by default', () => {
+    it('includes the raw secret type (not the kind) by default', () => {
       const secret = new Secret({ _type: TYPES.OPAQUE, metadata: {} }, ctx);
 
       expect(secret.details).toStrictEqual([{ label: 'secret.type', content: 'Opaque' }]);
+    });
+
+    it('shows the raw secret type, matching the list column, rather than the friendly label', () => {
+      const secret = new Secret({ _type: TYPES.DOCKER_JSON, metadata: {} }, ctx);
+      const typeDetail = secret.details.find((d: any) => d.label === 'secret.type');
+
+      expect(typeDetail?.content).toBe('kubernetes.io/dockerconfigjson');
     });
 
     it('includes a Service Account link for service account secrets', () => {

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -148,7 +148,7 @@ export default class Secret extends SteveModel {
     const out = [
       {
         label:   this.t('secret.type'),
-        content: this.subTypeDisplay
+        content: this._type
       }
     ];
 

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -148,7 +148,7 @@ export default class Secret extends SteveModel {
     const out = [
       {
         label:   this.t('secret.type'),
-        content: this.typeDisplay
+        content: this.subTypeDisplay
       }
     ];
 


### PR DESCRIPTION
### Summary
Fixes #16720

The Secrets list column and the Secret detail summary were surfacing the root resource **Kind** ("Secret") where they should show the secret's **Type** (its sub-type, e.g. `Opaque`, `kubernetes.io/tls`, `fleet.cattle.io/bundle-deployment/v1alpha1`). This PR relabels the list column to "Type" and makes both the list column and the detail-page summary display the actual secret sub-type instead of the root Kind.

### Occurred changes and/or fixed issues
- `shell/assets/translations/en-us.yaml` — `tableHeaders.subType` label changed from `Kind` to `Type` (this is the column used by both the Secrets and Project Secrets lists).
- `shell/models/secret.js` — the detail-page summary row's `content` changed from `this.typeDisplay` (the schema Kind label, "Secret") to `this.subTypeDisplay` (the actual secret sub-type). The row label was already `secret.type` ("Type").
- `shell/models/__tests__/secret.test.ts` — updated the `details` unit test to assert the sub-type is shown and to mock `i18n/withFallback`.

### Technical notes summary
`typeDisplay` resolves to the schema's Kind label ("Secret"), while `subTypeDisplay` resolves the secret's own sub-type. Only the display/label surfaces changed — no change to how secrets are stored or fetched.

### Areas or cases that should be tested
- Secrets list (`c/local/explorer/secret`) and Project Secrets list: confirm the column header reads "Type" and the value shows the secret sub-type.
- Secret detail page: confirm the summary masthead shows the sub-type, not "Secret".
- Tested locally in Chromium; reviewer should verify in a different browser.

### Areas which could experience regressions
- Any list/detail view that reuses the `tableHeaders.subType` translation key.

### Screenshot/Video
> 🔄 Recording + checks updated 2026-08-31 based on review feedback: the detail-page summary now shows the **raw** secret type (e.g. `kubernetes.io/dockerconfigjson`), matching the list column, instead of the friendly label (e.g. `Registry`) — resolving the list/detail inconsistency the reviewer flagged.

Verification recording (Playwright):

https://github.com/user-attachments/assets/9ff4bc69-1eda-4623-86d6-966c5fff774d

**Acceptance checks performed** (video recorded, 1280×800):

1. **Secrets list column is labelled "Type" (not "Kind").** Loaded `c/local/explorer/secret`; the table header row reads `State, Name, Namespace, Type, Data, …, Age` — the former "Kind" column is now "Type", and no column is labelled "Kind". ✅ PASS
2. **List "Type" column value is the raw secret type.** Filtered to the `application-collection` (namespace `default`) docker-registry secret; its Type cell reads `kubernetes.io/dockerconfigjson` — the raw secret type, not the root Kind "Secret". ✅ PASS
3. **Secret detail summary shows the SAME raw type as the list (the reviewer's point).** Opened that same secret; the masthead summary now shows `Type: kubernetes.io/dockerconfigjson` — identical to the list column, no longer the friendly label "Registry". List and detail are now consistent. ✅ PASS

**Verdict:** **3/3 checks passed.** The Secrets list column reads "Type", and both the list column and the detail-page summary now display the **raw** secret type — they are consistent, and the detail page no longer diverges from the list.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher mixin-issue console by marcelo.fukumoto@suse.com.


