### PR TITLE
[#16735] Only render the detail-page identifying-info column when it has content

### DIFF
--- a/shell/components/Resource/Detail/Metadata/__tests__/index.test.ts
+++ b/shell/components/Resource/Detail/Metadata/__tests__/index.test.ts
@@ -41,6 +41,20 @@ describe('component: Metadata/index', () => {
     expect(identingInformationComponent.props('rows')).toStrictEqual(identifyingInformation);
   });
 
+  it('should not render the identifying information column when there is no identifying information', async() => {
+    const wrapper = mount(Metadata, {
+      props: {
+        identifyingInformation: [],
+        labels:                 [],
+        annotations:            [],
+        resource:               {}
+      },
+      global: { provide: { store }, stubs }
+    });
+
+    expect(wrapper.find('.identifying-info').exists()).toBeFalsy();
+  });
+
   it('should render both empty message if labels and annotations are empty and labels/annotations are hidden', async() => {
     const wrapper = mount(Metadata, {
       props: {

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -27,6 +27,7 @@ const store = useStore();
 const i18n = useI18n(store);
 
 const showBothEmpty = computed(() => labels.length === 0 && annotations.length === 0);
+const hasIdentifyingInformation = computed(() => identifyingInformation.length > 0);
 </script>
 
 <template>
@@ -34,7 +35,9 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     class="metadata"
     v-bind="$attrs"
   >
+    <!-- Only reserve the first column when there is header info to show, so with no identifying info the labels/annotations stay left-aligned instead of being pushed to the middle. -->
     <div
+      v-if="hasIdentifyingInformation"
       class="identifying-info"
     >
       <IdentifyingInformation :rows="identifyingInformation" />

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -35,7 +35,6 @@ const hasIdentifyingInformation = computed(() => identifyingInformation.length >
     class="metadata"
     v-bind="$attrs"
   >
-    <!-- Only reserve the first column when there is header info to show, so with no identifying info the labels/annotations stay left-aligned instead of being pushed to the middle. -->
     <div
       v-if="hasIdentifyingInformation"
       class="identifying-info"


### PR DESCRIPTION
### Summary
Fixes #16735

The resource-detail masthead renders its header metadata as a dense 3-column grid: column 1 holds the identifying information ("header-left" content), while columns 2–3 hold labels and annotations. The first column was always rendered even for resources with no identifying information (e.g. a Compliance `ClusterScan`, which is cluster-scoped with `showAge: false` and no `details` getter). The resulting empty first cell pushed the "Labels and Annotations" block into the middle of the header, producing the missing/misaligned header reported in the issue.

This change adds a `hasIdentifyingInformation` computed and only renders the `.identifying-info` column when there is header-left content to show. Labels and annotations then flow into column 1 and are left-aligned. Resources that do have identifying information are unaffected.

### Occurred changes and/or fixed issues
- `shell/components/Resource/Detail/Metadata/index.vue`: the identifying-information column is now conditionally rendered via a new `hasIdentifyingInformation` computed, so it is omitted when a resource has no header-left content.
- `shell/components/Resource/Detail/Metadata/__tests__/index.test.ts`: added a case asserting the column is omitted when there is no identifying information.

### Technical notes summary
The grid is dense, so omitting the empty first column lets labels/annotations reflow to the container's left edge. Resources with identifying information (Age, IPs, Version, etc.) keep rendering that column first, unchanged.

### Areas or cases that should be tested
- A Compliance `ClusterScan` detail page (no identifying information): labels/annotations should be left-aligned.
- A Node detail page (has identifying information): the identifying column should still render on the left, followed by labels then annotations.

### Areas which could experience regressions
- Any resource-detail masthead using `shell/components/Resource/Detail/Metadata/index.vue` — resources both with and without identifying information should be checked for correct header layout.

### Screenshot/Video

> 🔄 Recording + checks updated 2026-09-10 based on review feedback: removed the template comment that
> restated the `v-if` condition, then re-recorded and re-ran the acceptance on the real UI.

Verification recording (Playwright):

https://github.com/user-attachments/assets/1db895bb-cb86-4bad-abdd-fb0c875a6429

**Acceptance checks performed** (video recorded, 1280×800):

1. **No header-left content → labels/annotations left-aligned.** Opened a Compliance `ClusterScan`
   detail page (`compliance.cattle.io.clusterscan`, the resource from the issue — cluster-scoped and
   configured `showAge: false`, so it has no identifying information). The `.identifying-info` column
   is not rendered and the "Labels and Annotations" block starts at the container's left edge
   (`offsetFromLeft = 0px`) instead of sitting in the middle as in the issue screenshot. ✅ PASS
2. **The removed template comment left no artifact and the guard still holds.** On that same page the
   `.metadata` container has exactly one element child (`labels-and-annotations-empty`) and **zero
   non-empty comment nodes** — the only comment nodes present are Vue's empty `v-if` placeholders. The
   comment deletion is purely cosmetic to the source; the conditional column behaves identically. ✅ PASS
3. **Header-left content present → it still shows on the left.** Opened a Node detail page (a resource
   with identifying information: Age, External/Internal IP, Version, OS, Container Runtime). The
   `.identifying-info` column renders at the left edge (`offsetFromLeft = 0px`), followed by the Labels
   then Annotations columns — unchanged by the fix. ✅ PASS

**Verdict:** **3/3 checks passed.** With no identifying (header-left) information the detail-page labels
and annotations are left-aligned instead of drifting to the middle; resources that do have identifying
information continue to show it on the left; and dropping the template comment changed nothing in the
rendered output.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher mixin-issue console by marcelo.fukumoto@suse.com.


