### PR TITLE
Fix release-cypress-pkg

### DIFF
--- a/.github/workflows/release-cypress-pkg.yaml
+++ b/.github/workflows/release-cypress-pkg.yaml
@@ -36,12 +36,16 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -50,9 +54,6 @@ jobs:
       # Ensure latest npm version is installed - 11.5.1 is required to pass OIDC token to npm publish
       - name: Update npm
         run: npm install -g npm@latest
-
-      - name: Install packages
-        run: yarn install --frozen-lockfile
 
       - name: Build Cypress Package
         run: yarn build-pkg


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The publish workflow is not working: https://github.com/rancher/dashboard/actions/runs/33855419107/job/100967779879
This seems to be related to a recent setup-node bump from v6 to v7.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

v7 behavior:

When it calls `actions/setup-node` with registry-url, it creates .npmrc and enforces registry authentication immediately
Any subsequent package manager command reads the .npmrc with ${NODE_AUTH_TOKEN} placeholder
If yarn install runs before the OIDC token is available, it fails with "Failed to replace env in config"

The fix is to ensure yarn install runs before the second setup-node with registry-url, which the v7 version now strictly enforces.
We also fix the comment about the version used, the correct one is v7

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
