### PR TITLE
Validate the namespace name

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -27,6 +27,20 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
       .checkExists();
   });
 
+  // Issue 16894: create button should be disabled unless name is filled in
+  it('create namespace screen should only enable Create once the name is filled in', () => {
+    projectsNamespacesPage.createNamespaceButton().click();
+    createNamespacePage.resourceDetail().createEditView()
+      .createButton()
+      .expectToBeDisabled();
+    createNamespacePage.resourceDetail().createEditView().nameNsDescription()
+      .name()
+      .set('test-1234');
+    createNamespacePage.resourceDetail().createEditView()
+      .createButton()
+      .expectToBeEnabled();
+  });
+
   describe('Project creation', () => {
     beforeEach(() => {
       cy.createE2EResourceName('proj').as('projectName');

--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -27,20 +27,6 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
       .checkExists();
   });
 
-  // Issue 16894: create button should be disabled unless name is filled in
-  it('create namespace screen should only enable Create once the name is filled in', () => {
-    projectsNamespacesPage.createNamespaceButton().click();
-    createNamespacePage.resourceDetail().createEditView()
-      .createButton()
-      .expectToBeDisabled();
-    createNamespacePage.resourceDetail().createEditView().nameNsDescription()
-      .name()
-      .set('test-1234');
-    createNamespacePage.resourceDetail().createEditView()
-      .createButton()
-      .expectToBeEnabled();
-  });
-
   describe('Project creation', () => {
     beforeEach(() => {
       cy.createE2EResourceName('proj').as('projectName');

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -269,6 +269,42 @@ describe('component: CruResource', () => {
     expect(footer.exists()).toBe(shouldRender);
   });
 
+  it.each([
+    ['disable', false, true],
+    ['enable', true, false],
+  ])('should %s the save button when validationPassed is %s', (_label, validationPassed, expected) => {
+    const wrapper = mount(CruResource, {
+      props: {
+        canYaml:  false,
+        mode:     _CREATE,
+        resource: {},
+        validationPassed
+      },
+      global: {
+        mocks: {
+          $store: {
+            getters: {
+              currentStore:              () => 'current_store',
+              'current_store/schemaFor': jest.fn(),
+              'current_store/all':       jest.fn(),
+              'i18n/t':                  jest.fn(),
+              'i18n/exists':             jest.fn(),
+            },
+            dispatch: jest.fn(),
+          },
+          // No `as` param, so the form is shown rather than the yaml editor
+          $route:  { query: {} },
+          $router: { applyQuery: jest.fn() },
+        },
+      }
+    });
+
+    const saveButton = wrapper.find('.cru-resource-footer [data-testid="form-save"]');
+
+    expect(saveButton.attributes('disabled') !== undefined).toBe(expected);
+    expect(saveButton.attributes('aria-disabled')).toStrictEqual(`${ expected }`);
+  });
+
   it('should not prevent default events on keypress Enter', async() => {
     const event = { preventDefault: jest.fn() };
     const wrapper = mount(CruResource, {

--- a/shell/edit/__tests__/namespace.test.ts
+++ b/shell/edit/__tests__/namespace.test.ts
@@ -1,6 +1,9 @@
 import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
 import Namespace from '@shell/edit/namespace.vue';
 import ContainerResourceLimit from '@shell/components/ContainerResourceLimit.vue';
+import CruResource from '@shell/components/CruResource.vue';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 
 describe('view Namespace should', () => {
   it('retrieve resource limits from project', () => {
@@ -46,5 +49,97 @@ describe('view Namespace should', () => {
     const limitsUi = wrapper.findComponent<typeof ContainerResourceLimit>('[data-testid="namespace-container-resource-limit"]');
 
     expect(limitsUi.props().value).toStrictEqual(limits);
+  });
+});
+
+describe('edit Namespace name validation should', () => {
+  const store = {
+    getters: {
+      'i18n/t':               (key: string) => key,
+      'management/all':       () => ([]),
+      'management/schemaFor': () => false,
+      currentCluster:         { id: 'local' },
+      currentProduct:         jest.fn(),
+      defaultNamespace:       'default',
+      isStandaloneHarvester:  false
+    }
+  };
+
+  // vee-validate debounces form-level schema validation, so microtasks alone
+  // aren't enough to see the result.
+  const settle = async() => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushPromises();
+  };
+
+  const mountNamespace = async(name: string | undefined, mode = _CREATE) => {
+    const wrapper = mount(Namespace, {
+      props: {
+        mode,
+        value: {
+          metadata:     { name },
+          listLocation: {},
+        }
+      },
+
+      global: {
+        mocks: {
+          $fetchState: {},
+          $route:      {
+            name:  'anything',
+            query: {}
+          },
+          $router: { applyQuery: {} },
+          $store:  store
+        },
+
+        provide: { store },
+
+        stubs: {
+          // Required to render the slot content, which holds the name field
+          CruResource: {
+            props:    ['validationPassed', 'errors'],
+            template: '<div><slot></slot></div>'
+          },
+          ResourceTabs: true,
+        },
+      },
+    });
+
+    // vee-validate validates on mount, asynchronously
+    await settle();
+
+    return wrapper;
+  };
+
+  it.each([
+    ['a missing name', undefined, false],
+    ['an empty name', '', false],
+    ['a valid name', 'my-namespace', true],
+  ])('resolve form validity for %s', async(_label, name, expected) => {
+    const wrapper = await mountNamespace(name);
+
+    expect(wrapper.getComponent(CruResource).props('validationPassed')).toBe(expected);
+  });
+
+  it('become valid once a name is typed in', async() => {
+    const wrapper = await mountNamespace('');
+
+    await wrapper.find('[data-testid="NameNsDescriptionNameInput"]').setValue('my-namespace');
+    await settle();
+
+    expect(wrapper.getComponent(CruResource).props('validationPassed')).toBe(true);
+  });
+
+  it('allow saving an existing namespace in edit mode', async() => {
+    const wrapper = await mountNamespace('my-namespace', _EDIT);
+
+    expect(wrapper.getComponent(CruResource).props('validationPassed')).toBe(true);
+  });
+
+  it('keep the name error out of the generic error banner', async() => {
+    const wrapper = await mountNamespace(undefined);
+
+    expect(wrapper.getComponent(CruResource).props('errors')).toStrictEqual([]);
   });
 });

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -1,8 +1,14 @@
 <script>
-import { mapGetters } from 'vuex';
+import { computed } from 'vue';
+import { mapGetters, useStore } from 'vuex';
+import { useForm } from 'vee-validate';
+import { toTypedSchema } from '@vee-validate/zod';
+import * as z from 'zod';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { useI18n } from '@shell/composables/useI18n';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 import { MANAGEMENT } from '@shell/config/types';
 import { CONTAINER_DEFAULT_RESOURCE_LIMIT, PROJECT } from '@shell/config/labels-annotations';
 import ContainerResourceLimit from '@shell/components/ContainerResourceLimit';
@@ -35,6 +41,20 @@ export default {
 
   mixins:       [CreateEditView],
   inheritAttrs: false,
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const { field } = zodValidators(t);
+
+    // Keys match the field names the inputs register under.
+    const validationSchema = toTypedSchema(z.object({ name: field('nameNsDescription.name.label').required() }));
+
+    const { errors } = useForm({ validationSchema });
+    const isFormValid = computed(() => Object.keys(errors.value).length === 0);
+
+    return { isFormValid };
+  },
 
   async fetch() {
     if (this.$store.getters['management/schemaFor'](MANAGEMENT.PROJECT)) {
@@ -172,7 +192,7 @@ export default {
     :mode="mode"
     :resource="value"
     :subtypes="[]"
-    :validation-passed="true"
+    :validation-passed="isFormValid"
     :errors="errors"
     :apply-hooks="applyHooks"
     @error="e=>errors = e"
@@ -185,6 +205,7 @@ export default {
       :namespaced="false"
       :mode="mode"
       :extra-columns="['project-col']"
+      name-field-name="name"
     >
       <template
         v-if="flatView && isCreate"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds validation to the namespace name.

Fixes #16894
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Cover namespace name validation with an e2e test
- Require a namespace name before enabling Create

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Validation uses the existing `zodValidators(t).field(...).required()` helper, consistent with other migrated forms.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Cluster Explorer → Projects/Namespaces → Create Namespace, both from a project row and from the top-level Create button. Create should be disabled until a name is typed, and the required message should appear on the name field, not in the banner
- When editing an existing namespace, save should be enabled straight away; clearing the name field shouldn't be possible/should not break the form

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The validation behavior of other cru resource forms that might rely on the namespace should not change.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/36dbb231-7cf6-4d1a-96d2-a69822948c2d

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
