### PR TITLE
Remove role="textbox" from search inputs

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -213,6 +213,33 @@ describe('component: LabeledInput', () => {
     });
   });
 
+  // The native input used to carry role="textbox" for every type but "number".
+  // On "search" and "password" that role is disallowed outright, and on
+  // "search" it also hid the implicit searchbox role from assistive
+  // technology; on the other types listed below it only repeated the implicit
+  // role. Either way the browser already exposes the right one, so the
+  // component writes none. "number" is listed because it must keep its
+  // implicit spinbutton role, and the "multiline" types are absent because
+  // they render a textarea rather than an input.
+  describe('a11y: leaving the implicit role alone', () => {
+    it.each([
+      ['text'],
+      ['search'],
+      ['password'],
+      ['email'],
+      ['number'],
+      ['integer'],
+      ['cron'],
+    ])('for type %p should not write an explicit role onto the input', (type) => {
+      const wrapper = mount(LabeledInput, {
+        propsData: { value: '', type },
+        mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
+      });
+
+      expect(wrapper.find('input').attributes('role')).toBeUndefined();
+    });
+  });
+
   it('a11y: rendering a "label" should not render an "aria-label" prop', () => {
     const label = 'some-label';
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -566,7 +566,6 @@ export default defineComponent({
         :id="inputId"
         ref="value"
         v-stripped-aria-label="!hasLabel && ariaLabel ? ariaLabel : undefined"
-        :role="nativeType === 'number' ? undefined : 'textbox'"
         :class="{ 'no-label': !hasLabel }"
         v-bind="$attrs"
         :name="name || undefined"

--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -741,7 +741,6 @@ export default {
             v-model="search"
             class="input-sm"
             type="search"
-            role="textbox"
             :aria-label="t('wm.containerLogs.searchLogs')"
             :placeholder="t('wm.containerLogs.search')"
           >

--- a/shell/components/Window/__tests__/ContainerLogs.test.ts
+++ b/shell/components/Window/__tests__/ContainerLogs.test.ts
@@ -194,4 +194,28 @@ describe('component: ContainerLogs', () => {
     expect(wrapper.vm.backlog).toHaveLength(3);
     expect(wrapper.vm.backlog[2].rawMsg).toBe(message.trimEnd());
   });
+
+  it('should leave the log search input its implicit searchbox role', () => {
+    const options = getDefaultOptions();
+    // Rendering the title slot evaluates featureDropdownMenu, which reaches
+    // the store the component's own setup() took from useStore()
+    // (ContainerLogs.vue:131) and reads a getter off it
+    // (shell/utils/version.js, getVersionInfo). useStore() reads the injected
+    // store, not the mocked $store, so it has to be provided.
+    const wrapper = shallowMount(ContainerLogs, {
+      ...options,
+      global: {
+        ...options.global,
+        provide: { store: { getters: { 'management/byId': jest.fn() } } },
+        // The search input lives in Window's "title" slot, which a stubbed
+        // Window would not render.
+        stubs:   { Window: { template: '<div><slot name="title"></slot></div>' } },
+      },
+    });
+
+    const search = wrapper.find('input[type="search"]');
+
+    expect(search.exists()).toBe(true);
+    expect(search.attributes('role')).toBeUndefined();
+  });
 });

--- a/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { shallowMount } from '@vue/test-utils';
 import Charts from '@shell/pages/c/_cluster/apps/charts/index.vue';
 import { UI_PLUGIN_ANNOTATION } from '@shell/config/uiplugins';
 
@@ -143,6 +144,41 @@ describe('page: Charts Index', () => {
 
       // The cancelled timer must not have fired — count stays at the reset value.
       expect(ctx.visibleChartsCount).toBe(30);
+    });
+  });
+
+  describe('template: catalog search input', () => {
+    // type="search" already exposes the implicit searchbox role, so no
+    // explicit role should be written over it.
+    it('should leave the search input its implicit searchbox role', () => {
+      const wrapper = shallowMount(Charts, {
+        global: {
+          // Only what the page reads while rendering: its three mapGetters,
+          // the prefs the template checks, and $fetchState for the Loading
+          // guard.
+          mocks: {
+            $store: {
+              getters: {
+                'catalog/charts': [],
+                'catalog/errors': [],
+                'catalog/repos':  [],
+                'prefs/get':      jest.fn(),
+                currentCluster:   { status: { provider: 'k3s' } },
+              }
+            },
+            $fetchState: { pending: false },
+            $route:      { query: {}, params: {} },
+          },
+          // Registered globally by the app, so absent under a bare mount.
+          stubs:      { RouterLink: true },
+          directives: { shortkey: {} }
+        }
+      });
+
+      const search = wrapper.find('[data-testid="charts-filter-input"]');
+
+      expect(search.exists()).toBe(true);
+      expect(search.attributes('role')).toBeUndefined();
     });
   });
 });

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -614,7 +614,6 @@ export default {
         :placeholder="t('catalog.charts.search')"
         data-testid="charts-filter-input"
         :aria-label="t('catalog.charts.search')"
-        role="textbox"
       >
       <i
         v-if="!searchQuery"

--- a/shell/pages/c/_cluster/fleet/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/fleet/__tests__/index.test.ts
@@ -716,5 +716,8 @@ describe('component: FleetDashboard', () => {
     const searchInput = wrapper.find('[data-testid="fleet-dashboard-search-input-fleet-local"]');
 
     expect(searchInput.exists()).toBe(true);
+    // type="search" already exposes the implicit searchbox role, so no
+    // explicit role should override it.
+    expect(searchInput.attributes('role')).toBeUndefined();
   });
 });

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -612,7 +612,6 @@ export default {
                 <input
                   :value="searchFilter[workspace.id]"
                   type="search"
-                  role="textbox"
                   class="input"
                   :data-testid="`fleet-dashboard-search-input-${ workspace.id }`"
                   :aria-label="t('fleet.dashboard.cards.search')"


### PR DESCRIPTION
### Summary
Fixes #19006

### Occurred changes and/or fixed issues
- Removed `role="textbox"` from `LabeledInput`'s native input, which put it on every list page's filter box.
- Removed the same hand-written attribute from the chart catalog, Fleet dashboard card and Container Logs searches.
- Added a unit assertion at each of the four sites.

### Technical notes summary
- The binding excluded only `number`, so it also hit `password`. Deleting beats a third exception.
- Chromium emits `readonly`/`required` only for `textbox`, not `searchbox`. No Rancher search input sets either.
- The issue says 8 violations; its table lists 6, which is what I measured.

### Areas or cases that should be tested
No fixture needed. On any Rancher, with DevTools or an axe scan open:

- Any list page, e.g. Apps > Repositories: the table Filter box reports role `searchbox`, not `textbox`.
- Apps > Charts: the catalog search box, same.
- A pod's Container Logs in the window manager: the log search box, same.
- Continuous Delivery > Dashboard in card view, with a workspace that has App Bundles: the card search box, same.

Correct result: `aria-allowed-role` reports nothing on those pages, and each search box still filters, still shows its clear button, and is still reachable by keyboard.

### Areas which could experience regressions
- `LabeledInput` ships in `@rancher/components`, so downstream DOM changes. An extension selecting on the role would break silently; nothing here does.
- The only role-based CSS selector is `[role="button"]`, so both themes are unaffected.
- `type="number"` already emitted no role, so it keeps `spinbutton`.

### Screenshot/Video

**Before** - both search boxes carry `role="textbox"`; every value in the banners is read live from the page by axe-core 4.10.2:

https://github.com/user-attachments/assets/9163054b-19cb-4815-871e-2398ddc3a7f9

**After** - the same walk, no role and no violation; 6 to 0 across the issue's six pages:

https://github.com/user-attachments/assets/5dc0b802-eba5-4562-b015-5938858042a8

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
