### PR TITLE
Give SortableTable's structural columns an accessible name

### DIFF
--- a/pkg/harvester-manager/config/harvester-manager.js
+++ b/pkg/harvester-manager/config/harvester-manager.js
@@ -121,10 +121,11 @@ export function init($extension, store) {
     MACHINE_POOLS,
     AGE,
     {
-      name:  'harvester',
-      label: ' ',
-      align: 'right',
-      width: 65,
+      name:                'harvester',
+      labelKey:            'harvesterManager.manage',
+      labelVisuallyHidden: true,
+      align:               'right',
+      width:               65,
     },
   ]);
   basicType([HCI.CLUSTER]);

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6700,6 +6700,8 @@ sortableTable:
     sortingIconAsc: Table header ascending sort icon
   genericGroupCheckbox: Table group selection checkbox
   genericRowCheckbox: Table row selection checkbox for item {item}
+  expandColumnHeader: Expand
+  actionsColumnHeader: Actions
   tableActionsLabel: More actions - { resource }
   tableActionsImgAlt: More actions icon
   bulkActions:
@@ -7094,6 +7096,7 @@ tableHeaders:
   effect: Effect
   endpoints: Endpoints
   expires: Expires
+  explore: Explore
   firstSeen: First Seen
   firstSeenTooltip: The time at which the event was first recorded
   flow: Flow

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -237,7 +237,11 @@ export default {
       <th
         v-if="subExpandColumn"
         :width="expandWidth"
-      />
+      >
+        <div class="content">
+          <span class="sr-only">{{ t('sortableTable.expandColumnHeader') }}</span>
+        </div>
+      </th>
       <th
         v-for="(col) in columns"
         v-show="!hasAdvancedFiltering || (hasAdvancedFiltering && col.isColVisible)"
@@ -263,6 +267,7 @@ export default {
             <span
               v-clean-html="labelFor(col)"
               class="text-no-break"
+              :class="{ 'sr-only': col.labelVisuallyHidden }"
             />
             <span
               v-if="col.subLabel"
@@ -298,10 +303,14 @@ export default {
         </div>
       </th>
       <th
-        v-if="rowActions && hasAdvancedFiltering && tableColsOptions.length"
+        v-if="rowActions"
         :width="rowActionsWidth"
       >
+        <div class="content">
+          <span class="sr-only">{{ t('sortableTable.actionsColumnHeader') }}</span>
+        </div>
         <div
+          v-if="hasAdvancedFiltering && tableColsOptions.length"
           ref="table-options"
           class="table-options-group"
         >
@@ -358,10 +367,6 @@ export default {
           </div>
         </div>
       </th>
-      <th
-        v-else-if="rowActions"
-        :width="rowActionsWidth"
-      />
     </tr>
   </thead>
 </template>
@@ -449,6 +454,11 @@ export default {
       &.sortable-table-head-element:focus-visible {
         @include focus-outline;
         outline-offset: -4px;
+      }
+
+      // Containing block for `.sr-only` header names, which would otherwise widen the page.
+      .content {
+        position: relative;
       }
 
       .table-header-container {

--- a/shell/components/SortableTable/__tests__/THead.test.ts
+++ b/shell/components/SortableTable/__tests__/THead.test.ts
@@ -1,0 +1,141 @@
+import fs from 'fs';
+import path from 'path';
+import jsyaml from 'js-yaml';
+import { shallowMount } from '@vue/test-utils';
+import THead from '@shell/components/SortableTable/THead.vue';
+import { NONE } from '@shell/components/SortableTable/selection';
+
+const NAME_COLUMN = {
+  name:     'name',
+  labelKey: 'tableHeaders.name',
+  sort:     ['nameSort'],
+};
+
+// The Explore column used to ship `label: ' '` as its accessible name. It has a real
+// one now, kept out of sight so the list looks the way it always has.
+const EXPLORE_COLUMN = {
+  name:                'explore',
+  labelKey:            'tableHeaders.explore',
+  labelVisuallyHidden: true,
+};
+
+const defaultProps = (overrides = {}) => ({
+  columns:         [NAME_COLUMN],
+  sortBy:          'name',
+  tableActions:    false,
+  rowActions:      false,
+  rowActionsWidth: 40,
+  howMuchSelected: NONE,
+  // mirrors labelFor() in SortableTable/index.vue, which prefers labelKey over label
+  labelFor:        (col: any) => (col.labelKey ? `%${ col.labelKey }%` : col.label || col.name),
+  ...overrides,
+});
+
+const mountTHead = (overrides = {}) => shallowMount(THead, { props: defaultProps(overrides) });
+
+describe('component: THead', () => {
+  it.each([
+    ['sub row expand', { subExpandColumn: true }, '%sortableTable.expandColumnHeader%'],
+    ['row actions', { rowActions: true }, '%sortableTable.actionsColumnHeader%'],
+    ['row actions with advanced filtering', {
+      rowActions: true, hasAdvancedFiltering: true, tableColsOptions: [{ label: 'Name', isTableOption: true }]
+    }, '%sortableTable.actionsColumnHeader%'],
+  ])('should give the %p column header a visually hidden name', (_label, props, expected) => {
+    const wrapper = mountTHead(props);
+    const srOnly = wrapper.findAll('th .sr-only');
+
+    expect(srOnly).toHaveLength(1);
+    expect(srOnly[0].text()).toStrictEqual(expected);
+  });
+
+  it.each([
+    ['sub row expand', { subExpandColumn: true }],
+    ['row actions', { rowActions: true }],
+    ['row actions with advanced filtering', {
+      rowActions: true, hasAdvancedFiltering: true, tableColsOptions: [{ label: 'Name', isTableOption: true }]
+    }],
+  ])('should keep the visually hidden name of %p inside a positioned element', (_label, props) => {
+    // `.content` is what the scoped style makes the containing block, so the absolutely
+    // positioned name cannot escape the list's horizontal scroller
+    const wrapper = mountTHead(props);
+
+    expect(wrapper.find('th .content > .sr-only').exists()).toBe(true);
+  });
+
+  it('should not make the cell holding the column options menu a containing block', () => {
+    const wrapper = mountTHead({
+      rowActions: true, hasAdvancedFiltering: true, tableColsOptions: [{ label: 'Name', isTableOption: true }]
+    });
+    const cells = wrapper.findAll('th');
+    const optionsCell = cells.find((th) => th.find('.table-options-group').exists());
+
+    expect(optionsCell?.find('.content > .sr-only').exists()).toBe(true);
+    expect(cells.filter((th) => th.classes('content'))).toHaveLength(0);
+  });
+
+  it.each([
+    ['without advanced filtering', {}, false],
+    // the row where the cell used to come from a different branch
+    ['with advanced filtering but no toggleable columns', { hasAdvancedFiltering: true }, false],
+    ['with advanced filtering', { hasAdvancedFiltering: true, tableColsOptions: [{ label: 'Name', isTableOption: true }] }, true],
+  ])('should render one row actions header cell %p', (_label, props, hasOptions) => {
+    const cells = mountTHead({ rowActions: true, ...props }).findAll('th');
+
+    expect(cells).toHaveLength(2);
+    expect(cells[1].find('.sr-only').text()).toStrictEqual('%sortableTable.actionsColumnHeader%');
+    expect(cells[1].find('.table-options-group').exists()).toStrictEqual(hasOptions);
+  });
+
+  it.each([
+    [true, true],
+    [false, false],
+    [undefined, false],
+  ])('should hide the header of a column declaring labelVisuallyHidden %p', (labelVisuallyHidden, hidden) => {
+    const span = mountTHead({ columns: [{ ...NAME_COLUMN, labelVisuallyHidden }] }).find('th .content > span');
+
+    // the name a screen reader gets is the same either way, it is only kept out of sight
+    expect(span.text()).toStrictEqual('%tableHeaders.name%');
+    expect(span.classes('sr-only')).toStrictEqual(hidden);
+  });
+
+  it('should keep a hidden column name inside a positioned element', () => {
+    const wrapper = mountTHead({ columns: [EXPLORE_COLUMN] });
+
+    expect(wrapper.find('th .content > .sr-only').exists()).toBe(true);
+  });
+
+  it('should leave no header cell without text a screen reader can read', () => {
+    const wrapper = mountTHead({
+      subExpandColumn: true,
+      rowActions:      true,
+      columns:         [NAME_COLUMN, EXPLORE_COLUMN],
+    });
+
+    expect(wrapper.findAll('th').map((th) => th.text())).toStrictEqual([
+      '%sortableTable.expandColumnHeader%',
+      '%tableHeaders.name%',
+      '%tableHeaders.explore%',
+      '%sortableTable.actionsColumnHeader%',
+    ]);
+  });
+});
+
+describe('translations for the named table headers', () => {
+  // The `t` mock returns `%key%` for any key, so the assertions above pass whether or not the key
+  // exists. Read the shipped translations to check these ones resolve to a real string.
+  const load = (file: string) => jsyaml.load(fs.readFileSync(path.resolve(__dirname, file), 'utf8')) as Record<string, any>;
+
+  const shell = load('../../../assets/translations/en-us.yaml');
+  const harvesterManager = load('../../../../pkg/harvester-manager/l10n/en-us.yaml');
+
+  it.each([
+    ['sortableTable.expandColumnHeader', shell.sortableTable.expandColumnHeader],
+    ['sortableTable.actionsColumnHeader', shell.sortableTable.actionsColumnHeader],
+    ['tableHeaders.explore', shell.tableHeaders.explore],
+    // names the harvester-manager column, which lives outside the file above
+    ['harvesterManager.manage', harvesterManager.harvesterManager.manage],
+  ])('should have a value for %p', (_key, value) => {
+    expect(typeof value).toStrictEqual('string');
+    expect(value.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -174,12 +174,13 @@ export function init(store) {
   };
 
   const EXPLORER = {
-    name:   'explorer',
-    label:  ' ',
-    align:  'right',
-    width:  65,
-    sort:   false,
-    search: false
+    name:                'explorer',
+    labelKey:            'tableHeaders.explore',
+    labelVisuallyHidden: true,
+    align:               'right',
+    width:               65,
+    sort:                false,
+    search:              false
   };
 
   headers(MANAGEMENT.CLUSTER, [


### PR DESCRIPTION
### Summary
Fixes #19005

### Occurred changes and/or fixed issues

- Name the sub-row expand and row actions header cells with visually hidden text.
- Add a `labelVisuallyHidden` column property, so the Explore and Manage columns can carry a real translated label in place of `label: ' '` without showing one.

### Technical notes summary

- `aria-label` on the `<th>` was the obvious alternative and does name it, but axe checks subtree text, so the reported violation keeps firing. Putting `.sr-only` on the `<th>` fails differently: the cell drops out of the table layout and collapses from 82px to 10px.
- `.sr-only` is `position: absolute`, so it needs a containing block inside the list's horizontal scroller or it widens the page. `.content` is that block. It cannot be the cell, whose options menu is positioned in viewport coordinates.

### Areas or cases that should be tested

- Cluster Management > Clusters             (Explore and row actions headers)
- Cluster Explorer > Workloads > Pods       (row actions header)
- Cluster Explorer > Storage > ConfigMaps   (row actions header)

### Areas which could experience regressions

- Every list page renders `SortableTable/THead.vue`. Column widths and header row height are unchanged everywhere, measured with and without the change.

### Screenshot/Video

**Before** - `column header.`, with no name:

https://github.com/user-attachments/assets/dbec4863-b8f3-4d2a-a052-9889ec40dcf3

**After** - the same walk, `Explore column header.`:

https://github.com/user-attachments/assets/fc866a67-fd8d-4878-adf8-a888809f77d7

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
