### PR TITLE
fix: support IPv6 CIDR in isValidCIDR validator

### DIFF
--- a/shell/utils/validators/__tests__/cidr.test.ts
+++ b/shell/utils/validators/__tests__/cidr.test.ts
@@ -20,6 +20,9 @@ describe('fx: isValidCIDR', () => {
     expect(isValidCIDR('2001:db8::')).toBe(false);
     expect(isValidCIDR('2001:db8::g/32')).toBe(false);
     expect(isValidCIDR('invalid/64')).toBe(false);
+    expect(isValidCIDR('2001:db8::/32abc')).toBe(false);
+    expect(isValidCIDR('2001:db8::/ 32')).toBe(false);
+    expect(isValidCIDR('2001:db8::/0x20')).toBe(false);
   });
 });
 

--- a/shell/utils/validators/__tests__/cidr.test.ts
+++ b/shell/utils/validators/__tests__/cidr.test.ts
@@ -9,6 +9,18 @@ describe('fx: isValidCIDR', () => {
     expect(isValidCIDR('10.42.0.0/500')).toBe(false);
     expect(isValidCIDR('300.42.0.0/8')).toBe(false);
   });
+  it('should be valid for IPv6 CIDR', () => {
+    expect(isValidCIDR('2001:db8::/32')).toBe(true);
+    expect(isValidCIDR('fe80::/10')).toBe(true);
+    expect(isValidCIDR('::1/128')).toBe(true);
+    expect(isValidCIDR('::0/0')).toBe(true);
+  });
+  it('should be invalid for bad IPv6 CIDR', () => {
+    expect(isValidCIDR('2001:db8::/129')).toBe(false);
+    expect(isValidCIDR('2001:db8::')).toBe(false);
+    expect(isValidCIDR('2001:db8::g/32')).toBe(false);
+    expect(isValidCIDR('invalid/64')).toBe(false);
+  });
 });
 
 describe('fx: isValidIP', () => {

--- a/shell/utils/validators/cidr.js
+++ b/shell/utils/validators/cidr.js
@@ -7,6 +7,7 @@ export function isValidCIDR(cidr) {
     // Try IPv6 CIDR using ipaddr.js
     try {
       const [ip, prefixLen] = cidr.split('/');
+
       if (!/^\d+$/.test(prefixLen)) {
         return false;
       }

--- a/shell/utils/validators/cidr.js
+++ b/shell/utils/validators/cidr.js
@@ -3,7 +3,28 @@ import ipaddr from 'ipaddr.js';
 const validCIDRregex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(3[0-2]|2[0-9]|1[0-9]|[0-9])$/;
 
 export function isValidCIDR(cidr) {
-  return !!cidr.match(validCIDRregex);
+  if (!validCIDRregex.test(cidr)) {
+    // Try IPv6 CIDR using ipaddr.js
+    try {
+      const [ip, prefixLen] = cidr.split('/');
+      const ipObj = ipaddr.parse(ip);
+      const prefix = parseInt(prefixLen, 10);
+
+      if (ipObj instanceof ipaddr.IPv6) {
+        return prefix >= 0 && prefix <= 128;
+      }
+
+      if (ipObj instanceof ipaddr.IPv4) {
+        return prefix >= 0 && prefix <= 32;
+      }
+    } catch {
+      return false;
+    }
+
+    return false;
+  }
+
+  return true;
 }
 
 export function isValidIP(ip) {

--- a/shell/utils/validators/cidr.js
+++ b/shell/utils/validators/cidr.js
@@ -7,6 +7,9 @@ export function isValidCIDR(cidr) {
     // Try IPv6 CIDR using ipaddr.js
     try {
       const [ip, prefixLen] = cidr.split('/');
+      if (!/^\d+$/.test(prefixLen)) {
+        return false;
+      }
       const ipObj = ipaddr.parse(ip);
       const prefix = parseInt(prefixLen, 10);
 


### PR DESCRIPTION
### Summary
Fixes #9589

### Occurred changes and/or fixed issues
- `shell/utils/validators/cidr.js`: Extended `isValidCIDR` to support IPv6 CIDR notation using `ipaddr.js` for parsing. Added strict prefix validation to reject malformed inputs (e.g., `'2001:db8::/32abc'`).
- `shell/utils/validators/__tests__/cidr.test.ts`: Added 7 new test cases covering valid IPv6 CIDRs, invalid IPv6 CIDRs, and edge cases with trailing junk in prefix.

### Technical notes summary
- Uses `ipaddr.js` (already a dependency) to parse and validate IPv6 addresses
- IPv6 prefix range: 0-128, IPv4 prefix range: 0-32
- Added `/^\d+$/` regex check on prefix before `parseInt` to prevent trailing junk from being silently accepted

### Areas or cases that should be tested
- IPv4 CIDR: `10.42.0.0/8` (valid), `10.42.0.0/500` (invalid)
- IPv6 CIDR: `2001:db8::/32` (valid), `fe80::/10` (valid), `::1/128` (valid)
- Edge cases: `2001:db8::/32abc` (invalid - trailing junk), `10.0.0.0/8abc` (invalid), `10.0.0.0/ 8` (invalid - space)

### Areas which could experience regressions
- CIDR validation in network configuration forms
- IP range inputs in firewall/security group rules

### Screenshot/Video
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone (v2.16.0)
- [x] The PR has a Milestone
- [x] The changes are covered by relevant tests
- [x] I have verified the code works as intended locally