### PR TITLE
Color Resources card relationships by their state flags

### DIFF
--- a/shell/components/Resource/Detail/Card/StateCard/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/Card/StateCard/__tests__/composables.test.ts
@@ -65,6 +65,21 @@ describe('useResourceCardRow', () => {
       expect(result.counts![1].count).toBe(1);
     });
 
+    it('should color a count with the most severe of the states it merges', () => {
+      const resources = [
+        { stateSimpleColor: 'success', stateDisplay: 'Active' },
+        { stateSimpleColor: 'error', stateDisplay: 'Active' },
+        { stateSimpleColor: 'success', stateDisplay: 'Active' }
+      ];
+
+      const result = useResourceCardRow('Pods', resources);
+
+      expect(result.counts).toHaveLength(1);
+      expect(result.counts![0]).toStrictEqual(expect.objectContaining({
+        label: 'active', count: 3, color: 'error'
+      }));
+    });
+
     it('should use default color when stateSimpleColor is undefined', () => {
       const resources = [
         { stateDisplay: 'Unknown' }
@@ -227,5 +242,72 @@ describe('useResourceCardRowFromRelationships', () => {
     expect(result.counts![0]).toStrictEqual(expect.objectContaining({
       label: 'missing', count: 2, color: 'warning'
     }));
+  });
+
+  it.each([
+    ['transitioning wins over the state name', 'unavailable', false, true, 'info'],
+    ['error wins over the state name', 'active', true, false, 'error'],
+    ['error wins over transitioning', 'active', true, true, 'error'],
+    ['neither flag leaves the state name in charge', 'unavailable', false, false, 'error'],
+  ])('should honor the relationship flags: %s', (_name, state, error, transitioning, color) => {
+    const rels = [{
+      toType: 'pod', state, error, transitioning
+    }];
+
+    const result = useResourceCardRowFromRelationships('Refers to', rels);
+
+    expect(result.color).toBe(color);
+    expect(result.counts![0]).toStrictEqual(expect.objectContaining({
+      label: state, count: 1, color
+    }));
+  });
+
+  it('should label a count with the remapped display state', () => {
+    const rels = [{ toType: 'pod', state: 'notready' }];
+
+    const result = useResourceCardRowFromRelationships('Refers to', rels);
+
+    expect(result.counts![0]).toStrictEqual(expect.objectContaining({ label: 'not ready', count: 1 }));
+  });
+
+  it.each([
+    ['warning state first', 'disabled', 'inactive'],
+    ['error state first', 'inactive', 'disabled'],
+  ])('should merge states that share a display name into one count: %s', (_name, first, second) => {
+    const rels = [
+      { toType: 'a', state: first },
+      { toType: 'b', state: second }
+    ];
+
+    const result = useResourceCardRowFromRelationships('Refers to', rels);
+
+    expect(result.counts).toHaveLength(1);
+    expect(result.counts![0]).toStrictEqual(expect.objectContaining({
+      label: 'inactive', count: 2, color: 'error'
+    }));
+  });
+
+  it.each([
+    ['errored relationship first', 'error', true, false, 'error'],
+    ['errored relationship last', 'error', false, true, 'error'],
+    ['transitioning relationship first', 'transitioning', true, false, 'success'],
+    ['transitioning relationship last', 'transitioning', false, true, 'success'],
+  ])('should color a merged count with its most severe state: %s', (_name, flag, firstFlag, secondFlag, color) => {
+    const rels = [
+      {
+        toType: 'a', state: 'active', [flag]: firstFlag
+      },
+      {
+        toType: 'b', state: 'active', [flag]: secondFlag
+      }
+    ];
+
+    const result = useResourceCardRowFromRelationships('Refers to', rels);
+
+    expect(result.counts).toHaveLength(1);
+    expect(result.counts![0]).toStrictEqual(expect.objectContaining({
+      label: 'active', count: 2, color
+    }));
+    expect(result.color).toBe(color);
   });
 });

--- a/shell/components/Resource/Detail/Card/StateCard/composables.ts
+++ b/shell/components/Resource/Detail/Card/StateCard/composables.ts
@@ -1,7 +1,7 @@
 import { Count, Props as ResourceRowProps } from '@shell/components/Resource/Detail/ResourceRow.types';
 import { isHigherAlert, StateColor } from '@shell/utils/style';
 import { RouteLocationRaw } from 'vue-router';
-import { simpleColorForState, stateDisplay as stateDisplayFn } from '@shell/plugins/dashboard-store/resource-class';
+import { simpleColorForState, stateDisplay as stateDisplayFn, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
 interface Tuple extends Count {
   color: StateColor;
@@ -32,6 +32,11 @@ export function useResourceCardRow(label: string, resources: any[], stateColorKe
     agg[state] = agg[state] || {
       color, label: state, count: 0
     };
+
+    if (isHigherAlert(color, agg[state].color)) {
+      agg[state].color = color;
+    }
+
     agg[state].count++;
   });
 
@@ -63,50 +68,20 @@ export function useResourceCardRow(label: string, resources: any[], stateColorKe
 
 /**
  * Builds a ResourceRowProps from relationship state data.
- * Each relationship entry includes a `state` field (e.g. "active", "error").
+ *
+ * Each relationship entry carries a `state` field (e.g. "active", "error")
+ * plus the `error` and `transitioning` flags, and its color is resolved from
+ * all three the same way `Resource.stateSimpleColor` resolves a resource's.
  */
 export function useResourceCardRowFromRelationships(label: string, relationships: any[], to?: RouteLocationRaw): ResourceRowProps {
-  if (!relationships.length) {
+  const resources = relationships.map((r: any) => {
+    const state = r.state || STATES_ENUM.MISSING;
+
     return {
-      label, color: undefined, counts: undefined, to
+      stateDisplay:     stateDisplayFn(state),
+      stateSimpleColor: simpleColorForState(state, r.error, r.transitioning),
     };
-  }
-
-  const agg: Record<string, { color: StateColor; label: string; count: number }> = {};
-
-  relationships.forEach((r: any) => {
-    const state = (r.state || 'missing').toLowerCase();
-    const color = simpleColorForState(state) as StateColor;
-    const display = (stateDisplayFn(state) as string)?.toLowerCase() || state;
-
-    agg[state] = agg[state] || {
-      color, label: display, count: 0
-    };
-    agg[state].count++;
   });
 
-  const tuples: Tuple[] = Object.values(agg);
-
-  tuples.sort((left: Tuple, right: Tuple) => {
-    if (isHigherAlert(left.color, right.color)) {
-      return -1;
-    }
-
-    if (left.color !== right.color) {
-      return 1;
-    }
-
-    if (left.count === right.count) {
-      return 0;
-    }
-
-    return left.count > right.count ? -1 : 1;
-  });
-
-  return {
-    label,
-    color:  tuples.length ? tuples[0].color : undefined,
-    counts: tuples.length ? tuples : undefined,
-    to
-  };
+  return useResourceCardRow(label, resources, 'stateSimpleColor', 'stateDisplay', to);
 }


### PR DESCRIPTION
### Summary
Fixes #19051

### Occurred changes and/or fixed issues

- Resolve a relationship's state color from its `error` and `transitioning` flags, not from the state name alone.
- Fold `useResourceCardRowFromRelationships` onto `useResourceCardRow` and delete its duplicate aggregate-and-sort block.
- Color a count that merges several states with the most severe of them rather than the first one seen.

### Technical notes summary

- The tab is treated as correct because `Resource.stateSimpleColor` resolves every other state in the product from these same three inputs. Changing the tab instead would agree with the card and disagree with the resource's own masthead and list row.
- The severity merge is required by the first change, not a bonus refactor. Once the flags matter one label can hold two colors, and a bucket keeping whichever it saw first re-opened this same bug: card blue, tab red, decided by the order the API returned.
- `isHigherAlert` ranks `info` below `success`, so a merged count reports an alert in preference to a transitioning member. The agreement here is per relationship, not per rolled-up count.
- Out of scope: `RelatedResources.vue` resolves a missing `state` from the store, which a composable cannot, so a stateless relationship can still differ.

### Areas or cases that should be tested

Apply this to the `local` cluster, wait for the pod to go unready, then open the ReplicaSet's detail page. Steve reports its relationship to that pod as state `unavailable` with `transitioning: true`.

<details>
<summary>Fixture: a Deployment whose pod never becomes ready</summary>

```yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: broken-nginx
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: broken-nginx
  template:
    metadata:
      labels:
        app: broken-nginx
    spec:
      containers:
        - name: nginx
          image: nginx:1.25
          readinessProbe:
            httpGet:
              path: /nope
              port: 80
            initialDelaySeconds: 2
            periodSeconds: 5
```

</details>

- Workloads > ReplicaSets > `broken-nginx-*`: the card's "Refers to" row and the "Unavailable" badge under "Refers To" must be the same blue.
- Light and dark mode: the dot and the badge take their color from different CSS variables.
- A Pod (containers row) and a Deployment (services, ingresses), which add their own rows to the same card.

### Areas which could experience regressions

- Every detail page Resources card, since both relationship rows go through the changed composable.
- The conditions, events, containers and workload service rows, which share `useResourceCardRow`.
- States sharing a display name, such as `disabled` and `inactive`, now merge into one count.

### Screenshot/Video

**Before** - the card paints the pod relationship red while the tab paints the same relationship blue:

https://github.com/user-attachments/assets/55f87e78-adf1-465e-b78b-bc32e7dee285

**After** - the same walk, with both showing blue:

https://github.com/user-attachments/assets/e9753f51-121a-44f7-8e45-dd51264df466

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

