### PR TITLE
Sort deprecated StorageClass provisioners below supported ones

### DIFF
--- a/shell/edit/__tests__/storage.k8s.io.storageclass.test.ts
+++ b/shell/edit/__tests__/storage.k8s.io.storageclass.test.ts
@@ -1,0 +1,84 @@
+import { shallowMount, VueWrapper } from '@vue/test-utils';
+import { _CREATE } from '@shell/config/query-params';
+import StorageClass from '@shell/edit/storage.k8s.io.storageclass/index.vue';
+
+const createEditViewMock = {
+  props: {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    realMode: {
+      type:    String,
+      default: _CREATE
+    },
+  },
+  data() {
+    return { errors: [] };
+  },
+  computed: {
+    isCreate:     () => true,
+    isEdit:       () => false,
+    isView:       () => false,
+    schema:       () => ({}),
+    isNamespaced: () => false,
+    doneRoute:    () => 'mockedRoute',
+    doneParams:   () => ({}),
+  },
+  methods: {
+    done:               jest.fn(),
+    save:               jest.fn(() => Promise.resolve()),
+    registerBeforeHook: jest.fn(),
+    // Echo the labelKey back so provisioner labels are deterministic for sorting assertions
+    t:                  (key: string) => key,
+  }
+};
+
+describe('storageClass edit', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StorageClass>>;
+
+  const createComponent = (showUnsupportedStorage = true) => {
+    wrapper = shallowMount(StorageClass,
+      {
+        props:  { value: { parameters: {} } },
+        mixins: [createEditViewMock],
+        global: {
+          mocks: {
+            $store: {
+              getters: {
+                'cluster/schemaFor': jest.fn(() => false),
+                'features/get':      jest.fn(() => showUnsupportedStorage),
+                'i18n/t':            jest.fn((key: string) => key),
+                'i18n/withFallback': jest.fn((key: string, args: any, fallback: string) => fallback),
+              }
+            }
+          },
+        },
+      }
+    );
+  };
+
+  it('lists non-deprecated provisioners before deprecated ones', () => {
+    createComponent();
+
+    const options = wrapper.vm.provisioners;
+    const firstDeprecatedIndex = options.findIndex((o: any) => o.deprecated);
+    const lastNonDeprecatedIndex = options.map((o: any) => !!o.deprecated).lastIndexOf(false);
+
+    // Every deprecated option should come after every non-deprecated option
+    expect(firstDeprecatedIndex).toBeGreaterThan(lastNonDeprecatedIndex);
+  });
+
+  it('sorts provisioners alphabetically within the deprecated and non-deprecated groups', () => {
+    createComponent();
+
+    const options = wrapper.vm.provisioners;
+    const nonDeprecated = options.filter((o: any) => !o.deprecated).map((o: any) => o.label.toLowerCase());
+    const deprecated = options.filter((o: any) => o.deprecated).map((o: any) => o.label.toLowerCase());
+
+    expect(nonDeprecated).toStrictEqual([...nonDeprecated].sort());
+    expect(deprecated).toStrictEqual([...deprecated].sort());
+  });
+});

--- a/shell/edit/storage.k8s.io.storageclass/index.vue
+++ b/shell/edit/storage.k8s.io.storageclass/index.vue
@@ -131,7 +131,14 @@ export default {
           label: this.$store.getters['i18n/withFallback'](`persistentVolume.csi.drivers.${ driver.metadata.name.replaceAll('.', '-') }`, null, fallback)
         });
       });
-      const out = dropdownOptions.sort((a, b) => a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1);
+      // Sort non-deprecated provisioners above deprecated ones, then alphabetically within each group
+      const out = dropdownOptions.sort((a, b) => {
+        if (!!a.deprecated !== !!b.deprecated) {
+          return a.deprecated ? 1 : -1;
+        }
+
+        return a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1;
+      });
 
       return out;
     },


### PR DESCRIPTION
### Summary
Fixes #15003

### Occurred changes and/or fixed issues
Deprecated StorageClass provisioners (AWS EBS, Azure Disk, GCE PD, etc.) are now sorted below the non-deprecated ones in the Provisioner dropdown, instead of being mixed into the alphabetical list.

### Technical notes summary
Updated the `provisioners` computed sort in `shell/edit/storage.k8s.io.storageclass/index.vue` to group non-deprecated options first, then sort alphabetically within each group. CSI drivers have no `deprecated` flag, so they stay in the top group. Deprecated options keep their existing "(Deprecated)" suffix. Added unit tests covering the grouping and alphabetical ordering.

### Areas or cases that should be tested
- Navigate to `storage.k8s.io.storageclass/create#parameters` and open the Provisioner dropdown; confirm deprecated provisioners appear below non-deprecated ones and each group is alphabetical.
- Toggle the `unsupported-storage-drivers` feature flag and verify ordering still holds.
- On a cluster with installed CSI drivers, confirm they appear in the non-deprecated group.
- Tested locally in Chrome; reviewer to verify in a different browser.

### Areas which could experience regressions
- StorageClass create/edit form (provisioner selection, deprecation banner, parameters/customize tabs).

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1716" height="517" alt="image" src="https://github.com/user-attachments/assets/4c3e26c3-211a-4238-9a3d-0d2c7a71412b" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
