### PR TITLE
[#11329] Fix Alt-hold cluster reveal stuck after focus loss

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -395,12 +395,13 @@ export default {
       return this.productFromRoute === obj?.value;
     },
 
-    handleKeyComboClick() {
-      if (!this.isCurrRouteClusterExplorer) {
-        return;
-      }
-
-      this.routeCombo = !this.routeCombo;
+    // Alt/Option "keep context" reveal (issue 11329). `v-shortkey.hold` reports the raw modifier as
+    // ABSOLUTE state (`detail.held` true on keydown, false on keyup) and force-releases on window blur /
+    // tab hide, so this just mirrors it onto `routeCombo`. The old `.push` modifier toggled instead, which
+    // desynced (stuck on, then inverted) whenever a key edge was missed while focus was elsewhere, e.g.
+    // clicking the URL bar or alt-tabbing away.
+    onRouteComboHold(e) {
+      this.routeCombo = e.detail.held;
     },
 
     clusterMenuClick(ev, cluster) {
@@ -716,7 +717,7 @@ export default {
                 >
                   <button
                     v-if="c.ready"
-                    v-shortkey.push="{windows: ['alt'], mac: ['option']}"
+                    v-shortkey.hold="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`pinned-menu-cluster-${ c.id }`"
                     class="cluster selector option"
                     :class="{'active-menu-link': c.isMenuActive }"
@@ -724,7 +725,7 @@ export default {
                     role="button"
                     :aria-label="`${t('nav.ariaLabel.cluster')} ${ c.label }`"
                     @click.prevent="clusterMenuClick($event, c)"
-                    @shortkey="handleKeyComboClick"
+                    @shortkey="onRouteComboHold"
                   >
                     <ClusterIconMenu
                       v-clean-tooltip="getTooltipConfig(c, true)"
@@ -795,7 +796,7 @@ export default {
                 >
                   <button
                     v-if="c.ready"
-                    v-shortkey.push="{windows: ['alt'], mac: ['option']}"
+                    v-shortkey.hold="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`menu-cluster-${ c.id }`"
                     class="cluster selector option"
                     :class="{'active-menu-link': c.isMenuActive }"
@@ -803,7 +804,7 @@ export default {
                     role="button"
                     :aria-label="`${t('nav.ariaLabel.cluster')} ${ c.label }`"
                     @click="clusterMenuClick($event, c)"
-                    @shortkey="handleKeyComboClick"
+                    @shortkey="onRouteComboHold"
                   >
                     <ClusterIconMenu
                       v-clean-tooltip="getTooltipConfig(c, true)"

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -837,43 +837,45 @@ describe('topLevelMenu', () => {
       });
     });
 
-    describe('handleKeyComboClick', () => {
-      it('should not toggle routeCombo when route is a non-explorer c-cluster route', async() => {
-        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          global: {
-            mocks: {
-              $route:  { name: 'c-cluster-fleet', params: { cluster: 'local', product: 'fleet' } },
-              $router: { push: jest.fn() },
-              $store:  { ...generateStore([]) }
-            },
-            stubs: ['BrandImage', 'router-link'],
-          }
-        });
+    // Alt/Option "keep context" reveal (issue 11329): routeCombo tracks the raw modifier with ABSOLUTE
+    // sets (keydown -> true, keyup -> false) and is forced off on any focus/visibility loss, so a missed
+    // key edge can never leave it stuck on or invert its next press.
+    // Alt/Option "keep context" reveal (issue 11329): routeCombo mirrors the ABSOLUTE state reported by
+    // the `v-hold-key` directive via its `holdkey` event (held on keydown, cleared on keyup / focus loss),
+    // so it can never desync or invert the way the old `v-shortkey.push` toggle did. The keydown/keyup/
+    // focus-loss detection itself is covered by the hold-key plugin's own tests.
+    describe('routeCombo (Alt/Option reveal)', () => {
+      const mountMenu = () => mount(TopLevelMenu, {
+        global: {
+          mocks: {
+            $route:  { name: 'c-cluster-explorer', params: { cluster: 'local', product: 'explorer' } },
+            $router: { push: jest.fn() },
+            $store:  { ...generateStore([]) }
+          },
+          stubs: ['BrandImage', 'router-link'],
+        }
+      }) as Wrapper<InstanceType<typeof TopLevelMenu>>;
+
+      it('mirrors the holdkey event detail onto routeCombo, absolutely (never toggles)', async() => {
+        const wrapper = mountMenu();
 
         await waitForIt();
 
         expect(wrapper.vm.routeCombo).toBe(false);
-        wrapper.vm.handleKeyComboClick();
-        expect(wrapper.vm.routeCombo).toBe(false);
-      });
 
-      it('should toggle routeCombo when route is cluster explorer', async() => {
-        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          global: {
-            mocks: {
-              $route:  { name: 'c-cluster-explorer', params: { cluster: 'local', product: 'explorer' } },
-              $router: { push: jest.fn() },
-              $store:  { ...generateStore([]) }
-            },
-            stubs: ['BrandImage', 'router-link'],
-          }
-        });
-
-        await waitForIt();
-
-        expect(wrapper.vm.routeCombo).toBe(false);
-        wrapper.vm.handleKeyComboClick();
+        wrapper.vm.onRouteComboHold({ detail: { held: true } } as CustomEvent);
         expect(wrapper.vm.routeCombo).toBe(true);
+
+        // A repeated held:true event keeps it on rather than flipping it off (the old toggle bug).
+        wrapper.vm.onRouteComboHold({ detail: { held: true } } as CustomEvent);
+        expect(wrapper.vm.routeCombo).toBe(true);
+
+        wrapper.vm.onRouteComboHold({ detail: { held: false } } as CustomEvent);
+        expect(wrapper.vm.routeCombo).toBe(false);
+
+        // A stray held:false (e.g. the directive's focus-loss release) can't invert it back on.
+        wrapper.vm.onRouteComboHold({ detail: { held: false } } as CustomEvent);
+        expect(wrapper.vm.routeCombo).toBe(false);
       });
     });
 

--- a/shell/plugins/__tests__/shortkey.test.ts
+++ b/shell/plugins/__tests__/shortkey.test.ts
@@ -1,0 +1,75 @@
+import { _internal } from '@shell/plugins/shortkey';
+
+const {
+  mapFunctions, handleHoldKeydown, handleHoldKeyup, releaseHeldKeys
+} = _internal;
+
+// The `.hold` modifier (issue 11329): a held binding reports ABSOLUTE state via the `shortkey` event's
+// `detail.held` (true on keydown, false on keyup / focus loss) and never preventDefaults, so it can't
+// desync or invert the way the old `.push` toggle did. The document listeners are disabled under
+// NODE_ENV=test, so these drive the extracted handlers directly against the shared registry.
+describe('shortkey .hold modifier', () => {
+  let el: HTMLElement;
+  let held: Array<boolean>;
+
+  const registerHold = (key = 'alt') => {
+    el = document.createElement('button');
+    held = [];
+    el.addEventListener('shortkey', (e) => held.push((e as CustomEvent).detail.held));
+    mapFunctions[key] = {
+      hold: true, held: false, key: 'windows', propagte: false, el: [el]
+    };
+  };
+
+  beforeEach(() => {
+    // Isolate each test from the shared module-level registry.
+    Object.keys(mapFunctions).forEach((k) => delete mapFunctions[k]);
+  });
+
+  it('dispatches held:true on keydown and held:false on keyup — absolute, never toggling', () => {
+    registerHold();
+
+    expect(handleHoldKeydown('alt')).toBe(true);
+    expect(held).toStrictEqual([true]);
+
+    // Auto-repeat / a re-press after a missed keyup stays held: no duplicate event, no flip off.
+    handleHoldKeydown('alt');
+    expect(held).toStrictEqual([true]);
+
+    expect(handleHoldKeyup('alt')).toBe(true);
+    expect(held).toStrictEqual([true, false]);
+
+    // A stray keyup with no matching keydown must not invert it back on (the old toggle bug).
+    handleHoldKeyup('alt');
+    expect(held).toStrictEqual([true, false]);
+  });
+
+  it('releases held bindings on focus loss (blur / tab hide)', () => {
+    registerHold();
+
+    handleHoldKeydown('alt');
+    expect(held).toStrictEqual([true]);
+
+    releaseHeldKeys();
+    expect(held).toStrictEqual([true, false]);
+
+    // Nothing held any more — releasing again is a no-op.
+    releaseHeldKeys();
+    expect(held).toStrictEqual([true, false]);
+  });
+
+  it('ignores non-hold bindings and unknown keys', () => {
+    el = document.createElement('button');
+    held = [];
+    el.addEventListener('shortkey', (e) => held.push((e as CustomEvent).detail?.held));
+    mapFunctions['x'] = {
+      hold: false, once: true, key: '', propagte: false, el: [el]
+    };
+
+    expect(handleHoldKeydown('x')).toBe(false);
+    expect(handleHoldKeyup('x')).toBe(false);
+    expect(handleHoldKeydown('unknown')).toBe(false);
+    expect(handleHoldKeyup('unknown')).toBe(false);
+    expect(held).toStrictEqual([]);
+  });
+});

--- a/shell/plugins/__tests__/shortkey.test.ts
+++ b/shell/plugins/__tests__/shortkey.test.ts
@@ -1,8 +1,17 @@
 import { _internal } from '@shell/plugins/shortkey';
 
 const {
-  mapFunctions, handleHoldKeydown, handleHoldKeyup, releaseHeldKeys
+  handleHoldKeydown, handleHoldKeyup, releaseHeldKeys
 } = _internal;
+
+// shortkey.js is untyped, so `_internal.mapFunctions` widens to `{}` and can't be string-indexed. Describe
+// the one binding shape these tests register (field names, incl. the source's `propagte` spelling, kept
+// verbatim) so the registry reads/writes are typed rather than implicit `any`.
+type ShortkeyBinding = {
+  hold?: boolean; held?: boolean; once?: boolean; push?: boolean; focus?: boolean;
+  key?: string; propagte?: boolean; el?: HTMLElement[];
+};
+const mapFunctions = _internal.mapFunctions as Record<string, ShortkeyBinding>;
 
 // The `.hold` modifier (issue 11329): a held binding reports ABSOLUTE state via the `shortkey` event's
 // `detail.held` (true on keydown, false on keyup / focus loss) and never preventDefaults, so it can't

--- a/shell/plugins/__tests__/shortkey.test.ts
+++ b/shell/plugins/__tests__/shortkey.test.ts
@@ -1,8 +1,6 @@
 import { _internal } from '@shell/plugins/shortkey';
 
-const {
-  handleHoldKeydown, handleHoldKeyup, releaseHeldKeys
-} = _internal;
+const { handleHoldKeydown, handleHoldKeyup, releaseHeldKeys } = _internal;
 
 // shortkey.js is untyped, so `_internal.mapFunctions` widens to `{}` and can't be string-indexed. Describe
 // the one binding shape these tests register (field names, incl. the source's `propagte` spelling, kept

--- a/shell/plugins/shortkey.js
+++ b/shell/plugins/shortkey.js
@@ -24,6 +24,10 @@ const parseValue = (value) => {
 
 const bindValue = (value, el, binding, vnode) => {
   const push = binding.modifiers.push === true;
+  // `hold` reveals while the key is held: it reports ABSOLUTE state (detail.held true on keydown, false on
+  // keyup / focus loss) and never preventDefaults, so it can't swallow a bare modifier like Alt. This is
+  // the reliable replacement for `push`, whose toggle-on-both-edges desynced on focus loss (issue 11329).
+  const hold = binding.modifiers.hold === true;
   const avoid = binding.modifiers.avoid === true;
   const focus = !binding.modifiers.focus === true;
   const once = binding.modifiers.once === true;
@@ -36,7 +40,7 @@ const bindValue = (value, el, binding, vnode) => {
     objAvoided.push(el);
   } else {
     mappingFunctions({
-      b: value, push, once, focus, propagte, el: vnode.el
+      b: value, push, once, focus, propagte, hold, el: vnode.el
     });
   }
 };
@@ -199,6 +203,78 @@ const dispatchShortkeyEvent = (pKey) => {
   }
 };
 
+// --- hold modifier (issue 11329) ---
+
+// Dispatch the `shortkey` event carrying ABSOLUTE state in `detail.held`, so a hold consumer assigns state
+// directly (no toggle). Mirrors dispatchShortkeyEvent's propagate / last-element targeting.
+const dispatchHoldEvent = (pKey, held) => {
+  const fn = mapFunctions[pKey];
+
+  if (!fn) {
+    return;
+  }
+
+  const makeEvent = () => {
+    const e = new CustomEvent('shortkey', { detail: { held }, bubbles: false });
+
+    if (fn.key) {
+      e.srcKey = fn.key;
+    }
+
+    return e;
+  };
+
+  if (!fn.propagte) {
+    fn.el[fn.el.length - 1].dispatchEvent(makeEvent());
+  } else {
+    fn.el.forEach((elmItem) => elmItem.dispatchEvent(makeEvent()));
+  }
+};
+
+// A hold binding observes only: it NEVER preventDefaults (so a bare modifier like Alt keeps its native
+// behaviour) and does no focus handling. Returns true when `decodedKey` is a hold binding, so the caller
+// skips the normal shortkey path.
+const handleHoldKeydown = (decodedKey) => {
+  const fn = mapFunctions[decodedKey];
+
+  if (!fn || !fn.hold) {
+    return false;
+  }
+  if (!fn.held) {
+    fn.held = true;
+    dispatchHoldEvent(decodedKey, true);
+  }
+
+  return true;
+};
+
+const handleHoldKeyup = (decodedKey) => {
+  const fn = mapFunctions[decodedKey];
+
+  if (!fn || !fn.hold) {
+    return false;
+  }
+  if (fn.held) {
+    fn.held = false;
+    dispatchHoldEvent(decodedKey, false);
+  }
+
+  return true;
+};
+
+// Focus / visibility loss releases every held binding: once focus leaves the page the keyup that would
+// clear it never arrives, so this is the reliable release.
+const releaseHeldKeys = () => {
+  Object.keys(mapFunctions).forEach((k) => {
+    const fn = mapFunctions[k];
+
+    if (fn.hold && fn.held) {
+      fn.held = false;
+      dispatchHoldEvent(k, false);
+    }
+  });
+};
+
 ShortKey.keyDown = (pKey) => {
   if ((!mapFunctions[pKey].once && !mapFunctions[pKey].push) || (mapFunctions[pKey].push && !keyPressed)) {
     dispatchShortkeyEvent(pKey);
@@ -209,6 +285,12 @@ if (process && process.env && process.env.NODE_ENV !== 'test') {
   (function() {
     document.addEventListener('keydown', (pKey) => {
       const decodedKey = ShortKey.decodeKey(pKey);
+
+      // Hold bindings observe only — handled before the avoid/preventDefault path so they never swallow
+      // the key (a bare Alt keeps its native behaviour) and aren't gated by the focus/avoid list.
+      if (handleHoldKeydown(decodedKey)) {
+        return;
+      }
 
       // Check avoidable elements
       if (availableElement(decodedKey)) {
@@ -231,6 +313,10 @@ if (process && process.env && process.env.NODE_ENV !== 'test') {
     document.addEventListener('keyup', (pKey) => {
       const decodedKey = ShortKey.decodeKey(pKey);
 
+      if (handleHoldKeyup(decodedKey)) {
+        return;
+      }
+
       if (availableElement(decodedKey)) {
         if (!mapFunctions[decodedKey].propagte) {
           pKey.preventDefault();
@@ -242,23 +328,36 @@ if (process && process.env && process.env.NODE_ENV !== 'test') {
       }
       keyPressed = false;
     }, true);
+
+    // A hold reveal must clear when focus leaves the page — the keyup that would release it never arrives
+    // once focus moves away (clicking the URL bar, alt-tabbing).
+    window.addEventListener('blur', releaseHeldKeys);
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        releaseHeldKeys();
+      }
+    });
   })();
 }
 
 const mappingFunctions = ({
-  b, push, once, focus, propagte, el
+  b, push, once, focus, propagte, hold, el
 }) => {
   for (const key in b) {
     const k = ShortKey.encodeKey(b[key]);
-    const elm = mapFunctions[k] && mapFunctions[k].el ? mapFunctions[k].el : [];
-    const propagated = mapFunctions[k] && mapFunctions[k].propagte;
+    const existing = mapFunctions[k];
+    const elm = existing && existing.el ? existing.el : [];
+    const propagated = existing && existing.propagte;
 
     elm.push(el);
     mapFunctions[k] = {
       push,
       once,
       focus,
+      hold,
       key,
+      // Preserve any in-progress held state across a re-bind so a re-render mid-hold doesn't reset it.
+      held:     existing ? existing.held : false,
       propagte: propagated || propagte,
       el:       elm
     };
@@ -280,3 +379,9 @@ const isActiveElementChildOf = (container) => {
 };
 
 export default ShortKey;
+
+// Exposed for unit tests — the global keydown/keyup listeners above are disabled under NODE_ENV=test, so
+// tests drive the hold logic through these directly (mapFunctions is the registry the directive fills).
+export const _internal = {
+  mapFunctions, handleHoldKeydown, handleHoldKeyup, releaseHeldKeys, dispatchHoldEvent
+};


### PR DESCRIPTION
### Summary
Fixes #11329

Holding Alt/Option over the cluster list reveals a "jump" icon that lets you switch cluster while staying on your current page (the "keep context" switch). That reveal could get **stuck on, then inverted**, when focus left the page while the key was held — e.g. clicking the browser URL bar or alt-tabbing away and coming back.

### Occurred changes and/or fixed issues
Root cause: the reveal was driven by `v-shortkey.push`, which fires one indistinguishable event on **both** the keydown and keyup edges, so the handler had to *toggle* `routeCombo`. A toggle only stays correct if the page receives both edges. When focus leaves the page mid-hold, the keyup lands outside the page and is never seen, so the toggle desynced: the icon stayed on, and the next Alt press flipped it the wrong way.

- `shell/plugins/shortkey.js` — add a `hold` modifier (additive; `.once`/plain paths untouched).
- `shell/components/nav/TopLevelMenu.vue` — switch the two cluster buttons from `v-shortkey.push` to `v-shortkey.hold`, and replace the toggle handler (`handleKeyComboClick`) with `onRouteComboHold(e) { this.routeCombo = e.detail.held }`.
- `shell/plugins/__tests__/shortkey.test.ts` — new tests for the `.hold` modifier.
- `shell/components/nav/__tests__/TopLevelMenu.test.ts` — replace the removed-toggle tests with coverage of the absolute-state handler.

### Technical notes summary
- The `hold` modifier reports **absolute** state: the `shortkey` event carries `detail.held` (`true` on keydown, `false` on keyup), so consumers assign state instead of toggling — it cannot desync or invert.
- Hold bindings are handled **before** the plugin's avoid/preventDefault path and **never** call `preventDefault`/`stopPropagation`, so a bare modifier like Alt keeps its native browser behaviour (it is not swallowed) and the reveal is not gated by input focus.
- `window` `blur` + `document` `visibilitychange` (hidden) release any held binding — the reliable "release" trigger, since the keyup never reaches the page once focus leaves.
- `.push` was used nowhere else in the codebase, so this change is purely additive; existing shortcuts are unaffected.

### Areas or cases that should be tested
Repro / verification:
1. Explore a cluster (be on a cluster-explorer route) with at least two ready clusters.
2. Open the side nav and hold **Alt** (Windows/Linux) or **Option** (macOS) — each cluster tile's pin icon should swap to a "jump" (keyboard_tab) icon.
3. While still holding, click the browser **URL bar** (or **alt-tab** to another app), release the key there, then return to the page.
   - Expected: the jump icon is gone; holding again shows it and releasing hides it — no stuck/inverted state.
4. Confirm a bare **Alt** still does its normal browser thing (e.g. focuses the menu bar on Windows) — it is not swallowed.
5. **Alt-click** a cluster tile still navigates to the same page in the other cluster (keep-context); a plain click still goes to that cluster's Explorer.

Automated: `yarn test:ci shell/plugins/__tests__/shortkey.test.ts shell/components/nav/__tests__/TopLevelMenu.test.ts` (33 passing).

Verified locally that unit tests pass and the app compiles/serves; the in-browser repro above should be confirmed by the reviewer/QA. The reviewer should test with a different browser.

### Areas which could experience regressions
- The shared `shortkey` plugin: the change is additive (the hold branch only affects `hold` bindings), but a smoke test of other keyboard shortcuts is worth doing — resource-list `/`, `j`/`k`, `shift+*` detail actions, `ctrl/cmd+k` search, etc. — to confirm they still fire and are not swallowed.
- The cluster side-nav "keep context" Alt-click behaviour and normal cluster navigation.

### Screenshot/Video
N/A — no visual or styling change; this is a behavioural fix. A short screen recording of the repro steps above can be attached if useful.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
