### PR TITLE
Bump postcss-selector-parser from 6.1.2 to 6.1.3

### DIFF
--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -8050,17 +8050,17 @@ postcss-selector-not@^8.0.1:
     postcss-selector-parser "^7.0.0"
 
 postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.16:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.3.tgz#2fde6313429f29f63db8b417a5880907461b9ff1"
+  integrity sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss-selector-parser@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
-  integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.3.tgz#6a65f1707b330c70430267d5a0eebc16064f33c5"
+  integrity sha512-ajnd7iZnqjJDkyHNfznl/ZVO0lWqvBmQXfKKENx9/p/bEiF/L3eHwdydNUg9RXZx6xfZWOCmXmBa5oeB+YrAPQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -10620,9 +10620,9 @@ postcss-reduce-transforms@^5.1.0:
     postcss-value-parser "^4.2.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.9:
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  version "6.1.3"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.3.tgz#2fde6313429f29f63db8b417a5880907461b9ff1"
+  integrity sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12596,9 +12596,9 @@ postcss-reduce-transforms@^5.1.0:
     postcss-value-parser "^4.2.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.9:
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  version "6.1.3"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.3.tgz#2fde6313429f29f63db8b417a5880907461b9ff1"
+  integrity sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Bumps the transitive dependency `postcss-selector-parser` to resolve open Dependabot alerts for [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92) / CVE-2026-9358 — "postcss-selector-parser allows denial of service through uncontrolled AST recursion".

### Vulnerabilities fixed
Bumping `postcss-selector-parser` to `6.1.3` / `7.1.3` resolves the following Dependabot alert(s):

- [**Dependabot #1114**](https://github.com/rancher/dashboard/security/dependabot/1114) · **LOW** — [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92) / CVE-2026-9358: postcss-selector-parser allows denial of service through uncontrolled AST recursion Vulnerable `>= 6.1.0, < 6.1.3`, patched in `6.1.3`.
- [**Dependabot #1113**](https://github.com/rancher/dashboard/security/dependabot/1113) · **LOW** — [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92) / CVE-2026-9358: postcss-selector-parser allows denial of service through uncontrolled AST recursion Vulnerable `>= 6.1.0, < 6.1.3`, patched in `6.1.3`.
- [**Dependabot #1112**](https://github.com/rancher/dashboard/security/dependabot/1112) · **LOW** — [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92) / CVE-2026-9358: postcss-selector-parser allows denial of service through uncontrolled AST recursion Vulnerable `>= 6.1.0, < 6.1.3`, patched in `6.1.3`.
- [**Dependabot #1111**](https://github.com/rancher/dashboard/security/dependabot/1111) · **LOW** — [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92) / CVE-2026-9358: postcss-selector-parser allows denial of service through uncontrolled AST recursion Vulnerable `>= 7.1.0, < 7.1.3`, patched in `7.1.3`.

### Occurred changes and/or fixed issues
Regenerated lockfiles to move `postcss-selector-parser` off the vulnerable ranges:
- `yarn.lock`: `6.1.2 → 6.1.3`
- `shell/yarn.lock`: `6.1.2 → 6.1.3`
- `docusaurus/yarn.lock`: `6.1.2 → 6.1.3` **and** `7.1.1 → 7.1.3`

`storybook/yarn.lock` holds `7.0.0`, which is below the vulnerable `>= 7.1.0, < 7.1.3` range, so it is left unchanged. Only lockfiles change — no `package.json` edits, since `postcss-selector-parser` is a transitive dependency.

### Technical notes summary
`postcss-selector-parser` is a build-time dependency of the CSS toolchain (`css-loader`, cssnano's `postcss-minify-selectors` / `postcss-merge-rules`); it is not imported at runtime by `shell/` or `pkg/` source. The bump is patch/minor within each major line and is behavior-preserving.

### Areas or cases that should be tested
The production build must compile cleanly and the compiled/minified CSS must render correctly against a live cluster (styled layout, data tables, status badges, CodeMirror editors). See the verification recording below.

### Areas which could experience regressions
Any area relying on compiled/minified CSS selectors — global layout, sortable tables, status badges, and CodeMirror-based editors. Verified in the recording below.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/347949d3-5e23-46a3-ba69-ffe806016856

**Playwright checks performed** (video recorded, 1280×800):
1. **Home dashboard renders fully styled — CSS integrity.** `/dashboard/home` loaded authenticated (23 clusters listed). 511 stylesheets / 6411 CSS rules present; the compound selector `.btn.role-primary` resolves to the Rancher brand green `rgb(0, 134, 87)` with `21px` padding, and the side-nav computes `display: flex`. Proves the minified CSS loaded and compound class selectors match the DOM. ✅ PASS
2. **Cluster Explorer Pods list — styled data table + status badges.** `/dashboard/c/local/explorer/pod` returned a real 95-row table from the live cluster (no error masthead); the sortable table rendered and status badges compute a colored value `rgb(0, 112, 50)`. Confirms component-scoped selectors apply against real data. ✅ PASS
3. **YAML editor renders with syntax highlighting.** ConfigMap create form (6 styled tabs, `cursor: pointer`) → **Edit as YAML** opened a CodeMirror editor showing 15 lines of real YAML (`apiVersion: v1`) in a monospace font with syntax-highlight token color `rgb(170, 117, 159)`. The complex `.cm-*` selectors that cssnano minifies all match and apply. ✅ PASS
4. **Minified compound/pseudo selectors match the live DOM.** Scan of the compiled stylesheets found 6365 rules with selectors — 1355 compound-class, 1130 pseudo (`:hover/:not/:nth-child/...`), 3700 descendant, 3649 attribute selectors — all syntactically intact (a corrupt selector-parser AST would have dropped or mangled these). Live-DOM probes matched: `.sortable-table thead` → 1, `.badge-state` → 95, `a` → 315. Direct proof postcss-selector-parser produced correct selector output. ✅ PASS

**Verdict:** **4/4 checks passed.** The production preview built cleanly from the bumped branch and every CSS-selector-backed behavior (styled layout, data tables, status badges, the CodeMirror YAML editor, and thousands of compound/pseudo/descendant/attribute selectors) renders and applies correctly against the live cluster — the postcss-selector-parser 6.1.3 / 7.1.3 bump is behavior-preserving and safe.
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


