### PR TITLE
Update Harvester documentation URL for Rancher Prime to v1.8

### DIFF
--- a/pkg/rancher-prime/docs.ts
+++ b/pkg/rancher-prime/docs.ts
@@ -80,7 +80,7 @@ const DOC_REPLACEMENTS = [
   },
   {
     from: 'https://docs.harvesterhci.io/',
-    to:   'https://documentation.suse.com/cloudnative/virtualization/v1.3/en/introduction/overview.html'
+    to:   'https://documentation.suse.com/cloudnative/virtualization/v1.8/en/introduction/overview.html'
   },
 ];
 


### PR DESCRIPTION
### Summary
Update Harvester documentation URL for Rancher Prime to point to v1.8 ; v1.3 is a 404.

### Occurred changes and/or fixed issues
- Updated the Harvester documentation URL replacement in `pkg/rancher-prime/docs.ts` from `v1.3` to `v1.8`.

### Test
- Verified that clicking Harvester documentation links in Rancher Prime mode directs to `https://documentation.suse.com/cloudnative/virtualization/v1.8/en/introduction/overview.html`.

### Areas which could experience regressions
- None.

### Checklist
- [x] The PR template has been filled out
- [x] The PR has been self reviewed