### PR TITLE
fix(test): mock management/schemaFor in MembershipEditor.remove spec (+ temporary e2e image pin to unblock CI)

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,12 +9,12 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "head"
+          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
         },
         "rancher-agent": {
           "namespace": "rancher",
           "name": "rancher-agent",
-          "tag": "head"
+          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
         },
         "runtime-rancher-version": "2.15.0",
         "helm": {

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -13,6 +13,8 @@ RANCHER_IMG_REGISTRY=
 RANCHER_IMG_NAMESPACE=rancher
 RANCHER_IMG_NAME=rancher
 
+USE_LOCAL_BRANCH_METADATA=true # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+
 # Host port mapping (configurable to avoid conflicts, e.g. with MCP Gateway on port 80)
 RANCHER_HOST_HTTP_PORT=${RANCHER_HOST_HTTP_PORT:-80}
 RANCHER_HOST_HTTPS_PORT=${RANCHER_HOST_HTTPS_PORT:-443}
@@ -27,8 +29,12 @@ if [ $# -eq 1 ]; then
   # When an image is specified, we use that image, including its front-end, so we don't want the volume args to mount the locally-built UI
   VOLUME_ARGS=""
 else
-  # Get container image from branch-metadata
-  BRANCH_DATA=$(./scripts/get-branch-metadata.sh ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  # Get container image from branch-metadata (PR-local when toggled, like e2e-k3s-start.sh)
+  if [ "$USE_LOCAL_BRANCH_METADATA" = "true" ]; then
+    BRANCH_DATA=$(./scripts/get-branch-metadata.sh --local ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  else
+    BRANCH_DATA=$(./scripts/get-branch-metadata.sh ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  fi
 
   if [ -n "$BRANCH_DATA" ]; then
     REGISTRY=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].registry // ""')

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -5,7 +5,7 @@
 # ----------------------- Input
 # ---------------------------------
 
-USE_LOCAL_BRANCH_METADATA=false # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+USE_LOCAL_BRANCH_METADATA=true # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
 KUBE_TYPE=${KUBE_TYPE:-K3S} # K3S or K3D
 OVERRIDE_UIS=${OVERRIDE_UIS:-true} # use UI bits supplied externally (e.g. by CI) rather than the built in UI bits
 TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}

--- a/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
@@ -36,7 +36,14 @@ describe('component: MembershipEditor removal', () => {
       },
       global: {
         mocks: {
-          $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
+          $store: {
+            getters: {
+              'rancher/schemaFor':    () => ({ type: 'object' }),
+              // canManageMembers (which gates the remove action) also reads the management
+              // role-template/PRTB schemas - provide them so the remove buttons render.
+              'management/schemaFor': () => ({ type: 'object' }),
+            }
+          },
           $fetchState: { pending: false },
         },
         stubs: { Principal: CachedPrincipal },


### PR DESCRIPTION
### Summary
Two things, so the PR can go green end-to-end:

**1. Fix the `master` unit-test regression (the actual fix).**
`MembershipEditor.remove.test.ts` fails with `TypeError: store.getters.management/schemaFor is not a function`. `MembershipEditor`'s `canManageMembers` computed (which gates the remove action) reads `management/schemaFor`; the removal spec's `$store` mock only provided `rancher/schemaFor`. The sibling `MembershipEditor.test.ts` was updated to mock it but this removal spec was not — the gap only surfaced once the members change landed on `master`. Ref: https://github.com/rancher/dashboard/pull/18840

**2. Pin the e2e Rancher image to unblock CI (temporary infra workaround).**
`master`'s e2e + a11y are red for every PR due to an upstream `rancher/rancher:head` regression — the jailer fails to start (`error running the jail command: exit status 1`) in builds after `4cd8c7d`, so Rancher never converges. Pin the e2e Rancher image/agent to the last-good build (`v2.16-4cd8c7dc…-head`) and read the PR-local `branches-metadata.json` in **both** the k3s path (e2e-test shards) and the docker path (a11y) so the pin actually takes effect everywhere.

### Occurred changes
* `shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts` — add `management/schemaFor` to the `$store.getters` mock (**the real fix**).
* `branches-metadata.json` — pin e2e `rancher-image`/`rancher-agent` tag to `v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head`.
* `scripts/e2e-k3s-start.sh` — `USE_LOCAL_BRANCH_METADATA=true` (k3s path → e2e-test shards use the pin).
* `scripts/e2e-docker-start` — add the `USE_LOCAL_BRANCH_METADATA` toggle (mirroring `e2e-k3s-start.sh`) so the docker path (a11y) also uses the pin.

### Technical notes
The three e2e files (branches-metadata + the two start scripts) are a **temporary CI unblock** for the upstream `head` regression — revert once `rancher/rancher:head` is fixed. The unit-test mock fix is the change meant to stay.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
