### PR TITLE
test(e2e): drop temporary rancher image pin — restore head + 2.16 master metadata

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,12 +9,12 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
+          "tag": "head"
         },
         "rancher-agent": {
           "namespace": "rancher",
           "name": "rancher-agent",
-          "tag": "v2.16-4cd8c7dc70df3224ce27171ab1efe8194207f6aa-head"
+          "tag": "head"
         },
         "runtime-rancher-version": "2.15.0",
         "helm": {

--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -16,7 +16,7 @@
           "name": "rancher-agent",
           "tag": "head"
         },
-        "runtime-rancher-version": "2.16.0",
+        "runtime-rancher-version": "2.15.0",
         "helm": {
           "repo-url": "https://charts.optimus.rancher.io/server-charts/release-2.16"
         },

--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -16,9 +16,9 @@
           "name": "rancher-agent",
           "tag": "head"
         },
-        "runtime-rancher-version": "2.15.0",
+        "runtime-rancher-version": "2.16.0",
         "helm": {
-          "repo-url": "https://charts.optimus.rancher.io/server-charts/release-2.15"
+          "repo-url": "https://charts.optimus.rancher.io/server-charts/release-2.16"
         },
         "kube": {
           "version": "v1.35.2+k3s1"

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -13,7 +13,7 @@ RANCHER_IMG_REGISTRY=
 RANCHER_IMG_NAMESPACE=rancher
 RANCHER_IMG_NAME=rancher
 
-USE_LOCAL_BRANCH_METADATA=true # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+USE_LOCAL_BRANCH_METADATA=false # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
 
 # Host port mapping (configurable to avoid conflicts, e.g. with MCP Gateway on port 80)
 RANCHER_HOST_HTTP_PORT=${RANCHER_HOST_HTTP_PORT:-80}

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -5,7 +5,7 @@
 # ----------------------- Input
 # ---------------------------------
 
-USE_LOCAL_BRANCH_METADATA=true # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
+USE_LOCAL_BRANCH_METADATA=false # branch_metadata usually just comes from `master`. if there are dependent changes in a PR and the local version is needed toggle this to `true`
 KUBE_TYPE=${KUBE_TYPE:-K3S} # K3S or K3D
 OVERRIDE_UIS=${OVERRIDE_UIS:-true} # use UI bits supplied externally (e.g. by CI) rather than the built in UI bits
 TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}


### PR DESCRIPTION
### Summary
_No issue — CI/e2e infrastructure change._

Drops the **temporary** `rancher/rancher` e2e image pin added in https://github.com/rancher/dashboard/pull/19018 (which unblocked CI after `head` builds broke the jailer). The floating `head` build is healthy again — validated by this branch's hourly probe runs — so this restores normal operation: the `master` e2e tracks `rancher:head` and reads its config from `master`'s `branches-metadata.json` again.

### Occurred changes and/or fixed issues
- `branches-metadata.json` (`master` block e2e):
  - `rancher-image` / `rancher-agent` tag: pinned `v2.16-4cd8c7d…-head` → floating **`head`**.
  - `helm.repo-url`: `server-charts/release-2.15` → **`server-charts/release-2.16`** (per review — the chart repo must match the 2.16 line the e2e server runs against). The separate `release-2.15` block's own `helm.repo-url` is intentionally left at `release-2.15`.
  - `runtime-rancher-version` is **kept at `2.15.0`** (see Technical notes) — not bumped to the milestone.
- `scripts/e2e-k3s-start.sh` and `scripts/e2e-docker-start`: `USE_LOCAL_BRANCH_METADATA` `true` → **`false`**, so the e2e reads `branches-metadata.json` from `master` again (the pin had forced it to read the PR-local copy).

### Technical notes summary
- **Why `runtime-rancher-version` stays `2.15.0`:** it feeds the Cypress `RANCHER_VERSION` (via `extract-e2e-runtime-rancher-version`, which always reads the local file). The docs-link e2e (`edit-fake-cluster.spec.ts`) cross-checks that against the dashboard's hardcoded `CURRENT_RANCHER_VERSION` in `shell/config/version.js` (`'2.15'`). So `runtime-rancher-version` must track that constant, not the milestone (`v2.16.0`); it should move to `2.16.0` only when the dashboard code does. `helm.repo-url` is a separate axis (the Rancher server's chart source) and correctly matches the 2.16 line.
- With `USE_LOCAL_BRANCH_METADATA=false`, this PR's **own** e2e cluster setup reads master's `branches-metadata.json` (still the pinned build until this merges), so it runs against the pinned image and is expected to stay green. Floating-`head` health was validated by this branch's earlier probe runs (with the flag `true`). Merging flips `master` to `head`, and all subsequent runs pick it up.
- The regression that motivated the pin (`head` after `4cd8c7d` broke the jailer — `error running the jail command: exit status 1`) is resolved upstream.

### Areas or cases that should be tested
- The Tests (e2e) workflow on this PR completes green (running against master's metadata).
- After merge: a `master` e2e run pulls `rancher/rancher:head` and converges (no jailer error) and charts install from `server-charts/release-2.16`.

### Areas which could experience regressions
- e2e infrastructure only — no product/UI code changes. Risk is confined to CI: if a fresh `head` build regresses again, `master` e2e would break and the pin would need reinstating.

### Screenshot/Video
N/A — CI/e2e configuration change, no UI.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
