### PR TITLE
test(e2e): pin Rancher image to f7438dd (pre-k3s-bump) to bracket the jail regression

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,12 +9,12 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "head"
+          "tag": "v2.16-f7438dd41feff6f30a6c265ba3514e09ede36186-head"
         },
         "rancher-agent": {
           "namespace": "rancher",
           "name": "rancher-agent",
-          "tag": "head"
+          "tag": "v2.16-f7438dd41feff6f30a6c265ba3514e09ede36186-head"
         },
         "runtime-rancher-version": "2.15.0",
         "helm": {


### PR DESCRIPTION
### Summary
Companion diagnostic to the `4cd8c7d` pin, isolating an upstream Rancher regression that breaks e2e for master and all PRs: Rancher fails at startup with `error running the jail command: exit status 1`, never converges after 3 rebuilds, and takes down every e2e shard.

The e2e uses the floating `rancher/rancher:head`. This pins the Rancher image + agent to **`f7438dd`** — the rancher/rancher master commit immediately **before** two suspect Dockerfile changes:
- `4cd8c7d` — `CATTLE_K3S_VERSION` v1.35 -> v1.36
- `23449b8` — `bci-micro` base image -> v16 (the build the first red run used)

If e2e is green here, the break is in `4cd8c7d`/`23449b8`; combined with the `4cd8c7d` pin PR it brackets exactly which one.

### Occurred changes
* Pin `branches-metadata.json` `branches.master.e2e.rancher-image.tag` and `rancher-agent.tag` to `v2.16-f7438dd41feff6f30a6c265ba3514e09ede36186-head`.

### Technical notes
Diagnostic / infra-unblock only; no product code. Draft.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`