### PR TITLE
Move machine pool logic into a separate composable

### DIFF
--- a/shell/composables/useMachinePools.test.ts
+++ b/shell/composables/useMachinePools.test.ts
@@ -1,0 +1,323 @@
+import { useMachinePools, syncMachineConfigWithLatest } from '@shell/composables/useMachinePools';
+
+const mockGetters: Record<string, any> = { 'i18n/t': (key: string) => key };
+
+jest.mock('vuex', () => ({
+  useStore: () => ({
+    getters: new Proxy(mockGetters, {
+      get(target, prop: string) {
+        return target[prop];
+      }
+    }),
+    dispatch: jest.fn(),
+  }),
+}));
+
+const pool = (overrides: Record<string, any> = {}) => ({
+  id:     'pool-1',
+  remove: false,
+  create: false,
+  pool:   {
+    etcdRole: false, controlPlaneRole: false, workerRole: true, quantity: 1
+  },
+  ...overrides,
+});
+
+describe('composable: useMachinePools', () => {
+  describe('nodeTotals / hasRequiredNodes', () => {
+    it('marks a role as error when it has no nodes', () => {
+      const { nodeTotals, hasRequiredNodes, machinePools } = useMachinePools();
+
+      machinePools.value = [];
+
+      expect(nodeTotals.value.color.etcd).toBe('bg-error');
+      expect(nodeTotals.value.color.controlPlane).toBe('bg-error');
+      expect(nodeTotals.value.color.worker).toBe('bg-error');
+      expect(hasRequiredNodes()).toBe(false);
+    });
+
+    it('marks etcd as a warning for an even count, a single node, or more than 7', () => {
+      const { nodeTotals, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ pool: { etcdRole: true, quantity: 2 } })];
+
+      expect(nodeTotals.value.color.etcd).toBe('bg-warning');
+    });
+
+    it('marks roles as success once every required role has at least one node', () => {
+      const { nodeTotals, hasRequiredNodes, machinePools } = useMachinePools();
+
+      machinePools.value = [
+        pool({
+          pool: {
+            etcdRole: true, controlPlaneRole: true, workerRole: false, quantity: 3
+          }
+        }),
+        pool({ id: 'pool-2', pool: { workerRole: true, quantity: 2 } }),
+      ];
+
+      expect(nodeTotals.value.color.etcd).toBe('bg-success');
+      expect(nodeTotals.value.color.controlPlane).toBe('bg-success');
+      expect(nodeTotals.value.color.worker).toBe('bg-success');
+      expect(hasRequiredNodes()).toBe(true);
+    });
+
+    it('ignores pools marked for removal and pools with a non-numeric quantity', () => {
+      const { nodeTotals, machinePools } = useMachinePools();
+
+      machinePools.value = [
+        pool({ remove: true, pool: { etcdRole: true, quantity: 3 } }),
+        pool({ id: 'pool-2', pool: { etcdRole: true, quantity: 'not-a-number' } }),
+      ];
+
+      expect(nodeTotals.value.color.etcd).toBe('bg-error');
+    });
+  });
+
+  describe('unremovedMachinePools', () => {
+    it('filters out pools marked for removal', () => {
+      const { unremovedMachinePools, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ id: 'keep' }), pool({ id: 'drop', remove: true })];
+
+      expect(unremovedMachinePools.value.map((p: any) => p.id)).toStrictEqual(['keep']);
+    });
+  });
+
+  describe('hasOnlyIpv6Pools / hasDualStackPools', () => {
+    it('is only ipv6 when every pool is ipv6 and none are dual-stack', () => {
+      const { hasOnlyIpv6Pools, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ isIpv6: true }), pool({ id: 'pool-2', isIpv6: true })];
+
+      expect(hasOnlyIpv6Pools.value).toBe(true);
+    });
+
+    it('is not only-ipv6 when any pool is not ipv6', () => {
+      const { hasOnlyIpv6Pools, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ isIpv6: true }), pool({ id: 'pool-2', isIpv6: false })];
+
+      expect(hasOnlyIpv6Pools.value).toBe(false);
+    });
+
+    it('detects dual-stack pools', () => {
+      const { hasDualStackPools, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ isDualStack: true })];
+
+      expect(hasDualStackPools.value).toBe(true);
+    });
+  });
+
+  describe('removeMachinePool', () => {
+    it('does nothing when the index does not exist', () => {
+      const { removeMachinePool, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ create: true })];
+
+      removeMachinePool(5);
+
+      expect(machinePools.value).toHaveLength(1);
+    });
+
+    it('drops a not-yet-saved pool entirely', () => {
+      const { removeMachinePool, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ create: true })];
+
+      removeMachinePool(0);
+
+      expect(machinePools.value).toHaveLength(0);
+    });
+
+    it('marks an existing pool for removal instead of deleting it', () => {
+      const { removeMachinePool, machinePools } = useMachinePools();
+
+      machinePools.value = [pool({ create: false })];
+
+      removeMachinePool(0);
+
+      expect(machinePools.value).toHaveLength(1);
+      expect((machinePools.value as any[])[0].remove).toBe(true);
+    });
+  });
+
+  describe('machinePoolValidationChanged', () => {
+    it('records the validation state for a pool', () => {
+      const { machinePoolValidationChanged, machinePoolValidation } = useMachinePools();
+
+      machinePoolValidationChanged('pool-1', false);
+
+      expect(machinePoolValidation.value['pool-1']).toBe(false);
+    });
+
+    it('removes the entry when the value is undefined', () => {
+      const { machinePoolValidationChanged, machinePoolValidation } = useMachinePools();
+
+      machinePoolValidationChanged('pool-1', false);
+      machinePoolValidationChanged('pool-1', undefined);
+
+      expect(machinePoolValidation.value).not.toHaveProperty('pool-1');
+    });
+  });
+
+  describe('recordMachinePoolError', () => {
+    const message = (count: number, poolName: string, fields: string) => `cluster.banner.machinePoolError-${ JSON.stringify({
+      count, pool_name: poolName, fields
+    }) }`;
+
+    it('formats a single offending field without a conjunction', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      const result = recordMachinePoolError({ 'pool-1': ['quantity'] });
+
+      expect(result).toStrictEqual([message(1, 'pool-1', 'quantity')]);
+    });
+
+    it('joins two offending fields with "and"', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      const result = recordMachinePoolError({ 'pool-1': ['quantity', 'roles'] });
+
+      expect(result).toStrictEqual([message(2, 'pool-1', 'quantity and roles')]);
+    });
+
+    it('joins three or more offending fields with commas and a trailing "and"', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      const result = recordMachinePoolError({ 'pool-1': ['quantity', 'roles', 'labels'] });
+
+      expect(result).toStrictEqual([message(3, 'pool-1', 'roles, labels, and quantity')]);
+    });
+
+    it('merges errors across multiple calls and returns one message per pool', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      recordMachinePoolError({ 'pool-1': ['quantity'] });
+      const result = recordMachinePoolError({ 'pool-2': ['roles'] });
+
+      expect(result).toStrictEqual([message(1, 'pool-1', 'quantity'), message(1, 'pool-2', 'roles')]);
+    });
+
+    it('omits pools whose error list is empty', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      recordMachinePoolError({ 'pool-1': ['quantity'] });
+      const result = recordMachinePoolError({ 'pool-2': [] });
+
+      expect(result).toStrictEqual([message(1, 'pool-1', 'quantity')]);
+    });
+
+    it('does NOT clear a pool\'s prior errors by reporting an empty list - lodash `merge` never shrinks an existing array', () => {
+      const { recordMachinePoolError } = useMachinePools();
+
+      recordMachinePoolError({ 'pool-1': ['quantity'] });
+      const result = recordMachinePoolError({ 'pool-1': [] });
+
+      expect(result).toStrictEqual([message(1, 'pool-1', 'quantity')]);
+    });
+  });
+
+  describe('syncMachineConfigWithLatest', () => {
+    const buildStore = () => ({
+      dispatch: jest.fn((action: string, payload: any) => {
+        if (action === 'management/create') {
+          return Promise.resolve({ ...payload, toJSON: () => payload });
+        }
+        if (action === 'management/request') {
+          return Promise.resolve({ metadata: { resourceVersion: '1' } });
+        }
+
+        return Promise.resolve(payload);
+      }),
+      getters: { 'i18n/t': (key: string, params: any) => `${ key } ${ JSON.stringify(params) }` },
+    });
+
+    it('does nothing when the machine pool has no config id', async() => {
+      const store = buildStore();
+
+      await syncMachineConfigWithLatest(store as any, {}, { config: null });
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('fetches the latest config and initial value for the pool', async() => {
+      const store = buildStore();
+      const config: any = {
+        id: 'mc-1', type: 'rke-machine-config.digitaloceandroplet', metadata: { resourceVersion: '1' }
+      };
+
+      config.toJSON = () => config;
+
+      await syncMachineConfigWithLatest(store as any, { 'mc-1': { metadata: { resourceVersion: '1' } } }, { config });
+
+      expect(store.dispatch).toHaveBeenCalledWith('management/request', { url: '/v1/rke-machine-config.digitaloceandroplets/mc-1' });
+    });
+
+    it('does not throw and applies non-conflicting server changes when there is no real conflict', async() => {
+      const store = buildStore();
+      // Server added a label the user never touched; user only changed `size`.
+      const initial = { metadata: { resourceVersion: '1' }, size: 's-2vcpu-4gb' };
+      const config: any = {
+        id: 'mc-1', type: 'rke-machine-config.digitaloceandroplet', metadata: { resourceVersion: '1' }, size: 's-4vcpu-8gb'
+      };
+
+      config.toJSON = () => config;
+      const machinePool = { config };
+      const latestFromServer = { metadata: { resourceVersion: '2', labels: { env: 'prod' } }, size: 's-2vcpu-4gb' };
+
+      store.dispatch.mockImplementation((action: string, payload: any) => {
+        if (action === 'management/request') {
+          return Promise.resolve(latestFromServer);
+        }
+        if (action === 'management/create') {
+          if (payload === latestFromServer) {
+            return Promise.resolve({ ...latestFromServer, toJSON: () => latestFromServer });
+          }
+
+          return Promise.resolve({ ...payload, toJSON: () => payload });
+        }
+
+        return Promise.resolve(payload);
+      });
+
+      await expect(syncMachineConfigWithLatest(store as any, { 'mc-1': initial }, machinePool)).resolves.toBeUndefined();
+
+      // Background change (label) applied, user's own change (size) preserved.
+      expect((machinePool.config as any).metadata.labels).toStrictEqual({ env: 'prod' });
+      expect(machinePool.config.size).toBe('s-4vcpu-8gb');
+      expect(machinePool.config.metadata.resourceVersion).toBe('2');
+    });
+
+    it('throws when the server and the user changed the same field to different values', async() => {
+      const store = buildStore();
+      const initial = { metadata: { resourceVersion: '1' }, size: 's-2vcpu-4gb' };
+      const config: any = {
+        id: 'mc-1', type: 'rke-machine-config.digitaloceandroplet', metadata: { resourceVersion: '1' }, size: 's-4vcpu-8gb'
+      };
+
+      config.toJSON = () => config;
+      const machinePool = { config };
+      // Server also changed `size`, to a third value - a genuine conflict.
+      const latestFromServer = { metadata: { resourceVersion: '2' }, size: 's-8vcpu-16gb' };
+
+      store.dispatch.mockImplementation((action: string, payload: any) => {
+        if (action === 'management/request') {
+          return Promise.resolve(latestFromServer);
+        }
+        if (action === 'management/create') {
+          if (payload === latestFromServer) {
+            return Promise.resolve({ ...latestFromServer, toJSON: () => latestFromServer });
+          }
+
+          return Promise.resolve({ ...payload, toJSON: () => payload });
+        }
+
+        return Promise.resolve(payload);
+      });
+
+      await expect(syncMachineConfigWithLatest(store as any, { 'mc-1': initial }, machinePool)).rejects.toThrow();
+    });
+  });
+});

