### PR TITLE
test(e2e): pin Rancher image to a known-good head build (isolate jail regression)

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,12 +9,12 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "head"
+          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
         },
         "rancher-agent": {
           "namespace": "rancher",
           "name": "rancher-agent",
-          "tag": "head"
+          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
         },
         "runtime-rancher-version": "2.15.0",
         "helm": {

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -5,7 +5,7 @@
 # ----------------------- Input
 # ---------------------------------
 
-USE_LOCAL_BRANCH_METADATA=false # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+USE_LOCAL_BRANCH_METADATA=true # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
 KUBE_TYPE=${KUBE_TYPE:-K3S} # K3S or K3D
 OVERRIDE_UIS=${OVERRIDE_UIS:-true} # use UI bits supplied externally (e.g. by CI) rather than the built in UI bits
 TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}


### PR DESCRIPTION
### Summary
The e2e `Tests` workflow has been failing across master and every PR because the Rancher server never converges: it dies at startup with `[FATAL] error running the jail command: exit status 1`, so its deployment never rolls out and the harness fails after 3 full cluster rebuilds — taking down all 18 e2e shards while build/lint/unit/type-check pass.

Root cause is **not** dashboard code: the e2e installs `rancher/rancher:head`, a **floating** tag. Between the last green master run (07:41 UTC, `head` = rancher/rancher `4cd8c7d`) and the first red one (08:35 UTC, `head` = rancher/rancher `23449b8` — "Update bci-micro base image → v16"), a new `head` build broke the jail. `branches-metadata.json` was unchanged between them.

This pins the e2e Rancher **image and agent** to the last `head` build that passed (`v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head`) instead of the floating tag. Purpose: (1) unblock e2e with a known-good Rancher build, and (2) isolate whether the later base-image bump (`23449b8`) is what broke the jail — if this run goes green, it is.

### Occurred changes
* Pin `branches-metadata.json` `branches.master.e2e.rancher-image.tag` and `rancher-agent.tag` from `head` to `v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head`.

### Technical notes
Diagnostic / infra-unblock change; no product code touched. Draft — pending the e2e result to confirm the pinned build is green (and thereby confirm the regression is in a later `head` build).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`