### PR TITLE
Bump qs from 6.15.2 to 6.16.0

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -70,6 +70,7 @@
     "uuid": "11.1.1",
     "@cypress/request": "4.0.1",
     "tmp": "0.2.7",
-    "webpack-dev-server": "5.2.6"
+    "webpack-dev-server": "5.2.6",
+    "qs": "6.16.0"
   }
 }

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -3766,13 +3766,6 @@ istanbul-reports@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
-  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
-  dependencies:
-    argparse "^2.0.1"
-
 js-yaml@^3.13.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
@@ -3780,6 +3773,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -4850,10 +4850,10 @@ qase-javascript-commons@~2.7.2:
     strip-ansi "^6.0.1"
     uuid "11.1.1"
 
-qs@^6.15.2, qs@~6.15.1:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
-  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+qs@6.16.0, qs@^6.15.2, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -52,7 +52,8 @@
     "uuid": "11.1.1",
     "ws": "8.21.0",
     "serialize-javascript": "7.0.5",
-    "webpack-dev-server": "5.2.6"
+    "webpack-dev-server": "5.2.6",
+    "qs": "6.16.0"
   },
   "engines": {
     "node": ">=18.0"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -8203,10 +8203,10 @@ pvutils@^1.1.3, pvutils@^1.1.5:
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
   integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
 
-qs@~6.15.1:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
-  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+qs@6.16.0, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"
@@ -8779,7 +8779,7 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
+serialize-javascript@7.0.5, serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
   integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
@@ -9590,7 +9590,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
+uuid@11.1.1, uuid@^8.3.2:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
@@ -9725,7 +9725,7 @@ webpack-dev-middleware@^7.4.2:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.15.2:
+webpack-dev-server@5.2.6, webpack-dev-server@^4.15.2:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz#3a5d41233cbb7504f814d19e59a59173fb8ae23d"
   integrity sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==
@@ -9895,7 +9895,7 @@ write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.3.1, ws@^8.18.0:
+ws@8.21.0, ws@^7.3.1, ws@^8.18.0:
   version "8.21.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
   integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
@@ -9948,4 +9948,3 @@ zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==
-

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "webpack-dev-server": "5.2.6",
     "postcss": "8.5.25",
     "@tootallnate/once": "^2.0.1",
-    "cookie": "0.7.2"
+    "cookie": "0.7.2",
+    "qs": "6.16.0"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -152,7 +152,8 @@
     "webpack-dev-server": "5.2.6",
     "postcss": "8.5.25",
     "@tootallnate/once": "^2.0.1",
-    "cookie": "0.7.2"
+    "cookie": "0.7.2",
+    "qs": "6.16.0"
   },
   "nyc": {
     "extension": [

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -10825,12 +10825,13 @@ pvutils@^1.1.3, pvutils@^1.1.5:
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
   integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
 
-qs@^6.12.3, qs@~6.15.1:
-  version "6.15.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
-  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
+qs@6.16.0, qs@^6.12.3, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
-    side-channel "^1.1.0"
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 querystring-es3@^0.2.1:
   version "0.2.1"
@@ -11455,6 +11456,14 @@ side-channel-list@^1.0.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
 
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
 side-channel-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
@@ -11484,6 +11493,17 @@ side-channel@^1.1.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
     side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7944,6 +7944,7 @@ eslint-plugin-jest@29.15.2:
 
 "eslint-plugin-local-rules@link:./eslint-plugin-local-rules":
   version "0.0.0"
+  uid ""
 
 "eslint-plugin-local-rules@link:eslint-plugin-local-rules":
   version "0.0.0"
@@ -12859,12 +12860,13 @@ qase-javascript-commons@~2.9.0:
     strip-ansi "^6.0.1"
     uuid "11.1.1"
 
-qs@^6.12.3, qs@^6.15.2, qs@~6.15.1:
-  version "6.15.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
-  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
+qs@6.16.0, qs@^6.12.3, qs@^6.15.2, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
-    side-channel "^1.1.0"
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 querystring-es3@^0.2.1:
   version "0.2.1"
@@ -13541,6 +13543,14 @@ side-channel-list@^1.0.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
 
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
 side-channel-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
@@ -13570,6 +13580,17 @@ side-channel@^1.1.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
     side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 


### PR DESCRIPTION
### Summary
Bumps `qs` from `6.15.2` to `6.16.0` across every workspace manifest (root, `shell/`, `cypress/`, `docusaurus/`) to resolve open Dependabot security alerts. No linked issue — this is a dependency security update.

### Vulnerabilities fixed
Bumping `qs` to `6.16.0` resolves the following Dependabot alert(s):

- [**Dependabot #1150**](https://github.com/rancher/dashboard/security/dependabot/1150) · **MEDIUM** — [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) / CVE-2026-82562: qs array-limit bypass via bracket-key comma parsing Vulnerable `>= 6.14.2, <= 6.15.3`, patched in `6.16.0`.
- [**Dependabot #1149**](https://github.com/rancher/dashboard/security/dependabot/1149) · **MEDIUM** — [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) / CVE-2026-82417: qs: Denial of Service via Attacker Controlled isBuffer Vulnerable `>= 2.2.5, < 6.16.0`, patched in `6.16.0`.
- [**Dependabot #1134**](https://github.com/rancher/dashboard/security/dependabot/1134) · **MEDIUM** — [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) / CVE-2026-82562: qs array-limit bypass via bracket-key comma parsing Vulnerable `>= 6.14.2, <= 6.15.3`, patched in `6.16.0`.
- [**Dependabot #1133**](https://github.com/rancher/dashboard/security/dependabot/1133) · **MEDIUM** — [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) / CVE-2026-82417: qs: Denial of Service via Attacker Controlled isBuffer Vulnerable `>= 2.2.5, < 6.16.0`, patched in `6.16.0`.
- [**Dependabot #1126**](https://github.com/rancher/dashboard/security/dependabot/1126) · **MEDIUM** — [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) / CVE-2026-82562: qs array-limit bypass via bracket-key comma parsing Vulnerable `>= 6.14.2, <= 6.15.3`, patched in `6.16.0`.
- [**Dependabot #1125**](https://github.com/rancher/dashboard/security/dependabot/1125) · **MEDIUM** — [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) / CVE-2026-82417: qs: Denial of Service via Attacker Controlled isBuffer Vulnerable `>= 2.2.5, < 6.16.0`, patched in `6.16.0`.
- [**Dependabot #1118**](https://github.com/rancher/dashboard/security/dependabot/1118) · **MEDIUM** — [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) / CVE-2026-82562: qs array-limit bypass via bracket-key comma parsing Vulnerable `>= 6.14.2, <= 6.15.3`, patched in `6.16.0`.
- [**Dependabot #1117**](https://github.com/rancher/dashboard/security/dependabot/1117) · **MEDIUM** — [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) / CVE-2026-82417: qs: Denial of Service via Attacker Controlled isBuffer Vulnerable `>= 2.2.5, < 6.16.0`, patched in `6.16.0`.

### Occurred changes and/or fixed issues
Pins `qs` to `6.16.0` via a `resolutions` entry in each `package.json` and regenerates each `yarn.lock`. Only dependency-manifest files are touched (`package.json` / `yarn.lock`); there are no application-logic changes.

### Technical notes summary
`qs` is pulled in transitively through several packages. The upgrade is enforced with a `resolutions`/override entry so every reference resolves to `6.16.0` — the first version patched for both advisories. `6.16.0` is a patch-level release within the `6.x` line, so it is semver-compatible.

### Areas or cases that should be tested
Query-string handling across the dashboard: URL params, list filtering, saved filters, and deep-linked routes. No functional change is expected — a navigation/filtering smoke test is sufficient. A Playwright verification recording is attached in the Screenshot/Video section below.

### Areas which could experience regressions
Anywhere `qs` parses or stringifies query strings — table filters, saved filters, and deep-linked routes. Risk is low given the patch-level bump within `6.x`.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/b979d124-8c98-4704-80dc-9aedc8f62b1d

**Playwright checks performed** (video recorded, 1280×800):
1. **Login + dashboard home render.** Logged into the preview as the admin user; `/dashboard/home`
   renders the "Welcome to prime" homepage with no error masthead — proves the qs bump did not break
   the build or client runtime. ✅ PASS
2. **Resource list loads with real cluster data.** Navigated to Pods on the `local` cluster
   (`c/local/explorer/pod`); the SortableTable renders **93** live pods proxied from the real Steve
   API through the preview's nginx. ✅ PASS
3. **Filter serializes state into the URL query string.** Typed `console` into the list filter; the
   URL updates to `…/pod?q=console` and the table filters from 93 → **18** matching rows — the
   query-string *stringify* half of the round-trip. ✅ PASS
4. **Query string parses back on reload.** Reloaded `…/pod?q=console` directly; the filter box is
   repopulated with `console` and the table is restored to the same **18** filtered rows — the
   query-string *parse* half of the round-trip, intact after the bump. ✅ PASS

**Verdict:** **4/4 checks passed.** With `qs` forced to 6.16.0 across all four workspaces the dashboard builds
cleanly, serves 200, loads real cluster data, and query-string-backed list filtering round-trips
(serialize → URL → parse) exactly as before — no regression from the security bump. No vulnerable
`qs` version remains in any lockfile, and the regen introduced no net-new vulnerable package (only
`side-channel@1.1.1` / `side-channel-list@1.0.1`, current and clean, as deps of qs 6.16.0).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


