### PR TITLE
Restrict editing extra zones for Regional GKE clusters

### DIFF
--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -206,6 +206,15 @@ export default defineComponent({
       return this.mode === _VIEW;
     },
 
+    // GKE does not permit changing node locations on an existing regional cluster
+    extraZonesDisabled(): boolean {
+      return this.isView || (this.useRegion && !this.isNewOrUnprovisioned);
+    },
+
+    extraZonesDisabledTooltip(): string | null {
+      return !this.isView && this.extraZonesDisabled ? this.t('gke.location.extraZonesDisabledTooltip') : null;
+    },
+
     releaseChannel(): string | undefined {
       const cluster = (this.clustersResponse?.clusters || []).find((c) => c.name === this.gkeClusterName);
 
@@ -509,11 +518,12 @@ export default defineComponent({
         <Checkbox
           v-for="(zoneOpt, i) in extraZoneOptions"
           :key="i"
+          v-clean-tooltip="extraZonesDisabledTooltip"
           :label="zoneOpt.name"
           :value="locations.includes(zoneOpt.name)"
           :mode="mode"
           :data-testid="`gke-extra-zones-${zoneOpt.name}`"
-          :disabled="isView"
+          :disabled="extraZonesDisabled"
           class="extra-zone-checkbox"
           @update:value="e=>setExtraZone(e, zoneOpt.name)"
         />

--- a/pkg/gke/components/__tests__/Config.test.ts
+++ b/pkg/gke/components/__tests__/Config.test.ts
@@ -277,4 +277,71 @@ describe('gke Config', () => {
     await flushPromises();
     expect(wrapper.emitted('update:locations')?.[0]?.[0]).toStrictEqual(['us-east4-b']);
   });
+
+  it.each([
+    ['creating a zonal cluster', {
+      mode: 'create', zone: 'us-east1-b', region: '', isNewOrUnprovisioned: true
+    }, false],
+    ['creating a regional cluster', {
+      mode: 'create', zone: '', region: 'us-east1', isNewOrUnprovisioned: true
+    }, false],
+    ['editing a zonal cluster', {
+      mode: 'edit', zone: 'us-east1-b', region: '', isNewOrUnprovisioned: false
+    }, false],
+    ['editing a regional cluster', {
+      mode: 'edit', zone: '', region: 'us-east1', isNewOrUnprovisioned: false
+    }, true],
+  ])('should only allow the extra zones checkboxes to be edited for zonal clusters - %s', async(_description, props, expectedDisabled) => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Config, {
+      props: {
+        cloudCredentialId: '',
+        projectId:         'test-project',
+        ...props
+      },
+      ...setup
+    });
+
+    wrapper.setProps({ cloudCredentialId: 'abc' });
+    await flushPromises();
+
+    const extraZoneCheckboxes = wrapper.findAllComponents(Checkbox);
+
+    expect(extraZoneCheckboxes.length).toBeGreaterThan(0);
+    extraZoneCheckboxes.forEach((checkbox) => {
+      expect(checkbox.props().disabled).toBe(expectedDisabled);
+    });
+  });
+
+  it.each([
+    ['creating a regional cluster', {
+      mode: 'create', zone: '', region: 'us-east1', isNewOrUnprovisioned: true
+    }, null],
+    ['editing a zonal cluster', {
+      mode: 'edit', zone: 'us-east1-b', region: '', isNewOrUnprovisioned: false
+    }, null],
+    ['viewing a regional cluster', {
+      mode: 'view', zone: '', region: 'us-east1', isNewOrUnprovisioned: false
+    }, null],
+    ['editing a regional cluster', {
+      mode: 'edit', zone: '', region: 'us-east1', isNewOrUnprovisioned: false
+    }, 'gke.location.extraZonesDisabledTooltip'],
+  ])('should only show the extra zones disabled tooltip when editing a regional cluster - %s', async(_description, props, expectedTooltip) => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Config, {
+      props: {
+        cloudCredentialId: '',
+        projectId:         'test-project',
+        ...props
+      },
+      ...setup
+    });
+
+    wrapper.setProps({ cloudCredentialId: 'abc' });
+    await flushPromises();
+
+    expect((wrapper.vm as any).extraZonesDisabledTooltip).toBe(expectedTooltip);
+  });
 });

--- a/pkg/gke/l10n/en-us.yaml
+++ b/pkg/gke/l10n/en-us.yaml
@@ -120,6 +120,7 @@ gke:
     label: Local SSD Count
   location:
     extraZones: Extra Zones
+    extraZonesDisabledTooltip: Editing node zones is available only in zonal clusters.
     region: Region
     regional: Regional
     zonal: Zonal


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13145 
<!-- Define findings related to the feature or bug issue. -->
Made 'Extra zones' not editable on provisioned regional GKE clusters matching google conole's behavior. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Provision a Regional cluster. Wait for cluster to become available. List of 'Extra zones' should not be editable and tooltip should be show.
2. Provision a Zonal cluster. Wait for cluster to become available. List of 'Extra zones' should be editable and no tooltip should be show.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None, this is very self-contained

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1806" height="951" alt="Screenshot 2026-09-03 at 2 15 52 PM" src="https://github.com/user-attachments/assets/aa3c46c6-d712-4a7c-9bf8-29321727bcd0" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
