### PR TITLE
Make the Tabbed tablist own only its tabs

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -321,7 +321,7 @@ export class WorkloadsCreatePageBasePo extends BaseDetailPagePo {
    * @returns po for vertical tabs used to configure nth container
    */
   nthContainerTabs(containerIndex: number) {
-    this.horizontalTabs().clickTabWithSelector(`>ul>li:nth-child(${ containerIndex + 3 })`);
+    this.horizontalTabs().clickTabWithSelector(`> .tabs > .tab-list > li:nth-child(${ containerIndex + 3 })`);
 
     return new TabbedPo(`[data-testid="workload-container-tabs-${ containerIndex }"]`);
   }

--- a/shell/components/Tabbed/__tests__/index.test.ts
+++ b/shell/components/Tabbed/__tests__/index.test.ts
@@ -83,4 +83,79 @@ describe('component: Tabbed', () => {
 
     expect(findTabNav(wrapper).exists()).toBe(true);
   });
+
+  describe('tablist structure', () => {
+    const twoTabs = {
+      components: { Tab },
+      template:   `
+        <Tab name="tab1" label="Tab 1" />
+        <Tab name="tab2" label="Tab 2" />
+      `,
+    };
+
+    it('should render the tab wrappers as presentational children of the tablist', async() => {
+      const wrapper = mount(Tabbed, {
+        slots:  { default: twoTabs },
+        global: { ...defaultGlobalMountOptions },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      const children = Array.from(findTabNav(wrapper).element.children)
+        .map((el) => `${ el.tagName.toLowerCase() }[role=${ el.getAttribute('role') }]`);
+
+      expect(children).toStrictEqual(['li[role=presentation]', 'li[role=presentation]']);
+    });
+
+    it('should render every tab as a role="tab" inside the tablist', async() => {
+      const wrapper = mount(Tabbed, {
+        slots:  { default: twoTabs },
+        global: { ...defaultGlobalMountOptions },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(findTabNav(wrapper).findAll('[role="tab"]')).toHaveLength(2);
+    });
+
+    it('should render the add/remove footer outside of the tablist', async() => {
+      const wrapper = mount(Tabbed, {
+        props:  { sideTabs: true, showTabsAddRemove: true },
+        slots:  { default: twoTabs },
+        global: { ...defaultGlobalMountOptions },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="tab-list-add"]').exists()).toBe(true);
+      expect(findTabNav(wrapper).find('[data-testid="tab-list-add"]').exists()).toBe(false);
+    });
+
+    it('should render the tab-row-extras slot outside of the tablist', async() => {
+      const wrapper = mount(Tabbed, {
+        slots: {
+          default:          twoTabs,
+          'tab-row-extras': '<div class="tablist-controls"><button type="button">Add container</button></div>',
+        },
+        global: { ...defaultGlobalMountOptions },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.tablist-controls').exists()).toBe(true);
+      expect(findTabNav(wrapper).find('.tablist-controls').exists()).toBe(false);
+    });
+
+    it('should render the empty side tabs placeholder outside of the tablist', async() => {
+      const wrapper = mount(Tabbed, {
+        props:  { sideTabs: true },
+        global: { ...defaultGlobalMountOptions },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.tab.disabled').exists()).toBe(true);
+      expect(findTabNav(wrapper).element.children).toHaveLength(0);
+    });
+  });
 });

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -340,58 +340,63 @@ export default {
     }"
     :data-testid="componentTestid"
   >
-    <ul
+    <div
       v-if="!hideTabs"
-      ref="tablist"
-      role="tablist"
       class="tabs"
       :class="{'clearfix':!sideTabs, 'vertical': sideTabs, 'horizontal': !sideTabs, 'remove-borders': removeBorders}"
-      :data-testid="`${componentTestid}-block`"
-      tabindex="0"
-      @keydown.right.prevent="selectNext(1)"
-      @keydown.left.prevent="selectNext(-1)"
-      @keydown.down.prevent="selectNext(1)"
-      @keydown.up.prevent="selectNext(-1)"
     >
-      <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
-      <li
-        v-for="tab in sortedTabs"
-        :id="tab.name"
-        :key="tab.name"
-        :data-testid="tab.name"
-        :class="{tab: true, active: tab.active, disabled: tab.disabled, error: (tab.error)}"
+      <ul
+        ref="tablist"
+        role="tablist"
+        class="tab-list"
+        :data-testid="`${componentTestid}-block`"
+        tabindex="0"
+        @keydown.right.prevent="selectNext(1)"
+        @keydown.left.prevent="selectNext(-1)"
+        @keydown.down.prevent="selectNext(1)"
+        @keydown.up.prevent="selectNext(-1)"
       >
-        <a
-          :id="`tab-${tab.name}`"
-          :ref="(el) => { if (el) tabRefs[tab.name] = el; }"
-          :data-testid="`btn-${tab.name}`"
-          :aria-controls="tab.name"
-          :aria-selected="tab.active"
-          :aria-label="tab.labelDisplay || ''"
-          role="tab"
-          :tabindex="tab.active ? '0' : '-1'"
-          @click.prevent="select(tab.name, $event)"
-          @keyup.enter.space="select(tab.name, $event)"
+        <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
+        <li
+          v-for="tab in sortedTabs"
+          :id="tab.name"
+          :key="tab.name"
+          :data-testid="tab.name"
+          role="presentation"
+          :class="{tab: true, active: tab.active, disabled: tab.disabled, error: (tab.error)}"
         >
-          <i
-            v-if="tab.labelIcon"
-            :class="`tab-label-icon icon ${tab.labelIcon}`"
-          />
-          <span>
-            {{ tab.labelDisplay }}
-          </span>
-          <span
-            v-if="tab.badge"
-            class="tab-badge"
-          >{{ tab.badge }}</span>
-          <i
-            v-if="hasErrorIcon(tab)"
-            v-clean-tooltip="tab.errorIconTooltip || t('validation.tab')"
-            class="conditions-alert-icon icon-error"
-          />
-        </a>
-      </li>
-      <li
+          <a
+            :id="`tab-${tab.name}`"
+            :ref="(el) => { if (el) tabRefs[tab.name] = el; }"
+            :data-testid="`btn-${tab.name}`"
+            :aria-controls="tab.name"
+            :aria-selected="tab.active"
+            :aria-label="tab.labelDisplay || ''"
+            role="tab"
+            :tabindex="tab.active ? '0' : '-1'"
+            @click.prevent="select(tab.name, $event)"
+            @keyup.enter.space="select(tab.name, $event)"
+          >
+            <i
+              v-if="tab.labelIcon"
+              :class="`tab-label-icon icon ${tab.labelIcon}`"
+            />
+            <span>
+              {{ tab.labelDisplay }}
+            </span>
+            <span
+              v-if="tab.badge"
+              class="tab-badge"
+            >{{ tab.badge }}</span>
+            <i
+              v-if="hasErrorIcon(tab)"
+              v-clean-tooltip="tab.errorIconTooltip || t('validation.tab')"
+              class="conditions-alert-icon icon-error"
+            />
+          </a>
+        </li>
+      </ul>
+      <div
         v-if="sideTabs && !sortedTabs.length"
         class="tab disabled"
       >
@@ -399,7 +404,7 @@ export default {
           href="#"
           @click.prevent
         >(None)</a>
-      </li>
+      </div>
       <ul
         v-if="sideTabs && showTabsAddRemove"
         class="tab-list-footer"
@@ -427,7 +432,7 @@ export default {
         </li>
       </ul>
       <slot name="tab-row-extras" />
-    </ul>
+    </div>
     <div
       :class="{
         'tab-container': !!tabs.length || !!sideTabs,
@@ -469,16 +474,24 @@ export default {
 }
 
 .tabs {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+  .tab-list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: inherit;
 
-  &:focus-visible {
-    outline: none;
+    &:focus-visible {
+      outline: none;
 
-    .tab.active {
-      @include focus-outline;
-      outline-offset: -2px;
+      .tab.active {
+        @include focus-outline;
+        outline-offset: -2px;
+      }
+    }
+
+    &:focus .tab.active a span {
+      text-decoration: underline;
     }
   }
 
@@ -506,10 +519,6 @@ export default {
     .tab.active {
       border-bottom: solid 2px var(--active, var(--primary));
     }
-  }
-
-  &:focus .tab.active a span {
-    text-decoration: underline;
   }
 
   .tab {
@@ -655,7 +664,7 @@ export default {
     .tab-list-footer {
       list-style: none;
       padding: 0;
-      margin-top: auto;
+      margin: auto 0 0;
       z-index: z-index('default');
 
       li {

--- a/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
+++ b/shell/detail/__tests__/__snapshots__/fleet.cattle.io.bundle.test.ts.snap
@@ -2,16 +2,18 @@
 
 exports[`view: fleet.cattle.io.bundle should render resources when bundle deployments exist 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
-  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" tabindex="0">
-    <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
-    <li id="resources" data-testid="resources" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
-        <!--v-if--><span>Resources</span>
-        <!--v-if-->
-        <!--v-if-->
-      </a></li>
+  <div class="tabs clearfix horizontal">
+    <ul role="tablist" class="tab-list" data-testid="tabbed-block" tabindex="0">
+      <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
+      <li id="resources" data-testid="resources" role="presentation" class="tab active"><a id="tab-resources" data-testid="btn-resources" aria-controls="resources" aria-selected="true" aria-label="Resources" role="tab" tabindex="0">
+          <!--v-if--><span>Resources</span>
+          <!--v-if-->
+          <!--v-if-->
+        </a></li>
+    </ul>
     <!--v-if-->
     <!--v-if-->
-  </ul>
+  </div>
   <div class="tab-container">
     <!-- This is where "normal" tab content goes... -->
     <section id="resources" aria-hidden="false" role="tabpanel" aria-labelledby="tab-resources" style="">
@@ -30,11 +32,13 @@ exports[`view: fleet.cattle.io.bundle should render the bundle detail page 1`] =
 
 exports[`view: fleet.cattle.io.bundle should render the bundle detail page with full mount 1`] = `
 <div class="tabbed-container resource-tabs view" data-testid="tabbed">
-  <ul role="tablist" class="tabs clearfix horizontal" data-testid="tabbed-block" tabindex="0">
-    <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
+  <div class="tabs clearfix horizontal">
+    <ul role="tablist" class="tab-list" data-testid="tabbed-block" tabindex="0">
+      <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
+    </ul>
     <!--v-if-->
     <!--v-if-->
-  </ul>
+  </div>
   <div class="">
     <!-- This is where "normal" tab content goes... -->
     <section id="resources" aria-hidden="true" role="tabpanel" aria-labelledby="tab-resources" style="display: none;">

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -662,7 +662,7 @@ export default {
           </Tabbed>
         </Tab>
         <template #tab-row-extras>
-          <li class="tablist-controls">
+          <div class="tablist-controls">
             <button
               v-if="!isView"
               type="button"
@@ -672,7 +672,7 @@ export default {
             >
               <i class="icon icon-plus pr-5" /> {{ t('workload.container.addContainer') }}
             </button>
-          </li>
+          </div>
         </template>
       </Tabbed>
     </CruResource>

--- a/storybook/src/stories/Components/Tab.stories.ts
+++ b/storybook/src/stories/Components/Tab.stories.ts
@@ -193,11 +193,11 @@ export const Slots: Story = {
           <div name="Pod">Pod tab content.</div>
         </Tab>
         <template #tab-row-extras>
-          <li class="tablist-controls">
+          <div class="tablist-controls">
             <button type="button" class="btn-sm mt-5" >
               Create
             </button>
-          </li>
+          </div>
         </template>
       </Tabbed>
     `,

--- a/storybook/src/stories/foundation/FormComponentNested.stories.ts
+++ b/storybook/src/stories/foundation/FormComponentNested.stories.ts
@@ -99,9 +99,9 @@ export const Template: Story = {
             </Tab>
           </FieldArray>
             <template #tab-row-extras>
-              <li class="tablist-controls">
+              <div class="tablist-controls">
                 <button @click="push({ name: '', image: '' })">Add container</button>
-              </li>
+              </div>
             </template>
         </Tabbed>
         <br />

--- a/storybook/src/stories/foundation/FormCompositionNested.stories.ts
+++ b/storybook/src/stories/foundation/FormCompositionNested.stories.ts
@@ -107,9 +107,9 @@ const Template: Story = {
       </Tab>
 
       <template #tab-row-extras>
-        <li class="tablist-controls">
+        <div class="tablist-controls">
           <button @click="addContainer({ name: '', image: '' })">Add container</button>
-        </li>
+        </div>
       </template>
     </Tabbed>
     ${ displayValidation() }


### PR DESCRIPTION
### Summary
Fixes #19004

### Occurred changes and/or fixed issues
- Tab `<li>` wrappers carry `role="presentation"`.
- The add/remove footer, empty placeholder and `tab-row-extras` slot moved out of the tablist into a wrapper `<div class="tabs">`.
- `tab-row-extras` consumers pass a `<div>` not an `<li>`.
- One Cypress selector re-anchored on the tablist.
- Unit tests assert the tablist owns only tabs.

### Technical notes summary
- `role="presentation"` alone, as the issue proposes, the footer and slot buttons become direct tablist children instead.
- `.tab-list-footer` needs an explicit zero bottom margin; nested in a `<ul>` it inherited the user agent `ul ul` reset.

### Areas or cases that should be tested
- Deployment create: "Add Container" still sits inline at the end of the tab row.
- Additional Redactions: "(None)" above the plus/minus buttons, still pinned to the bottom.
- Keyboard: focus the tab strip; arrow keys move selection and the focus ring lands on the active tab.
- Light and dark mode.

### Areas which could experience regressions
- Every tabbed page, since `.tabs` moved from the `<ul>` onto a wrapper `<div>`.
- Extensions filling `tab-row-extras` with an `<li>` now render it outside a list. It still displays; a `<div>` is correct.
- Cypress `allTabs()` still resolves. `nthContainerTabs` used `>ul>li` and is re-anchored.

### Screenshot/Video
Deployment create tab row, master left. Every tab is pixel identical, only "Add Container" shifts 4px left:

![tab row](https://github.com/user-attachments/assets/3c80b5cd-dbc7-476b-bb5c-757a23950d8c)

Side tabs with the add/remove footer and the "(None)" placeholder. Pixel identical:

![side tabs](https://github.com/user-attachments/assets/07b2c05f-ce96-4d3e-b110-3092ae263833)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