--- a/shell/composables/useMachinePools.ts
+++ b/shell/composables/useMachinePools.ts
@@ -1,0 +1,235 @@
+import { ref, computed } from 'vue';
+import { useStore, Store } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
+import { removeObject } from '@shell/utils/array';
+import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
+import merge from 'lodash/merge';
+
+/**
+ * Classes to be adopted by the node badges in Machine pools
+ */
+const NODE_TOTAL = {
+  error: {
+    color: 'bg-error',
+    icon:  'icon-x',
+  },
+  warning: {
+    color: 'bg-warning',
+    icon:  'icon-warning',
+  },
+  success: {
+    color: 'bg-success',
+    icon:  'icon-checkmark'
+  }
+};
+
+/**
+ * Owns the machine pool list and its per-pool validation state, and derives the
+ * presentation-level bits (node role totals/badges, ipv6/dual-stack detection) from them.
+ *
+ * Deliberately does NOT own machine pool creation/save/cleanup (initMachinePools, addMachinePool,
+ * saveMachinePools, cleanupMachinePools, validateMachinePool) - those are wired into the consuming
+ * component's save-hook lifecycle (registerBeforeHook/registerAfterHook) and the extension-provider
+ * mechanism, both of which need `this` on the component instance.
+ */
+export function useMachinePools() {
+  const store = useStore();
+  const { t } = useI18n(store);
+
+  const machinePools = ref<any[] | null>(null);
+  const machinePoolValidation = ref<Record<string, boolean>>({}); // map of validation states for each machine pool
+
+  const unremovedMachinePools = computed(() => (machinePools.value || []).filter((x) => !x.remove));
+
+  const hasOnlyIpv6Pools = computed(() => !(machinePools.value || []).find((p) => !p.isIpv6 || p.isDualStack));
+  const hasDualStackPools = computed(() => !!(machinePools.value || []).find((p) => p.isDualStack));
+
+  const nodeTotals = computed(() => {
+    const roles = ['etcd', 'controlPlane', 'worker'];
+    const counts: Record<string, number> = {};
+    const out: Record<string, Record<string, any>> = {
+      color:   {},
+      label:   {},
+      icon:    {},
+      tooltip: {},
+    };
+
+    for (const role of roles) {
+      counts[role] = 0;
+      out.color[role] = NODE_TOTAL.success.color;
+      out.icon[role] = NODE_TOTAL.success.icon;
+    }
+
+    for (const row of machinePools.value || []) {
+      if (row.remove) {
+        continue;
+      }
+
+      const qty = parseInt(row.pool.quantity, 10);
+
+      if (isNaN(qty)) {
+        continue;
+      }
+
+      for (const role of roles) {
+        counts[role] = counts[role] + (row.pool[`${ role }Role`] ? qty : 0);
+      }
+    }
+
+    for (const role of roles) {
+      out.label[role] = t(`cluster.machinePool.nodeTotals.label.${ role }`, { count: counts[role] });
+      out.tooltip[role] = t(`cluster.machinePool.nodeTotals.tooltip.${ role }`, { count: counts[role] });
+    }
+
+    if (counts.etcd <= 0) {
+      out.color.etcd = NODE_TOTAL.error.color;
+      out.icon.etcd = NODE_TOTAL.error.icon;
+    } else if (counts.etcd === 1 || counts.etcd % 2 === 0 || counts.etcd > 7) {
+      out.color.etcd = NODE_TOTAL.warning.color;
+      out.icon.etcd = NODE_TOTAL.warning.icon;
+    }
+
+    if (counts.controlPlane <= 0) {
+      out.color.controlPlane = NODE_TOTAL.error.color;
+      out.icon.controlPlane = NODE_TOTAL.error.icon;
+    } else if (counts.controlPlane === 1) {
+      out.color.controlPlane = NODE_TOTAL.warning.color;
+      out.icon.controlPlane = NODE_TOTAL.warning.icon;
+    }
+
+    if (counts.worker <= 0) {
+      out.color.worker = NODE_TOTAL.error.color;
+      out.icon.worker = NODE_TOTAL.error.icon;
+    } else if (counts.worker === 1) {
+      out.color.worker = NODE_TOTAL.warning.color;
+      out.icon.worker = NODE_TOTAL.warning.icon;
+    }
+
+    return out;
+  });
+
+  /**
+   * Ensure that all the existing node roles pool are at least 1 each
+   */
+  function hasRequiredNodes() {
+    return nodeTotals.value?.color && Object.values(nodeTotals.value.color).every((color) => color !== NODE_TOTAL.error.color);
+  }
+
+  function removeMachinePool(idx: number) {
+    const entry = (machinePools.value as any[])[idx];
+
+    if (!entry) {
+      return;
+    }
+
+    if (entry.create) {
+      // If this is a new pool that isn't saved yet, it can just be dropped
+      removeObject(machinePools.value as any[], entry);
+    } else {
+      // Mark for removal on save
+      entry.remove = true;
+    }
+  }
+
+  /**
+   * Track Machine Pool validation status
+   */
+  function machinePoolValidationChanged(id: string, value: boolean | undefined) {
+    if (value === undefined) {
+      delete machinePoolValidation.value[id];
+    } else {
+      machinePoolValidation.value[id] = value;
+    }
+  }
+
+  const machinePoolErrors = ref<Record<string, string[]>>({});
+
+  /**
+   * Merges in a newly reported machine pool error and returns every pool's errors, formatted as
+   * one human-readable message per pool (e.g. "pool-a has invalid fields: quantity and roles").
+   */
+  function recordMachinePoolError(error: Record<string, string[]>): string[] {
+    machinePoolErrors.value = merge(machinePoolErrors.value, error);
+
+    return Object.entries(machinePoolErrors.value)
+      .map(([poolName, fields]) => {
+        if (!fields.length) {
+          return undefined;
+        }
+
+        const formattedFields = (() => {
+          switch (fields.length) {
+          case 1:
+            return fields[0];
+          case 2:
+            return `${ fields[0] } and ${ fields[1] }`;
+          default: {
+            const [head, ...rest] = fields;
+
+            return `${ rest.join(', ') }, and ${ head }`;
+          }
+          }
+        })();
+
+        return t('cluster.banner.machinePoolError', {
+          count: fields.length, pool_name: poolName, fields: formattedFields
+        }, true);
+      })
+      .filter((x): x is string => !!x);
+  }
+
+  return {
+    machinePools,
+    machinePoolValidation,
+    unremovedMachinePools,
+    hasOnlyIpv6Pools,
+    hasDualStackPools,
+    nodeTotals,
+    hasRequiredNodes,
+    removeMachinePool,
+    machinePoolValidationChanged,
+    recordMachinePoolError,
+  };
+}
+
+/**
+ * Resolves a single machine pool's config against the latest server state before it's saved,
+ * surfacing a conflict as a thrown error (which the save flow uses to abort and show the user).
+ *
+ * `initialMachinePoolsValues` is keyed by machine config id, holding a snapshot taken when the
+ * pool was first loaded/created - used as the merge base for `handleConflict`.
+ */
+export async function syncMachineConfigWithLatest(
+  store: Store<any>,
+  initialMachinePoolsValues: Record<string, any>,
+  machinePool: any
+) {
+  if (machinePool?.config?.id) {
+    // Use management/request instead of management/find to avoid overwriting the current machine pool in the store
+    const _latestConfig = await store.dispatch('management/request', { url: `/v1/${ machinePool.config.type }s/${ machinePool.config.id }` });
+    const latestConfig = await store.dispatch('management/create', _latestConfig);
+
+    const _initialMachinePoolValue = initialMachinePoolsValues[machinePool?.config?.id] || {};
+    const initialMachinePoolValue = await store.dispatch('management/create', _initialMachinePoolValue);
+
+    // if there's the initial machine pool config, we are in a good position to apply the handleConflict function
+    // to deal with out-of-sync data between machinePools configs. This also mutates the data inside machinePool.config through object reference
+    const conflict = await handleConflict(
+      initialMachinePoolValue,
+      machinePool.config,
+      latestConfig,
+      {
+        dispatch: store.dispatch,
+        getters:  store.getters
+      },
+      'management'
+    );
+
+    // if there's conflicts, throw Error stops save process and surfaces error to user
+    if (conflict) {
+      // handleConflict resolves an array of conflict errors (or false); Error() stringifies
+      // whatever it's given, same as it did when this ran as untyped JS in rke2.vue.
+      throw Error(conflict as any);
+    }
+  }
+}

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -248,7 +248,6 @@ describe('component: rke2', () => {
       data: (() => ({
         credentialId: 'I am authenticated',
         credential:   { decodedData: { clusterId: 'some-cluster-id' } },
-        machinePools: [],
       })) as any,
 
       global: {
@@ -271,6 +270,8 @@ describe('component: rke2', () => {
         stubs: defaultStubs,
       },
     });
+
+    (wrapper.vm as any).machinePools = [];
 
     // we need to mock the "save" method from the create-edit-view-mixin
     // otherwise we get console errors
@@ -681,7 +682,7 @@ describe('component: rke2', () => {
       const dispatch = jest.fn();
       const wrapper = createWrapper({ mode: _EDIT, dispatch });
 
-      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+      (wrapper.vm as any).machinePools = [{ id: 'pool1' }];
 
       await (wrapper.vm as any).showIpv6Warning();
 
@@ -692,7 +693,7 @@ describe('component: rke2', () => {
       const dispatch = jest.fn();
       const wrapper = createWrapper({ dispatch });
 
-      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+      (wrapper.vm as any).machinePools = [{ id: 'pool1' }];
 
       Object.defineProperty(wrapper.vm, 'selectedVersion', { get: () => ({ label: 'v1.30.0+rke2r1' }) });
       Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
@@ -714,7 +715,7 @@ describe('component: rke2', () => {
       });
       const wrapper = createWrapper({ dispatch });
 
-      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+      (wrapper.vm as any).machinePools = [{ id: 'pool1' }];
 
       Object.defineProperty(wrapper.vm, 'selectedVersion', { get: () => ({ label: 'v1.30.0+k3s1' }) });
       Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
@@ -746,7 +747,7 @@ describe('component: rke2', () => {
       });
       const wrapper = createWrapper({ dispatch });
 
-      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+      (wrapper.vm as any).machinePools = [{ id: 'pool1' }];
 
       Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
       Object.defineProperty(wrapper.vm, 'hasDualStackPools', { get: () => false });
@@ -978,54 +979,6 @@ describe('component: rke2', () => {
 
         expect(options[0]).toStrictEqual({ label: 'legacy-provider (Current)', value: 'legacy-provider' });
       });
-    });
-  });
-
-  // Characterization tests written ahead of extracting machine-pool orchestration into a composable.
-  describe('methods: removeMachinePool', () => {
-    it('does nothing when the index does not exist', () => {
-      const vm: any = { machinePools: [{ create: true }] };
-
-      (rke2.methods as any).removeMachinePool.call(vm, 5);
-
-      expect(vm.machinePools).toHaveLength(1);
-    });
-
-    it('drops a not-yet-saved pool entirely', () => {
-      const pool = { create: true };
-      const vm: any = { machinePools: [pool] };
-
-      (rke2.methods as any).removeMachinePool.call(vm, 0);
-
-      expect(vm.machinePools).toHaveLength(0);
-    });
-
-    it('marks an existing pool for removal instead of deleting it', () => {
-      const pool: { create: boolean; remove?: boolean } = { create: false };
-      const vm: any = { machinePools: [pool] };
-
-      (rke2.methods as any).removeMachinePool.call(vm, 0);
-
-      expect(vm.machinePools).toHaveLength(1);
-      expect(pool.remove).toBe(true);
-    });
-  });
-
-  describe('methods: machinePoolValidationChanged', () => {
-    it('records the validation state for a pool', () => {
-      const vm: any = { machinePoolValidation: {} };
-
-      (rke2.methods as any).machinePoolValidationChanged.call(vm, 'pool-1', false);
-
-      expect(vm.machinePoolValidation['pool-1']).toBe(false);
-    });
-
-    it('removes the entry when the value is undefined', () => {
-      const vm: any = { machinePoolValidation: { 'pool-1': false } };
-
-      (rke2.methods as any).machinePoolValidationChanged.call(vm, 'pool-1', undefined);
-
-      expect(vm.machinePoolValidation).not.toHaveProperty('pool-1');
     });
   });
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2,14 +2,13 @@
 import difference from 'lodash/difference';
 import throttle from 'lodash/throttle';
 import isArray from 'lodash/isArray';
-import merge from 'lodash/merge';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import { useKubernetesVersions, getDefaultVersion } from '@shell/composables/useKubernetesVersions';
 import { usePodSecurityAdmissionTemplates } from '@shell/composables/usePodSecurityAdmissionTemplates';
+import { useMachinePools, syncMachineConfigWithLatest } from '@shell/composables/useMachinePools';
 import { normalizeName } from '@shell/utils/kube';
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
-import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
 
 import {
   CAPI,
@@ -23,7 +22,7 @@ import {
 } from '@shell/config/types';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 
-import { removeObject, clear } from '@shell/utils/array';
+import { clear } from '@shell/utils/array';
 import { createYaml } from '@shell/utils/create-yaml';
 import {
   clone, diff, set, get, isEmpty, mergeWithReplace
@@ -74,23 +73,6 @@ const GOOGLE = 'google';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 const NETBIOS_TRUNCATION_LENGTH = 15;
 
-/**
- * Classes to be adopted by the node badges in Machine pools
- */
-const NODE_TOTAL = {
-  error: {
-    color: 'bg-error',
-    icon:  'icon-x',
-  },
-  warning: {
-    color: 'bg-warning',
-    icon:  'icon-warning',
-  },
-  success: {
-    color: 'bg-success',
-    icon:  'icon-checkmark'
-  }
-};
 const CLUSTER_AGENT_CUSTOMIZATION = 'clusterAgentDeploymentCustomization';
 const FLEET_AGENT_CUSTOMIZATION = 'fleetAgentDeploymentCustomization';
 const REGISTRIES_TAB_NAME = 'registry';
@@ -153,6 +135,7 @@ export default {
     return {
       ...useKubernetesVersions(props),
       ...usePodSecurityAdmissionTemplates(),
+      ...useMachinePools(),
     };
   },
 
@@ -248,7 +231,6 @@ export default {
       credentialId:                    '',
       credential:                      null,
       initialMachinePoolsValues:       {},
-      machinePools:                    null,
       s3Backup:                        false,
       /**
        * All info related to a specific version of the chart
@@ -274,10 +256,8 @@ export default {
       complianceOverride:                       false,
       truncateLimit:                            this.value.defaultHostnameLengthLimit || 0,
       busy:                                     false,
-      machinePoolValidation:                    {}, // map of validation states for each machine pool
       infrastructureClusterValid:               true,
       provisioningClusterValid:                 true,
-      machinePoolErrors:                        {},
       addonConfigValidation:                    {}, // validation state of each addon config (boolean of whether codemirror's yaml lint passed)
       stackPreferenceError:                     false, //  spec.networking.stackPreference is validated in conjunction with hasOnlyIpv6Pools
       allNamespaces:                            [],
@@ -447,10 +427,6 @@ export default {
       return true;
     },
 
-    unremovedMachinePools() {
-      return (this.machinePools || []).filter((x) => !x.remove);
-    },
-
     /**
      * Extension provider where being provisioned by an extension
      */
@@ -503,70 +479,6 @@ export default {
       }
 
       return this.$store.getters['management/schemaFor'](schema);
-    },
-
-    nodeTotals() {
-      const roles = ['etcd', 'controlPlane', 'worker'];
-      const counts = {};
-      const out = {
-        color:   {},
-        label:   {},
-        icon:    {},
-        tooltip: {},
-      };
-
-      for (const role of roles) {
-        counts[role] = 0;
-        out.color[role] = NODE_TOTAL.success.color;
-        out.icon[role] = NODE_TOTAL.success.icon;
-      }
-
-      for (const row of this.machinePools || []) {
-        if (row.remove) {
-          continue;
-        }
-
-        const qty = parseInt(row.pool.quantity, 10);
-
-        if (isNaN(qty)) {
-          continue;
-        }
-
-        for (const role of roles) {
-          counts[role] = counts[role] + (row.pool[`${ role }Role`] ? qty : 0);
-        }
-      }
-
-      for (const role of roles) {
-        out.label[role] = this.t(`cluster.machinePool.nodeTotals.label.${ role }`, { count: counts[role] });
-        out.tooltip[role] = this.t(`cluster.machinePool.nodeTotals.tooltip.${ role }`, { count: counts[role] });
-      }
-
-      if (counts.etcd <= 0) {
-        out.color.etcd = NODE_TOTAL.error.color;
-        out.icon.etcd = NODE_TOTAL.error.icon;
-      } else if (counts.etcd === 1 || counts.etcd % 2 === 0 || counts.etcd > 7) {
-        out.color.etcd = NODE_TOTAL.warning.color;
-        out.icon.etcd = NODE_TOTAL.warning.icon;
-      }
-
-      if (counts.controlPlane <= 0) {
-        out.color.controlPlane = NODE_TOTAL.error.color;
-        out.icon.controlPlane = NODE_TOTAL.error.icon;
-      } else if (counts.controlPlane === 1) {
-        out.color.controlPlane = NODE_TOTAL.warning.color;
-        out.icon.controlPlane = NODE_TOTAL.warning.icon;
-      }
-
-      if (counts.worker <= 0) {
-        out.color.worker = NODE_TOTAL.error.color;
-        out.icon.worker = NODE_TOTAL.error.icon;
-      } else if (counts.worker === 1) {
-        out.color.worker = NODE_TOTAL.warning.color;
-        out.icon.worker = NODE_TOTAL.warning.icon;
-      }
-
-      return out;
     },
 
     showCni() {
@@ -805,14 +717,6 @@ export default {
       } else {
         return false;
       }
-    },
-
-    hasOnlyIpv6Pools() {
-      return !(this.machinePools || []).find((p) => !p.isIpv6 || p.isDualStack);
-    },
-
-    hasDualStackPools() {
-      return !!(this.machinePools || []).find((p) => p.isDualStack);
     },
 
     validationPassed() {
@@ -1343,49 +1247,8 @@ export default {
       });
     },
 
-    removeMachinePool(idx) {
-      const entry = this.machinePools[idx];
-
-      if (!entry) {
-        return;
-      }
-
-      if (entry.create) {
-        // If this is a new pool that isn't saved yet, it can just be dropped
-        removeObject(this.machinePools, entry);
-      } else {
-        // Mark for removal on save
-        entry.remove = true;
-      }
-    },
-
     async syncMachineConfigWithLatest(machinePool) {
-      if (machinePool?.config?.id) {
-        // Use management/request instead of management/find to avoid overwriting the current machine pool in the store
-        const _latestConfig = await this.$store.dispatch('management/request', { url: `/v1/${ machinePool.config.type }s/${ machinePool.config.id }` });
-        const latestConfig = await this.$store.dispatch('management/create', _latestConfig);
-
-        const _initialMachinePoolValue = this.initialMachinePoolsValues[machinePool?.config?.id] || {};
-        const initialMachinePoolValue = await this.$store.dispatch('management/create', _initialMachinePoolValue);
-
-        // if there's the initial machine pool config, we are in a good position to apply the handleConflict function
-        // to deal with out-of-sync data between machinePools configs. This also mutates the data inside machinePool.config through object reference
-        const conflict = await handleConflict(
-          initialMachinePoolValue,
-          machinePool.config,
-          latestConfig,
-          {
-            dispatch: this.$store.dispatch,
-            getters:  this.$store.getters
-          },
-          'management'
-        );
-
-        // if there's conflicts, throw Error stops save process and surfaces error to user
-        if (conflict) {
-          throw Error(conflict);
-        }
-      }
+      return syncMachineConfigWithLatest(this.$store, this.initialMachinePoolsValues, machinePool);
     },
 
     async saveMachinePools(hookContext) {
@@ -1554,13 +1417,6 @@ export default {
           },
         });
       });
