### PR TITLE
[backport 2.15.2] Automation: Fix kubewarden test

### DIFF
--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -102,8 +102,8 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     kubewardenPo.goTo();
     kubewardenPo.waitForPage();
 
-    cy.get('h1').contains('Kubewarden').should('exist');
-    cy.get('button').contains('Install Kubewarden').should('exist');
+    cy.get('h1').contains('SUSE Security Admission Controller').should('exist');
+    cy.get('button').contains('Install SUSE Security Admission Controller').should('exist');
   }));
 
   qase(1433, it('Should uninstall Kubewarden', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Fix from https://github.com/rancher/dashboard/pull/18854 needs to be backported to unblock 2.15.x release lines (example CI e2e test [failure](https://github.com/rancher/dashboard/actions/runs/33175983731/job/99009002715?pr=18924#step:8:154))

<!-- Define findings related to the feature or bug issue. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
