### PR TITLE
[Automation] - Make a matrix row state its own kind, tag and Kubernetes version

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -3,12 +3,38 @@
 //
 // Stages: Pre-Clean → Preflight → Checkout → Disk → Run Tests → Grab Results
 //   finally: Clean Test Environment → Cleanup Executor → Test Report
+//
+// Both repositories are checked out here. init.sh does no git: it turns Jenkins
+// parameters into vars.yaml and runs the playbook, the same job run.sh does for
+// a local checkout.
 
 def branch = "${env.BRANCH}" != 'null' && "${env.BRANCH}" != '' ? "${env.BRANCH}" : 'master'
 def testExecutionResult = null
 def testsTotal = 0
 def testsFailed = 0
 def testExitCode = null
+
+// The agents intermittently get HTTP 401 from github.com for these public
+// repositories, in bursts lasting minutes. Probing the agent showed curl gets
+// 200 for the same ref listing git is refused, so it is the git endpoint
+// specifically, not credentials. One cheap retry, kept only because a git
+// checkout records a revision on the build and a tarball cannot; the fallback
+// does the work, since waiting bursts out took up to eight minutes and often
+// failed anyway. The durable fix is authenticating the clones, which needs a
+// credential the controller does not have.
+def checkoutWithRetry(String what, Closure body) {
+  List pauses = [20]
+  int attempt = 0
+  retry(pauses.size() + 1) {
+    if (attempt > 0) {
+      int pause = pauses[attempt - 1]
+      echo "${what}: attempt ${attempt + 1}/${pauses.size() + 1} after a failure; pausing ${pause}s before the retry."
+      sleep time: pause, unit: 'SECONDS'
+    }
+    attempt++
+    body()
+  }
+}
 
 timeout(time: 270, unit: 'MINUTES') {
 node('harvester-vpn-1') {
@@ -53,26 +79,224 @@ node('harvester-vpn-1') {
                 '''
                 def tag = (env.VARS_YAML_CONFIG ?: '').find(/rancher_image_tag:\s*['"]?([^'"\n]+)/) { it[1] } ?: (env.RANCHER_IMAGE_TAG ?: 'unknown')
                 def cypress = (env.VARS_YAML_CONFIG ?: '').find(/cypress_tags:\s*['"]?([^'"\n]+)/) { it[1] } ?: (env.CYPRESS_TAGS ?: '')
-                def repo = (env.VARS_YAML_CONFIG ?: '').find(/rancher_helm_repo:\s*['"]?([^'"\n]+)/) { it[1] } ?: (env.RANCHER_HELM_REPO ?: 'rancher-com-rc')
-                def edition = repo.startsWith('rancher-com') || repo == 'rancher-community' ? 'community' : 'prime'
-                currentBuild.description = "${tag} · ${edition} · ${cypress}"
+                // What the row asked for, which is all that is knowable here. A
+                // metadata or prime row resolves its channel inside the
+                // playbook, so rancher_helm_repo is not written for it and
+                // reading it would report every such run as community. The
+                // build type itself is only known once Rancher is up, and the
+                // description is rewritten with it after the run.
+                def source = (env.VARS_YAML_CONFIG ?: '').find(/channel_source:\s*['"]?([^'"\n]+)/) { it[1] } ?: 'fixed'
+                def requested
+                if (source == 'fixed') {
+                  def repo = (env.VARS_YAML_CONFIG ?: '').find(/rancher_helm_repo:\s*['"]?([^'"\n]+)/) { it[1] } ?: (env.RANCHER_HELM_REPO ?: 'rancher-com-rc')
+                  requested = repo.startsWith('rancher-com') || repo == 'rancher-community' ? 'community' : 'prime'
+                } else {
+                  requested = "${source} row"
+                }
+                currentBuild.description = "${tag} · ${requested} · ${cypress}"
               }
               stage('Checkout') {
                 deleteDir()
-                checkout([
-                  $class: 'GitSCM',
-                  branches: [[name: "*/${branch}"]],
-                  extensions: scm.extensions.findAll {
-                    !(it instanceof hudson.plugins.git.extensions.impl.CleanCheckout ||
-                      it instanceof hudson.plugins.git.extensions.impl.WipeWorkspace)
-                  },
-                  userRemoteConfigs: scm.userRemoteConfigs
-                ])
-                // init.sh clones qa-infra-automation at runtime
+
+                // ORDER MATTERS. dashboard lands on $WORKSPACE, and the git
+                // plugin empties its target directory before git init, so
+                // qa-infra-automation must be fetched after it or be deleted.
+                //
+                // The refspec names one branch: the default asks for all 32.
+                def dashboardRefspec = "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+                def dashboardUrl = scm.userRemoteConfigs[0].url
+                try {
+                  checkoutWithRetry('dashboard') {
+                    checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      // Shallow and tagless: nothing here reads history. An
+                      // inherited CloneOption is dropped so this is not a
+                      // duplicate, and the clean extensions with it, since they
+                      // would take qa-infra-automation on a later build.
+                      extensions: scm.extensions.findAll {
+                        !(it instanceof hudson.plugins.git.extensions.impl.CleanCheckout ||
+                          it instanceof hudson.plugins.git.extensions.impl.CleanBeforeCheckout ||
+                          it instanceof hudson.plugins.git.extensions.impl.WipeWorkspace ||
+                          it instanceof hudson.plugins.git.extensions.impl.CloneOption)
+                      } + [[$class: 'CloneOption', shallow: true, depth: 1, noTags: true, honorRefspec: true, timeout: 5]],
+                      userRemoteConfigs: scm.userRemoteConfigs.collect { remote ->
+                        def cfg = [url: remote.url, refspec: dashboardRefspec]
+                        if (remote.credentialsId) {
+                          cfg['credentialsId'] = remote.credentialsId
+                        }
+                        cfg
+                      }
+                    ])
+                  }
+                } catch (cloneErr) {
+                  // Same fallback as below. This one extracts into $WORKSPACE,
+                  // so it extracts over the top rather than wiping first, which
+                  // would take anything already fetched beside it.
+                  //
+                  // Inline rather than a cypress/jenkins/*.sh file: this runs
+                  // because the checkout of that very repository failed, so no
+                  // script from it is on disk yet. Jenkins also asks for one
+                  // large sh step over several small ones, since only Groovy
+                  // costs the controller. See pipeline-best-practices.
+                  echo "dashboard: git checkout failed (${cloneErr}). Falling back to the source tarball."
+                  def dashSlug = dashboardUrl
+                    .replaceFirst(/^https?:\/\/github\.com\//, '')
+                    .replaceFirst(/\.git$/, '')
+                  withEnv(["DASH_SLUG=${dashSlug}", "DASH_BRANCH=${branch}"]) {
+                    sh '''#!/bin/bash
+                      set -euo pipefail
+                      # Resolve the branch to a commit first, so the fallback
+                      # records which revision it took and fetches that exact
+                      # tree, which is what a git checkout gives and a branch
+                      # tarball does not. See the qa-infra fallback below.
+                      api="https://api.github.com/repos/${DASH_SLUG}/commits/${DASH_BRANCH}"
+                      sha=$(curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+                              --max-time 60 -H 'Accept: application/vnd.github.sha' \
+                              "${api}" 2>/dev/null || true)
+                      if [[ "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                        ref="${sha}"
+                        echo "[tarball] ${DASH_BRANCH} is ${sha}"
+                      else
+                        ref="refs/heads/${DASH_BRANCH}"
+                        echo "[tarball] could not resolve a commit, taking the branch tip unpinned"
+                      fi
+                      url="https://codeload.github.com/${DASH_SLUG}/tar.gz/${ref}"
+                      echo "[tarball] GET ${url}"
+                      rm -f dashboard-src.tar.gz
+                      curl -fsSL --retry 5 --retry-delay 20 --retry-all-errors \
+                        --max-time 600 -o dashboard-src.tar.gz "${url}"
+                      # Recorded for audit, not enforced. GitHub does not
+                      # guarantee its archives are byte-stable, so a pinned hash
+                      # would break on a compression change rather than on an
+                      # attack. The commit ID below is the integrity control.
+                      echo "[tarball] sha256 $(sha256sum dashboard-src.tar.gz | cut -d" " -f1)"
+                      # git archive names the top directory <repo>-<ref>, so when
+                      # a commit was requested this proves the archive really is
+                      # that commit's tree and not another ref.
+                      listing=$(tar -tzf dashboard-src.tar.gz)
+                      first=${listing%%$'\n'*}
+                      top=${first%%/*}
+                      if [ -n "${sha}" ] && [ "${top}" != "${DASH_SLUG##*/}-${sha}" ]; then
+                        echo "[tarball] REFUSING: archive is '${top}', expected '${DASH_SLUG##*/}-${sha}'"
+                        exit 1
+                      fi
+                      [ -n "${sha}" ] && echo "[tarball] verified: archive holds the tree of ${sha}"
+                      tar -xzf dashboard-src.tar.gz --strip-components=1
+                      rm -f dashboard-src.tar.gz
+                      echo "[tarball] extracted $(find cypress/jenkins -type f 2>/dev/null | wc -l) files under cypress/jenkins"
+                    '''
+                  }
+                }
+
+                // qa-infra-automation carries the playbook. init.sh used to
+                // clone it with raw git, which meant a second retry policy to
+                // keep in step and a clone Jenkins knew nothing about.
+                def qaInfraRepo = env.QA_INFRA_REPO ?: 'https://github.com/rancher/qa-infra-automation.git'
+                def qaInfraBranch = env.QA_INFRA_BRANCH ?: 'main'
+                def qaInfraDir = 'qa-infra-automation'
+                def qaInfraPlaybook = "${qaInfraDir}/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml"
+                try {
+                  checkoutWithRetry(qaInfraDir) {
+                    // dir() rather than the RelativeTargetDirectory extension,
+                    // which the git plugin deprecates for Pipeline jobs.
+                    dir(qaInfraDir) {
+                      checkout(
+                        // Not this job's code under test, so it contributes no
+                        // changelog and must never make this job poll for it.
+                        changelog: false,
+                        poll: false,
+                        scm: [
+                          $class: 'GitSCM',
+                          branches: [[name: "*/${qaInfraBranch}"]],
+                          extensions: [
+                            [$class: 'CloneOption', shallow: true, depth: 1, noTags: true, honorRefspec: true, timeout: 5]
+                          ],
+                          userRemoteConfigs: [[
+                            url: qaInfraRepo,
+                            refspec: "+refs/heads/${qaInfraBranch}:refs/remotes/origin/${qaInfraBranch}"
+                          ]]
+                        ]
+                      )
+                    }
+                  }
+                  echo "qa-infra-automation (${qaInfraBranch}) at ${sh(script: "git -C ${qaInfraDir} rev-parse --short HEAD", returnStdout: true).trim()}"
+                } catch (cloneErr) {
+                  // Fall back to the source tarball, served by codeload over
+                  // plain HTTPS while the git endpoint refuses this agent, and a
+                  // third of the size. Nothing downstream needs the repository,
+                  // only the tree: the only git command run against it is the
+                  // rev-parse above, which is why the echo differs below.
+                  //
+                  // Twin of the dashboard fallback above and deliberately not
+                  // shared with it: that one runs when its own repository failed
+                  // to arrive, so it can reach no file, and hoisting the common
+                  // shell into a Groovy string would put a CPS local on a path
+                  // that only runs during an outage. Fix the two together.
+                  echo "qa-infra-automation: git checkout failed (${cloneErr}). Falling back to the source tarball."
+                  def slug = qaInfraRepo
+                    .replaceFirst(/^https?:\/\/github\.com\//, '')
+                    .replaceFirst(/\.git$/, '')
+                  withEnv(["QA_INFRA_SLUG=${slug}",
+                           "QA_INFRA_BRANCH_NAME=${qaInfraBranch}",
+                           "QA_INFRA_DIR_NAME=${qaInfraDir}"]) {
+                    sh '''#!/bin/bash
+                      set -euo pipefail
+                      # Resolve the branch to a commit first, so the build
+                      # records which revision it took. api.github.com is a
+                      # different endpoint from the git one refusing this
+                      # agent; if it fails the branch tip still works,
+                      # unpinned, so this can only add provenance.
+                      api="https://api.github.com/repos/${QA_INFRA_SLUG}/commits/${QA_INFRA_BRANCH_NAME}"
+                      sha=$(curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+                              --max-time 60 -H 'Accept: application/vnd.github.sha' \
+                              "${api}" 2>/dev/null || true)
+                      if [[ "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                        ref="${sha}"
+                        echo "[tarball] ${QA_INFRA_BRANCH_NAME} is ${sha}"
+                      else
+                        ref="refs/heads/${QA_INFRA_BRANCH_NAME}"
+                        echo "[tarball] could not resolve a commit, taking the branch tip unpinned"
+                      fi
+                      url="https://codeload.github.com/${QA_INFRA_SLUG}/tar.gz/${ref}"
+                      echo "[tarball] GET ${url}"
+                      rm -rf "${QA_INFRA_DIR_NAME}" "${QA_INFRA_DIR_NAME}.tar.gz"
+                      # Last resort: a failure leaves no playbook at all.
+                      curl -fsSL --retry 5 --retry-delay 20 --retry-all-errors \
+                        --max-time 300 -o "${QA_INFRA_DIR_NAME}.tar.gz" "${url}"
+                      # As above: the hash is recorded, the commit ID is what
+                      # is enforced.
+                      echo "[tarball] sha256 $(sha256sum "${QA_INFRA_DIR_NAME}.tar.gz" | cut -d" " -f1)"
+                      listing=$(tar -tzf "${QA_INFRA_DIR_NAME}.tar.gz")
+                      first=${listing%%$'\n'*}
+                      top=${first%%/*}
+                      if [ -n "${sha}" ] && [ "${top}" != "${QA_INFRA_SLUG##*/}-${sha}" ]; then
+                        echo "[tarball] REFUSING: archive is '${top}', expected '${QA_INFRA_SLUG##*/}-${sha}'"
+                        exit 1
+                      fi
+                      [ -n "${sha}" ] && echo "[tarball] verified: archive holds the tree of ${sha}"
+                      mkdir -p "${QA_INFRA_DIR_NAME}"
+                      # Strip the single <repo>-<branch>/ top directory so the
+                      # result matches the clone layout.
+                      tar -xzf "${QA_INFRA_DIR_NAME}.tar.gz" -C "${QA_INFRA_DIR_NAME}" --strip-components=1
+                      rm -f "${QA_INFRA_DIR_NAME}.tar.gz"
+                      echo "[tarball] extracted $(find "${QA_INFRA_DIR_NAME}" -type f | wc -l) files"
+                    '''
+                  }
+                  echo "qa-infra-automation (${qaInfraBranch}) from tarball, no git metadata"
+                }
+
+                // Fail here, where the cause is on screen, rather than in
+                // init.sh two stages later.
+                if (!fileExists(qaInfraPlaybook)) {
+                  error("Checkout: ${qaInfraDir} is missing the dashboard-e2e playbook after checkout.")
+                }
               }
               // In the repo, so it cannot run before Checkout.
               stage('Disk') {
-                sh 'cypress/jenkins/disk-report.sh before'
+                if (fileExists('cypress/jenkins/disk-report.sh')) {
+                  sh 'cypress/jenkins/disk-report.sh before'
+                }
               }
               stage('Run Tests') {
                 timeout(time: 180, unit: 'MINUTES') {
@@ -91,16 +315,41 @@ node('harvester-vpn-1') {
                 sh 'test -f results.xml && echo "results.xml found" || echo "results.xml not found"'
                 sh 'test -d html && echo "html/ report found" || echo "html/ report not found"'
               }
+              // Restate the description now that the run knows what it got. The
+              // Preflight version can only name what the row asked for; the
+              // playbook resolves the chart and asks the deployed Rancher which
+              // build it is, and writes both here.
+              if (fileExists('notification_values.txt')) {
+                def resolved = [:]
+                readFile('notification_values.txt').split('\n').each { line ->
+                  def kv = line.split('=', 2)
+                  if (kv.size() == 2) {
+                    resolved[kv[0].trim()] = kv[1].trim()
+                  }
+                }
+                def ranTag = resolved['RANCHER_IMAGE_TAG']
+                def ranType = resolved['RANCHER_BUILD_TYPE']
+                def ranTags = resolved['CYPRESS_TAGS']
+                if (ranTag && ranType) {
+                  currentBuild.description = "${ranTag} · ${ranType} · ${ranTags ?: ''}"
+                }
+              }
               // Always destroy infra unless CLEANUP is explicitly set to false/no/0
               def skipCleanup = "${env.CLEANUP}".toLowerCase() in ['false', 'no', '0']
               if (!skipCleanup) {
                 try {
                   stage('Clean Test Environment') {
                     timeout(time: 15, unit: 'MINUTES') {
-                      sh """#!/bin/bash
-                        set +x
-                        bash cypress/jenkins/init.sh destroy || true
-                      """
+                      // A build that failed in Checkout has no init.sh to run
+                      // and provisioned nothing to destroy.
+                      if (fileExists('cypress/jenkins/init.sh')) {
+                        sh """#!/bin/bash
+                          set +x
+                          bash cypress/jenkins/init.sh destroy || true
+                        """
+                      } else {
+                        echo 'No checkout to clean up: the build did not get past Checkout.'
+                      }
                     }
                   }
                 } catch (destroyErr) {
@@ -177,7 +426,11 @@ node('harvester-vpn-1') {
                 currentBuild.result = 'FAILURE'
               }
 
-              if (currentBuild.result != 'SUCCESS') {
+              // ABORTED is someone stopping the build on purpose, so there is
+              // nothing to report: the result is already known to whoever
+              // pressed stop, and posting it pages a channel about a decision
+              // rather than a failure.
+              if (currentBuild.result != 'SUCCESS' && currentBuild.result != 'ABORTED') {
                 if ("${env.SLACK_NOTIFICATION}".toLowerCase() != 'false') {
                   withEnv(["SLACK_BUILD_STATUS=${currentBuild.result}",
                            "TESTS_TOTAL=${testsTotal}",

--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -1,14 +1,128 @@
 #!groovy
 
-def branch = "${env.BRANCH}" != 'null' && "${env.BRANCH}" != '' ? "${env.BRANCH}" : 'master'
-def test_tags = "${env.TEST_TAGS}".split(',').collect { it.trim() }.findAll { it }
-def k8s_versions = "${env.K3S_KUBERNETES_VERSIONS}".split(',').collect { it.trim() }.findAll { it }
-def all_cypress_tags = "${env.CYPRESS_TAGS}".split('\\|').collect { it.trim() }.findAll { it }
+// Jenkinsfile_multi: parent job for the Rancher Dashboard E2E matrix.
+//
+// A row names a Rancher minor and a kind; the child resolves the channel at run
+// time, which is what lets one job cover both editions. Kinds mix freely.
+//
+//   TEST_MATRIX = "metadata:head, prime:v2.14:v1.35.2+k3s1, prime-ga:v2.13:v1.34.5+k3s1"
+//
+// | Kind          | Tag shape     | Channel comes from                          |
+// |---------------|---------------|---------------------------------------------|
+// | metadata:     | head, -head   | the branch's registry key in branches-metadata|
+// | prime:        | vX.Y          | newest Prime chart on the release ladder: an |
+// |               |               | rc or alpha once the next patch opens        |
+// | prime-head:   | vX.Y          | newest Prime head build of that minor, even  |
+// |               |               | when it has released. A different commit on  |
+// |               |               | every run, so it tests what is in flight     |
+// | prime-ga:     | vX.Y, vX.Y.Z  | shipped Prime releases only                  |
+// | community-ga: | vX.Y, vX.Y.Z  | shipped Community releases only              |
+// | community:    | head, -head   | the fixed Community channel on Docker Hub    |
+//
+// The optional third field pins Kubernetes for that row. Only a metadata: row
+// reads e2e.kube.version from the file, so pin it on every other kind or they
+// keep the base config's single value.
+//
+// Every row is crossed with CYPRESS_TAGS, so N rows and M tag sets launch N*M
+// children, in batches sized by available memory and CPU.
+
+// BRANCH is passed through to each child, not used here.
+// unique() as well as trim: a repeated tag set would otherwise multiply every
+// row by it, launching identical children on their own clusters.
+def all_cypress_tags = "${env.CYPRESS_TAGS}".split('\\|').collect { it.trim() }.findAll { it }.unique()
 def baseConfig = env.VARS_YAML_CONFIG ?: ''
 def batchSizeRaw = env.BATCH_SIZE?.trim() ?: env.MAX_CHILD_BUILDS?.trim() ?: "4"
 def estimatedRunMbRaw = env.ESTIMATED_RUN_MB?.trim() ?: "2500"
 def ramReserveMbRaw = env.RAM_RESERVE_MB?.trim() ?: "8192"
 def batchSizeCapRaw = env.BATCH_SIZE_CAP?.trim() ?: "4"
+
+// What each kind resolves to in the child. channel_source is read by
+// qa-infra-automation tasks/resolve-channel.yml; repo is only consulted when
+// the source is fixed.
+def KIND_CHANNEL = [
+    metadata:       [source: 'metadata',     repo: ''],
+    prime:          [source: 'prime',        repo: ''],
+    'prime-head':   [source: 'prime-head',   repo: ''],
+    'prime-ga':     [source: 'prime-ga',     repo: ''],
+    'community-ga': [source: 'community-ga', repo: ''],
+    community:      [source: 'fixed',        repo: 'rancher-com-rc']
+]
+
+// Kinds that name a shipped release rather than a branch head, so they take a
+// minor or a full version. The edition is part of the kind: 2.15.1 exists in
+// both channels and they are different builds.
+def GA_KINDS = ['prime-ga', 'community-ga']
+
+// Kinds that resolve a moving target from a minor, so they take a bare minor
+// and nothing else. A full version would name one build and defeat the point.
+def MINOR_KINDS = ['prime', 'prime-head']
+
+// A row is one deployment, parsed from TEST_MATRIX.
+//
+// The older TEST_TAGS + K3S_KUBERNETES_VERSIONS pair is gone. It matched
+// Kubernetes versions to tags by position, so reordering one list and not the
+// other passed the length check and silently gave every row the wrong version,
+// and it had no kind at all: the edition came from which of the two parent jobs
+// was running, which is the duplication this job removes.
+def rows = []
+def matrixSpec = env.TEST_MATRIX?.trim() ?: ''
+if (!matrixSpec) {
+    error("TEST_MATRIX is empty. Each row is kind:tag[:k8s_version], such as " +
+          "'metadata:v2.15-head' or 'prime:v2.14:v1.35.2+k3s1'. A job still " +
+          "configured with the older TEST_TAGS and K3S_KUBERNETES_VERSIONS " +
+          "pair lands here: those are replaced by TEST_MATRIX, and the job " +
+          "definition needs updating with it.")
+}
+
+matrixSpec.split(',').collect { it.trim() }.findAll { it }.each { String spec ->
+    def parts = spec.split(':').collect { it.trim() }
+    if (parts.size() < 2 || !parts[0] || !parts[1]) {
+        error("TEST_MATRIX row '${spec}' is not kind:tag[:k8s_version].")
+    }
+    String kind = parts[0]
+    String tag = parts[1]
+    // Rejoin so a future format with a ':' cannot be silently truncated.
+    String k8s = parts.size() > 2 ? parts[2..-1].join(':') : ''
+    if (!KIND_CHANNEL.containsKey(kind)) {
+        // Case and underscores are the likely slips, so name the correction
+        // rather than only the valid set. Plain string operations: a Matcher
+        // here would not survive the pipeline.
+        String guess = kind.toLowerCase().replace('_', '-')
+        String hint = KIND_CHANNEL.containsKey(guess) ? " Did you mean '${guess}'?" : ''
+        error("TEST_MATRIX row '${spec}' has unknown kind '${kind}'. Valid: ${KIND_CHANNEL.keySet().join(', ')}.${hint}")
+    }
+    // Two rows run together read as one row with a space in the tag, and the
+    // kind-specific message below would then blame the tag rather than the
+    // missing comma.
+    if (tag.contains(' ')) {
+        error("TEST_MATRIX row '${spec}': rows are separated by commas, not spaces, " +
+              "so '${tag}' was read as one tag. Add a comma between the rows.")
+    }
+    // Fail here rather than after the child has provisioned AWS.
+    if (kind in MINOR_KINDS && !(tag ==~ /^v?\d+\.\d+$/)) {
+        error("TEST_MATRIX row '${spec}': a ${kind} row needs a minor version such as v2.14, got '${tag}'.")
+    }
+    // A GA row also takes a full version, which pins one shipped release rather
+    // than tracking the newest patch of the minor.
+    if (kind in GA_KINDS && !(tag ==~ /^v?\d+\.\d+(\.\d+)?$/)) {
+        error("TEST_MATRIX row '${spec}': a ${kind} row needs a minor such as v2.15 or a full version such as v2.15.1, got '${tag}'.")
+    }
+    if (!(kind in MINOR_KINDS) && !(kind in GA_KINDS) && !(tag == 'head' || tag.endsWith('-head'))) {
+        error("TEST_MATRIX row '${spec}': a ${kind} row needs a branch head such as v2.14-head or head, got '${tag}'.")
+    }
+    // Deduplicated on the identity that decides what gets deployed, so a
+    // repeated row costs one cluster rather than two identical ones. The tag is
+    // normalised because "prime-ga:v2.14.5" and "prime-ga:2.14.5" resolve to the
+    // same chart. k8s is part of the identity: the same tag on two Kubernetes
+    // versions is two different tests, not a duplicate.
+    String identity = "${kind}:${tag.toLowerCase().replaceFirst(/^v/, '')}:${k8s}"
+    if (rows.any { it.identity == identity }) {
+        echo "TEST_MATRIX row '${spec}' repeats an earlier row, so it is only run once."
+    } else {
+        rows << [kind: kind, tag: tag, k8s: k8s, identity: identity]
+    }
+}
+
 if (!batchSizeRaw.isInteger()) {
     error("BATCH_SIZE must be a positive integer, got '${batchSizeRaw}'.")
 }
@@ -16,7 +130,7 @@ if (!estimatedRunMbRaw.isInteger()) {
     error("ESTIMATED_RUN_MB must be a positive integer, got '${estimatedRunMbRaw}'.")
 }
 if (!ramReserveMbRaw.isInteger()) {
-    error("RAM_RESERVE_MB must be a positive integer, got '${ramReserveMbRaw}'.")
+    error("RAM_RESERVE_MB must be a whole number of MB, got '${ramReserveMbRaw}'.")
 }
 if (!batchSizeCapRaw.isInteger()) {
     error("BATCH_SIZE_CAP must be a positive integer, got '${batchSizeCapRaw}'.")
@@ -25,23 +139,16 @@ def batchSize = batchSizeRaw.toInteger()
 def estimatedRunMb = estimatedRunMbRaw.toInteger()
 def ramReserveMb = ramReserveMbRaw.toInteger()
 def batchSizeCap = batchSizeCapRaw.toInteger()
-def requestedFanout = test_tags.size() * all_cypress_tags.size()
 
 // Fail early on bad parameters
 if (!baseConfig.trim()) {
     error("VARS_YAML_CONFIG is empty. Provide a valid YAML configuration.")
 }
-if (test_tags.isEmpty()) {
-    error("TEST_TAGS is empty after trimming.")
-}
-if (k8s_versions.isEmpty()) {
-    error("K3S_KUBERNETES_VERSIONS is empty after trimming.")
+if (rows.isEmpty()) {
+    error("No rows to run: TEST_MATRIX is empty after trimming.")
 }
 if (all_cypress_tags.isEmpty()) {
     error("CYPRESS_TAGS is empty after trimming.")
-}
-if (test_tags.size() != k8s_versions.size()) {
-    error("TEST_TAGS (${test_tags.size()}) and K3S_KUBERNETES_VERSIONS (${k8s_versions.size()}) must have the same number of entries.")
 }
 if (batchSize < 1) {
     error("BATCH_SIZE must be >= 1, got ${batchSize}.")
@@ -61,16 +168,96 @@ if (batchSizeCap < 1) {
     }
 }
 
-def childRuns = []
-test_tags.eachWithIndex { String rancher_version, int i ->
-    String k8s_version = k8s_versions[i]
-    for (String ct : all_cypress_tags) {
-        childRuns << [
-            rancher_version: rancher_version,
-            k8s_version:     k8s_version,
-            cypress_tags:    ct
-        ]
+// Set a top-level key in the YAML blob, replacing it when present and appending
+// it when not: a base config written before this change has no line to replace.
+def setConfigKey = { String cfg, String key, String value ->
+    boolean present = cfg.split('\n').any { it.trim().startsWith("${key}:") }
+    if (present) {
+        return cfg.replaceAll("(?m)^${key}:.*\$", "${key}: \"${value}\"")
     }
+    return cfg.trim() + "\n${key}: \"${value}\"\n"
+}
+
+// The newest GA patch a minor has in a set of chart channels, or -1 for none.
+// Returns null when a channel could not be read, which is not the same as a
+// channel with nothing in it: dropping on unreadable data would remove healthy
+// rows whenever the network hiccups. A 404 is a retired channel and counts as
+// empty, since the release team is consolidating these repositories.
+def newestGaPatch = { List channels, String minor ->
+    int best = -1
+    for (String url : channels) {
+        // One call: the HTTP status and the body, separated by a marker, so the
+        // two can never disagree about which request they describe.
+        String out = sh(
+            script: """set -o pipefail
+                       code=\$(curl -sSL -o /tmp/idx.\$\$ -w '%{http_code}' --max-time 60 --retry 2 '${url}/index.yaml' 2>/dev/null || echo 000)
+                       echo "STATUS:\${code}"
+                       grep -oE 'version: [0-9]+[.][0-9]+[.][0-9]+\$' /tmp/idx.\$\$ 2>/dev/null || true
+                       rm -f /tmp/idx.\$\$""",
+            returnStdout: true
+        ).trim()
+        // No Matcher survives past this point. Jenkins serializes the whole
+        // scope at every step, and java.util.regex.Matcher is not
+        // serializable, so holding one in a variable fails the build at the
+        // next sh() with NotSerializableException. Groovy parsing does not
+        // catch it: it is a runtime property of the CPS transform.
+        String status = '000'
+        for (String l : out.split('\n')) {
+            if (l.startsWith('STATUS:')) { status = l.substring(7).trim() }
+        }
+        if (status == '404') { continue }
+        if (status != '200') { return null }
+        String prefix = 'version: ' + minor + '.'
+        for (String l : out.split('\n')) {
+            String t = l.trim()
+            if (!t.startsWith(prefix)) { continue }
+            String patch = t.substring(prefix.length())
+            if (patch.isInteger()) { best = Math.max(best, patch.toInteger()) }
+        }
+    }
+    return best
+}
+
+// A Community minor has stopped when the newest Prime GA is ahead of the newest
+// Community GA. A recently rebuilt -head image is not evidence otherwise: head
+// images keep building after releases stop, which is how a 2.13 row stayed green
+// against a frozen image. qa-tasks#2410, and docs/jenkins.md.
+//
+// This lives in the parent, not the Ansible resolver, because it is the only
+// place that can act before the cost: the resolver runs inside a child that has
+// already provisioned AWS. The parent decides whether a row has anything behind
+// it at all; the resolver still owns which chart and image the row becomes.
+def COMMUNITY_CHANNELS = ['https://releases.rancher.com/server-charts/stable',
+                          'https://releases.rancher.com/server-charts/latest',
+                          'https://releases.rancher.com/server-charts/alpha']
+def PRIME_CHANNELS = ['https://charts.rancher.com/server-charts/prime',
+                      'https://charts.optimus.rancher.io/server-charts/latest',
+                      'https://charts.optimus.rancher.io/server-charts/alpha']
+
+def dropReason = { row ->
+    // community-ga is dropped on the same signal: a minor whose Community
+    // releases have stopped serves a frozen chart, and community 2.13.3 against
+    // Prime 2.13.9 is exactly that. A prime-ga: row is not dropped here; if the
+    // release it names is absent the child says so in seconds, before any AWS.
+    if (!(row.kind in ['community', 'community-ga'])) { return null }
+    // Same reason: extract with a replace rather than holding a Matcher.
+    String minor = row.tag.replaceFirst(/^v?([0-9]+[.][0-9]+).*$/, '$1')
+    if (!(minor ==~ /^[0-9]+[.][0-9]+$/)) { return null }
+    Integer comm = newestGaPatch(COMMUNITY_CHANNELS, minor)
+    Integer prime = newestGaPatch(PRIME_CHANNELS, minor)
+    if (comm == null || prime == null) {
+        echo "  row ${row.kind}:${row.tag}: a chart channel could not be read, keeping the row"
+        return null
+    }
+    if (comm >= 0 && prime > comm) {
+        return "Community stopped at ${minor}.${comm} while Prime is at ${minor}.${prime}"
+    }
+    // Neither edition has a release. That is a new minor, not a stopped one:
+    // 2.16 ships Community first and has no GA on either side until 2.16.1, so
+    // its Community head build is the only thing testing it. Dropping here
+    // would remove coverage from the newest minor, the exact opposite of the
+    // intent. A tag that genuinely does not exist fails in the child instead.
+    return null
 }
 
 node {
@@ -83,36 +270,104 @@ node {
         ).trim().toInteger()
         int cpuCount = sh(script: "nproc", returnStdout: true).trim().toInteger()
 
+        // Keep this between the machine facts above and the batching below: a
+        // CPS local does not survive an sh() step, so moving it fails at run
+        // time with MissingPropertyException, which parsing does not catch.
+        def dropped = []
+        def keptRows = []
+        rows.each { r ->
+          String why = dropReason(r)
+          if (why) {
+            dropped << "${r.kind}:${r.tag} (${why})"
+          } else {
+            keptRows << r
+          }
+        }
+        if (dropped) {
+          echo "Dropped ${dropped.size()} row(s) with nothing behind them:"
+          dropped.each { echo "  ${it}" }
+          currentBuild.description = ([currentBuild.description, "dropped: ${dropped.size()}"] - null).join(' | ')
+        }
+        // Rebuilt from the surviving rows rather than filtered from childRuns:
+        // childRuns is a script-scope local and reading it here is exactly the
+        // dependency that failed. This is the same product that built it.
+        def liveChildRuns = []
+        keptRows.each { r ->
+          all_cypress_tags.each { ct -> liveChildRuns << [row: r, cypress_tags: ct] }
+        }
+        if (!liveChildRuns) {
+          error("Every TEST_MATRIX row was dropped, so there is nothing to run. " +
+                "Dropped: ${dropped.join('; ')}. A stopped Community minor is still " +
+                "testable as prime-ga:<minor> or metadata:<branch head>.")
+        }
+
         int ramBound = (memAvailableMb - ramReserveMb) / estimatedRunMb
         int cpuBound = Math.max(1, cpuCount - 1)
         int staticBound = Math.min(batchSize, batchSizeCap)
-        int dynamicBatchSize = Math.min(requestedFanout, Math.max(1, Math.min(staticBound, Math.min(ramBound, cpuBound))))
+        int dynamicBatchSize = Math.min(liveChildRuns.size(), Math.max(1, Math.min(staticBound, Math.min(ramBound, cpuBound))))
 
         echo "Dynamic batching inputs: mem_available_mb=${memAvailableMb}, cpus=${cpuCount}, estimated_run_mb=${estimatedRunMb}, ram_reserve_mb=${ramReserveMb}, static_batch=${batchSize}, batch_cap=${batchSizeCap}, ram_bound=${ramBound}, cpu_bound=${cpuBound}"
-        echo "Fan-out plan: TEST_TAGS=${test_tags.size()}, CYPRESS_TAGS=${all_cypress_tags.size()}, requested=${requestedFanout}, effective_batch_size=${dynamicBatchSize}"
+        echo "Fan-out plan: rows=${keptRows.size()}, CYPRESS_TAGS=${all_cypress_tags.size()}, requested=${liveChildRuns.size()}, effective_batch_size=${dynamicBatchSize}"
+        keptRows.each { r ->
+          echo "  row ${r.kind}:${r.tag}${r.k8s ? ' (k8s ' + r.k8s + ')' : ''}"
+        }
 
         int batchNumber = 0
-        for (int offset = 0; offset < childRuns.size(); offset += dynamicBatchSize) {
+        // Child results are collected rather than propagated. propagate: false
+        // stops one failing row aborting the batch, but on its own it also lets
+        // the parent finish green while every child failed, which is a scheduled
+        // matrix reporting success having proved nothing.
+        //
+        // A plain map, not a ConcurrentHashMap: the sandbox rejects constructing
+        // one, and CPS runs parallel branches on a single thread, so distinct
+        // keys need no synchronisation.
+        def childResults = [:]
+        for (int offset = 0; offset < liveChildRuns.size(); offset += dynamicBatchSize) {
           batchNumber += 1
-          int endExclusive = Math.min(offset + dynamicBatchSize, childRuns.size())
-          def batch = new ArrayList(childRuns.subList(offset, endExclusive))
+          int endExclusive = Math.min(offset + dynamicBatchSize, liveChildRuns.size())
+          def batch = new ArrayList(liveChildRuns.subList(offset, endExclusive))
 
-          echo "Launching batch ${batchNumber}: jobs ${offset + 1}-${endExclusive} of ${childRuns.size()} (size=${batch.size()})"
+          echo "Launching batch ${batchNumber}: jobs ${offset + 1}-${endExclusive} of ${liveChildRuns.size()} (size=${batch.size()})"
 
           def batchBranches = [:]
           batch.eachWithIndex { runCfg, int idx ->
             def cfg = runCfg
             int ordinal = offset + idx + 1
-            String branchName = "child-${ordinal}-${cfg.rancher_version}-${cfg.cypress_tags}"
+            String branchName = "child-${ordinal}-${cfg.row.kind}-${cfg.row.tag}-${cfg.cypress_tags}"
 
             batchBranches[branchName] = {
+              def channel = KIND_CHANNEL[cfg.row.kind] ?: [source: 'fixed', repo: '']
               def childConfig = baseConfig
-                  .replaceAll(/(?m)^rancher_image_tag:.*$/, "rancher_image_tag: \"${cfg.rancher_version}\"")
-                  .replaceAll(/(?m)^k3s_kubernetes_version:.*$/, "k3s_kubernetes_version: \"${cfg.k8s_version}\"")
-                  .replaceAll(/(?m)^cypress_tags:.*$/, "cypress_tags: \"${cfg.cypress_tags}\"")
+              childConfig = setConfigKey(childConfig, 'rancher_image_tag', cfg.row.tag)
+              childConfig = setConfigKey(childConfig, 'cypress_tags', cfg.cypress_tags)
+              childConfig = setConfigKey(childConfig, 'channel_source', channel.source)
+              // Only a fixed row states a channel. Blank the others rather
+              // than leaving the base config's rancher-com-rc behind, which
+              // would advertise Community on a prime row the resolver then
+              // overwrites.
+              childConfig = setConfigKey(childConfig, 'rancher_helm_repo', channel.repo ?: '')
+              // A row without its own Kubernetes version leaves the base config
+              // alone, so a metadata row takes it from branches-metadata.json
+              // where that branch fills the key in, and keeps the base value
+              // where it does not.
+              if (cfg.row.k8s) {
+                childConfig = setConfigKey(childConfig, 'k3s_kubernetes_version', cfg.row.k8s)
+              }
 
-              echo "Launching child ${ordinal}/${childRuns.size()} — RANCHER_TAG=${cfg.rancher_version}, K8S_VERSION=${cfg.k8s_version}, CYPRESS_TAGS=${cfg.cypress_tags}"
-              def childBuild = build(job: 'ui-automation-ansible-job', parameters: [
+              // channel_source says how the channel is found, not which one it is:
+              // a community row resolves nothing, so it reads "fixed" and the
+              // channel itself is in the repo. Print both, or the line looks
+              // like it says nothing about the edition.
+              echo "Launching child ${ordinal}/${liveChildRuns.size()}: KIND=${cfg.row.kind}, RANCHER_TAG=${cfg.row.tag}, CHANNEL_SOURCE=${channel.source}${channel.repo ? " (repo ${channel.repo})" : ' (resolved at run time)'}, K8S_VERSION=${cfg.row.k8s ?: '(from config or metadata)'}, CYPRESS_TAGS=${cfg.cypress_tags}"
+              // Parameterised so a second copy of this matrix can run beside
+              // the real one without colliding on the same child job. The
+              // fallback names the child that exists today, so a blank
+              // parameter still targets a real job. It does not keep the old
+              // parents alive: those pass TEST_TAGS and stop at the check
+              // above, which is why their job definitions land together with
+              // this file. See docs/jenkins.md.
+              def childJob = env.CHILD_JOB?.trim() ?: 'ui-automation-ansible-job'
+              def childBuild = build(job: childJob, parameters: [
                   text(name: 'VARS_YAML_CONFIG', value: childConfig),
                   string(name: 'BRANCH', value: "${BRANCH}"),
                   string(name: 'QA_INFRA_REPO', value: "${QA_INFRA_REPO}"),
@@ -121,13 +376,30 @@ node {
                   string(name: 'SLACK_NOTIFICATION', value: "${SLACK_NOTIFICATION}"),
                   string(name: 'ANSIBLE_VERBOSITY', value: "${ANSIBLE_VERBOSITY}")
               ], propagate: false, wait: true)
-              echo "Child ${ordinal}/${childRuns.size()} finished: result=${childBuild.result}, url=${childBuild.absoluteUrl}"
+              echo "Child ${ordinal}/${liveChildRuns.size()} finished: result=${childBuild.result}, url=${childBuild.absoluteUrl}"
+              childResults[branchName] = (childBuild.result ?: 'UNKNOWN') as String
             }
           }
 
           timeout(time: 270, unit: 'MINUTES') {
             parallel batchBranches
           }
+        }
+
+        // Take the worst child result. A child that failed to start at all is
+        // recorded as UNKNOWN and counted as a failure, since a row nobody ran
+        // is not a row that passed.
+        def failed = childResults.findAll { k, v -> !(v in ['SUCCESS']) }
+        echo "Child results: ${childResults.size()} of ${liveChildRuns.size()} reported"
+        childResults.each { k, v -> echo "  ${v}  ${k}" }
+        if (childResults.size() < liveChildRuns.size()) {
+          currentBuild.result = 'FAILURE'
+          error("${liveChildRuns.size() - childResults.size()} child build(s) never reported a result.")
+        }
+        if (failed) {
+          def worst = failed.values().any { it != 'UNSTABLE' } ? 'FAILURE' : 'UNSTABLE'
+          currentBuild.result = worst
+          echo "${failed.size()} of ${childResults.size()} children did not pass, so this matrix is ${worst}."
         }
       }
     }

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #
-# Thin wrapper: clones qa-infra-automation, builds the runner image,
-# generates vars.yaml from Jenkins environment, runs the playbook in a container.
+# Builds the runner image, generates vars.yaml from the Jenkins environment,
+# runs the playbook in a container. The Jenkins-side counterpart of the
+# playbook's own run.sh.
 #
-# No tool installation needed — everything is inside the container image.
+# It does no git: the Jenkinsfile checks out both repositories.
 #
 set -euo pipefail
 trap 'echo "FAILED at line $LINENO: $BASH_COMMAND (exit $?)"' ERR
@@ -12,7 +13,6 @@ trap 'echo "FAILED at line $LINENO: $BASH_COMMAND (exit $?)"' ERR
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 JENKINS_WORKSPACE="${WORKSPACE:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
 
-QA_INFRA_REPO="${QA_INFRA_REPO:-https://github.com/rancher/qa-infra-automation.git}"
 QA_INFRA_BRANCH="${QA_INFRA_BRANCH:-main}"
 QA_INFRA_DIR="${JENKINS_WORKSPACE}/qa-infra-automation"
 PLAYBOOK_DIR="${QA_INFRA_DIR}/ansible/testing/dashboard-e2e"
@@ -22,20 +22,15 @@ LOCK_FD=""
 # Ansible verbosity: 0=normal, 1=-v, 2=-vv, etc.
 ANSIBLE_VERBOSITY="${ANSIBLE_VERBOSITY:-0}"
 
-# Clone qa-infra-automation
-clone_qa_infra() {
-  if [[ -d "${QA_INFRA_DIR}/.git" ]]; then
-    echo "[init] qa-infra-automation already present, updating..."
-    cd "${QA_INFRA_DIR}"
-    if ! git fetch origin || ! git checkout -qf "${QA_INFRA_BRANCH}" || ! git reset --hard "origin/${QA_INFRA_BRANCH}"; then
-      echo "[init] ERROR: Failed to update qa-infra-automation to branch '${QA_INFRA_BRANCH}'"
-      exit 1
-    fi
-  else
-    echo "[init] Cloning qa-infra-automation (${QA_INFRA_BRANCH})..."
-    git clone -b "${QA_INFRA_BRANCH}" "${QA_INFRA_REPO}" "${QA_INFRA_DIR}"
+# Fail early and legibly if the Checkout stage did not produce what this needs.
+require_qa_infra() {
+  if [[ ! -d "${PLAYBOOK_DIR}" ]]; then
+    echo "[init] ERROR: ${PLAYBOOK_DIR} is missing." >&2
+    echo "[init]        The Jenkinsfile Checkout stage places qa-infra-automation" >&2
+    echo "[init]        in the workspace. This script does not clone it." >&2
+    exit 1
   fi
-  echo "[init] qa-infra-automation (${QA_INFRA_BRANCH}) at $(git -C "${QA_INFRA_DIR}" rev-parse --short HEAD)"
+  echo "[init] qa-infra-automation (${QA_INFRA_BRANCH}) at ${PLAYBOOK_DIR}"
 }
 
 # Build the runner image from Dockerfile.quickstart.
@@ -43,10 +38,22 @@ clone_qa_infra() {
 # Cached rather than --no-cache: Pre-Clean removes this tag every build, so the
 # image is rebuilt regardless, and --no-cache only added a cold build plus a
 # BuildKit cache record per layer that nothing on the agent reclaims.
+#
+# Bounded: a contended agent once printed one line and then nothing for ten
+# minutes, and the only other timeout is the 180 minute one around the whole
+# run. Quiet again now that the bound exists: the build is cached on almost
+# every run, so the fifty lines of layer output said nothing a stalled build
+# does not, and `timeout` is what turns a hang into a failure, not the noise.
 build_runner_image() {
   echo "[init] Building ${RUNNER_IMAGE} image..."
-  docker build -q -f "${PLAYBOOK_DIR}/Dockerfile.quickstart" \
-    -t "${RUNNER_IMAGE}" "${PLAYBOOK_DIR}"
+  local rc=0
+  timeout 900 docker build -q -f "${PLAYBOOK_DIR}/Dockerfile.quickstart" \
+    -t "${RUNNER_IMAGE}" "${PLAYBOOK_DIR}" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    [ "${rc}" -eq 124 ] &&
+      echo "[init] ERROR: building ${RUNNER_IMAGE} exceeded 15 minutes." >&2
+    return "${rc}"
+  fi
 }
 
 # Generate vars.yaml from Jenkins environment variables
@@ -243,14 +250,20 @@ run_container() {
 
 # --- Main ---
 if [[ "${1:-}" == "destroy" ]]; then
-  clone_qa_infra
-  if ! docker image inspect "${RUNNER_IMAGE}" &>/dev/null; then
-    build_runner_image
-  fi
-
+  # Nothing is fetched here. Cleanup runs in the same build as the run that
+  # created the infrastructure, so the Jenkinsfile's checkout is still on disk.
+  # When this script did fetch, a transient github.com refusal made it exit
+  # before the destroy, leaving the run's cloud resources standing.
+  #
+  # vars.yaml is the signal that there is anything to destroy: it is written by
+  # generate_vars, so its absence means the run never provisioned.
   if [[ ! -f "${PLAYBOOK_DIR}/vars.yaml" ]]; then
     echo "[cleanup] No vars.yaml found — nothing to destroy"
     exit 0
+  fi
+
+  if ! docker image inspect "${RUNNER_IMAGE}" &>/dev/null; then
+    build_runner_image
   fi
 
   echo "[cleanup] Destroying infrastructure via playbook..."
@@ -258,7 +271,7 @@ if [[ "${1:-}" == "destroy" ]]; then
   [[ -d "${PLAYBOOK_DIR}/outputs" ]] && rm -rf "${PLAYBOOK_DIR}/outputs" 2>/dev/null || true
   echo "[cleanup] Done."
 else
-  clone_qa_infra
+  require_qa_infra
   build_runner_image
   generate_vars
 

--- a/cypress/jenkins/slack-notification.sh
+++ b/cypress/jenkins/slack-notification.sh
@@ -31,7 +31,11 @@ EOF
 	# Send the notification using Slack Web API
 	# Try-catch block to handle any errors when communicating with Slack API
 	set +e # Disable exit on error for try block
+	# Bounded: this runs in the post block, so a stalled Slack call would hold
+	# the build open against the outer timeout rather than the few seconds a
+	# notification is worth.
 	curl -X POST \
+		--connect-timeout 10 --max-time 30 --retry 2 --retry-delay 3 \
 		-H "Content-type: application/json; charset=utf-8" \
 		-H "Authorization: Bearer $bot_token" \
 		--data "$payload" \
@@ -95,6 +99,9 @@ send_jenkins_e2e_failure_notification() {
 	local rancher_image_tag=$(read_notification_value "RANCHER_IMAGE_TAG")
 	local rancher_chart_url=$(read_notification_value "RANCHER_CHART_URL")
 	local rancher_helm_repo=$(read_notification_value "RANCHER_HELM_REPO")
+	local rancher_build_type=$(read_notification_value "RANCHER_BUILD_TYPE")
+	local ui_build=$(read_notification_value "UI_BUILD")
+	local ui_source=$(read_notification_value "UI_SOURCE")
 	local cypress_tags=$(read_notification_value "CYPRESS_TAGS")
 	local kubernetes_version=$(read_notification_value "KUBERNETES_VERSION")
 	local dashboard_branch=$(read_notification_value "DASHBOARD_BRANCH")
@@ -138,6 +145,10 @@ send_jenkins_e2e_failure_notification() {
 	message+=$(append_field "Tests" "$test_summary")
 	message+=$(append_field "Rancher Version" "$rancher_version")
 	message+=$(append_field "Rancher Image" "$rancher_image_tag")
+	message+=$(append_field "Build Type" "$rancher_build_type")
+	# A run tests a backend and a UI, and on a head build the default serves the
+	# UI from the CDN rather than the image, so the pair is worth naming.
+	message+=$(append_field "UI Build" "${ui_build:+${ui_build}${ui_source:+ (from the ${ui_source})}}")
 	message+=$(append_field "K8s Version" "$kubernetes_version")
 	message+=$(append_field "Chart URL" "$rancher_chart_url")
 	message+=$(append_field "Helm Repo" "$rancher_helm_repo")


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#2410

### Occurred changes and/or fixed issues

The channel a row deploys from was a property of the job, not the row, so covering both editions needed two parent job definitions differing by one value. `TEST_MATRIX` replaces `TEST_TAGS` with rows that carry their own kind, which sets `channel_source` for the child. rancher/qa-tasks#2410.

    metadata:head, metadata:v2.14-head:v1.35.2+k3s1, prime:v2.14

- Removes `TEST_TAGS` and `K3S_KUBERNETES_VERSIONS`, which paired Kubernetes versions to tags by position, so reordering one list passed the length check and gave every row the wrong version. Rows are validated before any child launches, so a bad one fails in seconds.
- `prime-ga:` and `community-ga:` rows are added for post-release runs. `prime:` means "newest on the release ladder", so it becomes an `rc` the day the next patch opens, which is wrong for verifying a release that just shipped. The edition is part of the kind because `2.15.1` exists in both channels and they are different builds.
- A `community:` row whose minor has stopped publishing is dropped in the parent, so a meaningless run costs no AWS. The signal is the newest Prime GA being ahead of the newest Community GA. A minor with no GA on either side is new rather than stopped and is kept.
- Preflight labelled every self-resolving run as community, because it read `rancher_helm_repo`, which such a row does not set. It now names what the row asked for.
- The `Jenkinsfile` checks out both repositories, so `init.sh` runs no `git` and one retry policy replaces two. A checkout retries the intermittent `401` from github.com, then falls back to the `codeload` tarball, pinned to the resolved commit and refused if the archive does not match.

Row kinds and the resolution they trigger are documented in `qa-infra-automation`, `ansible/testing/dashboard-e2e/docs/resolver.md`.



### Areas or cases that should be tested
CI Jenkins

### Areas which could experience regressions
CI Jenkins


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