-    },
-
-    /**
-     * Ensure that all the existing node roles pool are at least 1 each
-     */
-    hasRequiredNodes() {
-      return this.nodeTotals?.color && Object.values(this.nodeTotals.color).every((color) => color !== NODE_TOTAL.error.color);
     },
 
     cancelCredential() {
@@ -2168,16 +2024,6 @@ export default {
     handleShowDeprecatedPatchVersionsChanged(value) {
       this.showDeprecatedPatchVersions = value;
     },
-    /**
-     * Track Machine Pool validation status
-     */
-    machinePoolValidationChanged(id, value) {
-      if (value === undefined) {
-        delete this.machinePoolValidation[id];
-      } else {
-        this.machinePoolValidation[id] = value;
-      }
-    },
 
     updateNginxConfiguration(disabledServerConfig) {
       // We only need to explicitly set INGRESS_CONTROLLER for RKE2, we continue to rely on disable list for K3s
@@ -2225,35 +2071,9 @@ export default {
     },
 
     handleMachinePoolError(error) {
-      this.machinePoolErrors = merge(this.machinePoolErrors, error);
+      const errors = this.recordMachinePoolError(error);
 
-      const errors = Object.entries(this.machinePoolErrors)
-        .map((x) => {
-          if (!x[1].length) {
-            return;
-          }
-
-          const formattedFields = (() => {
-            switch (x[1].length) {
-            case 1:
-              return x[1][0];
-            case 2:
-              return `${ x[1][0] } and ${ x[1][1] }`;
-            default: {
-              const [head, ...rest] = x[1];
-
-              return `${ rest.join(', ') }, and ${ head }`;
-            }
-            }
-          })();
-
-          return this.t('cluster.banner.machinePoolError', {
-            count: x[1].length, pool_name: x[0], fields: formattedFields
-          }, true);
-        })
-        .filter((x) => x);
-
-      if (!errors) {
+      if (!errors.length) {
         return;
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18941 
<!-- Define findings related to the feature or bug issue. -->
Moved machine pool logic into a separate composable. There should be no functional or visual difference from former implementation

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Moved the logic to manage machine pools into a separate composable. 
No issues were found or fixed in the process

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Moved to useMachinePools.ts
| Piece | What it does |
|---|---|
| `machinePools` (ref) | The pool list itself |
| `machinePoolValidation` (ref) | Per-pool validation-passed state, keyed by pool id |
| `unremovedMachinePools` (computed) | Filters out pools marked for removal |
| `hasOnlyIpv6Pools` / `hasDualStackPools` (computed) | ipv6/dual-stack detection across the pool list |
| `nodeTotals` (computed) | Per-role (etcd/control-plane/worker) node counts, badge colors/icons, and the etcd odd-count/≤7 warning rule |
| `hasRequiredNodes()` | Whether every role has at least one non-error-state node |
| `removeMachinePool(idx)` | Drops an unsaved pool, or flags an existing one for removal |
| `machinePoolValidationChanged(id, value)` | Records/clears a pool's validation state |
| `machinePoolErrors` (ref, private) | Per-pool field-level validation errors — not exposed, only consumed internally |
| `recordMachinePoolError(error)` | Merges in a new error, returns formatted per-pool messages |
| `syncMachineConfigWithLatest` (standalone export) | Resolves a pool's config against the latest server state before save |

Stayed in rke2.vue
| Piece | Why it stayed |
|---|---|
| `hasMachinePools` (computed) | Trivial one-liner reading `this.value`/props directly; no real logic to extract |
| `initMachinePools(existing)` | Builds the initial pool list from the resource being edited — needs `this.value`/`this.mode`/etc. |
| `addMachinePool(idx)` | Needs `this.$store` to create new machine-config resources |
| `saveMachinePools(hookContext)`, `cleanupMachinePools()`, `validateMachinePool()` | Wired into the save-hook lifecycle via `registerBeforeHook`/`registerAfterHook`, and delegate to `this.extensionProvider` when present |
| `syncMachineConfigWithLatest` (thin wrapper method) | One line forwarding to the composable's standalone function with `this.$store`/`this.initialMachinePoolsValues` |
| `handleMachinePoolError(error)` | 6-line wrapper: calls `this.recordMachinePoolError(error)`, pushes the result into `this.errors` (a component-wide concern, not machine-pool-specific) |

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Node role total badges render

1. On Create, default single pool with etcd + controlPlane + worker roles, quantity 1.
2. Observe the three badges (etcd / Control Plane / Worker) above the pool tabs.

Expected: All three show a count label and tooltip. etcd shows warning (yellow, icon-warning) because count = 1; Control Plane and Worker show warning because count = 1. No badge is green yet.

2. Badge colors track role counts

| Role total | Badge color | Icon |
|---|---|---|
| **etcd** = 0 | `bg-error` (red) | `icon-x` |
| **etcd** = 1 | `bg-warning` (yellow) | `icon-warning` |
| **etcd** = 2 (any even) | `bg-warning` | `icon-warning` |
| **etcd** = 3, 5, 7 (odd, 3–7) | `bg-success` (green) | `icon-checkmark` |
| **etcd** = 8 (>7) | `bg-warning` | `icon-warning` |
| **etcd** = 9 (odd, >7) | `bg-warning` | `icon-warning` |
| **Control Plane** = 0 | `bg-error` | `icon-x` |
| **Control Plane** = 1 | `bg-warning` | `icon-warning` |
| **Control Plane** ≥ 2 | `bg-success` | `icon-checkmark` |
| **Worker** = 0 | `bg-error` | `icon-x` |
| **Worker** = 1 | `bg-warning` | `icon-warning` |
| **Worker** ≥ 2 | `bg-success` | `icon-checkmark` |
Change quantities / role checkboxes and confirm each badge updates live.

3. hasRequiredNodes gates the Create/Save button

1. Configure pools so every role has ≥1 node → Create enabled (assuming rest of form valid).
2. Uncheck all role checkboxes on the only pool (or set qty 0) → at least one badge goes red → Create disabled.
3. Restore roles → button re‑enables.

4. Add machine pool

1. Click the + / add‑pool control.
2. New tab appears; badges recount to include it.
3. New pool has a generated id and is flagged as unsaved (create).

5. Remove machine pool

1. New, unsaved pool: click remove on its tab → tab disappears entirely, unremovedMachinePools count drops, badges recount.
2. Existing pool (edit mode, previously saved): click remove → tab is hidden/marked removed but not gone; on Save the pool is deleted server‑side.
3. Remove all pools → the "no pools" empty‑state message (v-if="!unremovedMachinePools.length") shows and Create is blocked.
4. Remove with an out‑of‑range/no‑op index (rapid double click) → no crash, list unchanged.

6. Machine pool error banner (handleMachinePoolError / recordMachinePoolError)

Trigger pool‑level validation errors (e.g. invalid quantity, no roles selected, bad pool name) and check the page error banner text:
- a. One invalid field: message names the pool and the single field, no "and".
- b. Two invalid fields: fields joined with " and ".
- c. Three+ invalid fields: "<f2>, <f3>, and <f1>" format (first field rotated to the end — matches existing behavior).
- d. Multiple pools invalid: one line per offending pool.
- e. Fix one pool's errors, leave another broken: banner still shows the remaining pool's error. (Note: because errors are merged and never shrink, a fixed pool's message may persist until navigation/re‑save — this matches pre‑refactor behavior; confirm it's not worse than before.)
- 6f. Regression check for the subtle change: get an error banner showing, then cause a pool @error emit with an empty field list → confirm the page behaves as before (banner not spuriously cleared/re‑set). No console errors.

7. IPv6 / dual‑stack warnings

1. Create a pool on an IPv6‑only subnet → hasOnlyIpv6Pools true → the IPv6 warning/stack‑preference validation shows where has-some-ipv6-pools is bound (networking section, and the k8s‑version IPv6 support warning).
2. Add a dual‑stack pool → hasDualStackPools true → dual‑stack handling/warning appears; IPv6‑only warning clears.
3. Mix one IPv4 pool in → hasOnlyIpv6Pools false → IPv6‑only warning clears.
4. spec.networking.stackPreference validation still reacts to IPv6‑only pools (stackPreferenceError).

8. Pre‑save config conflict check (syncMachineConfigWithLatest) — edit mode

1. Open an existing node‑driver cluster for edit (loads initialMachinePoolsValues snapshot per pool config id).
2. In a second session, edit the same cluster's machine config — change a different field than you will (e.g. change a label) — and save.
3. Back in the first session, change one field (e.g. instance size) and Save.
   Expected: Save succeeds; the background change (label) is merged in, your change (size) preserved, resourceVersion advances. No conflict error.
4. Repeat but in the second session change the same field to a different value.
   Expected: Save aborts, user sees a conflict error surfaced from the thrown Error. Cluster not left half‑saved.
5. Pool with no config.id (brand‑new pool) → Save proceeds, no management/request fired for it.

9. Save round‑trip / snapshot refresh

1. Create a cluster with 2 pools → Save → provisioning starts, cluster appears in list.
2. Re‑open for edit → both pools load, badges correct, initialMachinePoolsValues re‑snapshotted (verify by immediately doing case 8 again without a conflict — should be clean).
3. Edit a pool quantity → Save → change persists.


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Machine pool listing, editing, creating, and saving could be affected for all providers

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
