### PR TITLE
Remove the @shell/config/version ambient shim

### DIFF
--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 553
+# Total errors: 540
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/aks/components/Config.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
 pkg/aks/components/Config.vue: error TS2532: Object is possibly 'undefined'.
@@ -12,7 +12,6 @@ pkg/aks/components/Config.vue: error TS7006: Parameter 'sn' implicitly has an 'a
 pkg/aks/components/Config.vue: error TS7006: Parameter 'v' implicitly has an 'any' type.
 pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"_validSize"' can't be used to index type 'AKSNodePool'.
 pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"_validSize"' can't be used to index type 'AKSNodePool'.
-pkg/aks/components/CruAks.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 pkg/aks/components/CruAks.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/aks/components/CruAks.vue: error TS7006: Parameter 'opt' implicitly has an 'any' type.
 pkg/aks/components/CruAks.vue: error TS7006: Parameter 'val' implicitly has an 'any' type.
@@ -63,7 +62,6 @@ pkg/gke/components/Config.vue: error TS2531: Object is possibly 'null'.
 pkg/gke/components/Config.vue: error TS2554: Expected 4 arguments, but got 5.
 pkg/gke/components/Config.vue: error TS7006: Parameter 'z' implicitly has an 'any' type.
 pkg/gke/components/CruGKE.vue: error TS2322: Type 'string | null | undefined' is not assignable to type 'string | undefined'.
-pkg/gke/components/CruGKE.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 pkg/gke/components/CruGKE.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/gke/components/CruGKE.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/gke/components/CruGKE.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
@@ -92,7 +90,6 @@ shell/apis/shell/proxy.ts: error TS2305: Module '"@shell/apis/intf/shell"' has n
 shell/apis/shell/proxy.ts: error TS2305: Module '"@shell/apis/intf/shell"' has no exported member 'ProxyRequestOptions'.
 shell/apis/shell/proxy.ts: error TS2459: Module '"@shell/apis/intf/shell"' declares 'ProxyApi' locally, but it is not exported.
 shell/components/AppModal.vue: error TS2345: Argument of type '{ role: string; 'aria-modal': "true"; style: object; class: string; id: string; ref: string; onClick: () => void; }' is not assignable to parameter of type 'HTMLAttributes & ReservedProps & Record<string, unknown>'.
-shell/components/Certificates.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<{}, {}>, {}, Data, { expiredData(): any; }, {}, ComponentOptionsMixin, ComponentOptionsMixin, ... 18 more ..., {}>'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
@@ -258,8 +255,6 @@ shell/components/__tests__/TabTitle.test.ts: error TS2540: Cannot assign to 'get
 shell/components/__tests__/TabTitle.test.ts: error TS2540: Cannot assign to 'updatePageTitle' because it is a read-only property.
 shell/components/__tests__/TabTitle.test.ts: error TS2740: Type '{ warn: Mock<any, any, any>; error: Mock<any, any, any>; }' is missing the following properties from type 'Console': assert, clear, count, countReset, and 14 more.
 shell/components/fleet/FleetClusterTargets/index.vue: error TS2345: Argument of type '{ raw: boolean; }' is not assignable to parameter of type 'boolean | undefined'.
-shell/components/fleet/FleetConfigMapSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; }>, { ...; }>, ... 24 more ..., { ...; }>'.
-shell/components/fleet/FleetSecretSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; lockedOptions: { ...; }; }>, { ...; }>, ......'.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2739: Type 'Record<string, any>' is missing the following properties from type 'HelmOpResource': spec, metadata
@@ -292,8 +287,6 @@ shell/components/form/GitPicker.vue: error TS2322: Type 'unknown' is not assigna
 shell/components/form/NodeScheduling.vue: error TS18046: 'n' is of type 'unknown'.
 shell/components/form/NodeScheduling.vue: error TS2322: Type 'string | null' is not assignable to type 'string | boolean | Record<string, any> | undefined'.
 shell/components/form/NodeScheduling.vue: error TS2554: Expected 1-2 arguments, but got 3.
-shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resourceType: { type: StringConstructor; required: true; }; context: { type: StringConstructor; default: null; }; inStore: { type: StringConstructor; default: undefined; }; paginateMode: { ...; }; allResourcesSettings: { ...; }; paginatedReso...'.
-shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resourceType: { type: StringConstructor; required: true; }; context: { type: StringConstructor; default: null; }; inStore: { type: StringConstructor; default: undefined; }; paginateMode: { ...; }; allResourcesSettings: { ...; }; paginatedReso...'.
 shell/components/form/ResourceQuota/__tests__/ResourceQuotaEntry.test.ts: error TS2322: Type '{ id: string; mode: string; types: { value: string; inputExponent: number; baseUnit: string; placeholder: string; increment: number; }[]; resourceType: string; resourceIdentifier: string; projectLimit: string; namespaceDefaultLimit: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly id: string; readonly index: number; readonly mode: string; ... 9 more ...; readonly "onUpdate:namespaceDefaultLimit"?: ((value: string | undefined) => any) | undefined; } & AllowedComponentProps & ComponentCus...'.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
@@ -342,7 +335,6 @@ shell/components/nav/NotificationCenter/Notification.vue: error TS7053: Element 
 shell/components/nav/__tests__/Group.test.ts: error TS2322: Type 'Record<string, unknown>' is not assignable to type 'Stubs | undefined'.
 shell/components/nav/__tests__/TopLevelMenu.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 shell/composables/useUserRetentionValidation.ts: error TS2769: No overload matches this call.
-shell/detail/auditlog.cattle.io.auditpolicy.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/detail/management.cattle.io.oidcclient.vue: error TS2307: Cannot find module '~shell/assets/images/key.svg' or its corresponding type declarations.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
@@ -383,8 +375,6 @@ shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exis
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
-shell/edit/auditlog.cattle.io.auditpolicy/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
-shell/edit/autoscaling.horizontalpodautoscaler/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS2322: Type '{ selected: string; } | null' is not assignable to type 'Record<string, any> | undefined'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS2345: Argument of type 'string | LocationQueryValue[]' is not assignable to parameter of type 'string'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'clusterRepoType' implicitly has an 'any' type.
@@ -392,7 +382,6 @@ shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'key' impl
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'neu' implicitly has an 'any' type.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'newVal' implicitly has an 'any' type.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'old' implicitly has an 'any' type.
-shell/edit/management.cattle.io.podsecurityadmissionconfigurationtemplate.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/list/node.vue: error TS2339: Property 'id' does not exist on type 'string'.
@@ -451,7 +440,6 @@ shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'item' implicitl
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'item' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'key' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'name' implicitly has an 'any' type.
-shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'name' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'obj' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'obj' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'resources' implicitly has an 'any' type.
@@ -474,7 +462,6 @@ shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'type' implicitl
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'type' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'value' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'value' implicitly has an 'any' type.
-shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'workspace' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'workspace' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'workspace' implicitly has an 'any' type.
 shell/pages/c/_cluster/fleet/index.vue: error TS7006: Parameter 'workspace' implicitly has an 'any' type.

--- a/shell/pages/c/_cluster/fleet/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/fleet/__tests__/index.test.ts
@@ -76,15 +76,13 @@ const requiredSetup = (computed = {}, dataProps = {}) => {
       ...computed
     },
     data: () => ({
-      presetVersion:         '1.2.3',
-      permissions:           {},
+      presetVersion:   '1.2.3',
+      permissions:     {},
       FLEET,
-      [FLEET.GIT_REPO]:      [],
-      [FLEET.HELM_OP]:       [],
-      [FLEET.CLUSTER]:       [],
-      [FLEET.CLUSTER_GROUP]: [],
-      fleetWorkspaces:       [],
-      viewModeOptions:       [
+      gitRepos:        [],
+      helmOps:         [],
+      fleetWorkspaces: [],
+      viewModeOptions: [
         {
           icon:     'icon-list-flat',
           value:    'flat',
@@ -135,8 +133,8 @@ describe('component: FleetDashboard', () => {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
         {
-          [FLEET.GIT_REPO]: gitRepos,
-          [FLEET.HELM_OP]:  helmOps,
+          gitRepos,
+          helmOps,
         }
       ),
     });
@@ -152,7 +150,7 @@ describe('component: FleetDashboard', () => {
     const wrapper = mount(Dashboard, {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
-        { [FLEET.GIT_REPO]: gitRepos }
+        { gitRepos }
       ),
     });
 
@@ -175,7 +173,7 @@ describe('component: FleetDashboard', () => {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
         {
-          [FLEET.GIT_REPO]:     gitRepos,
+          gitRepos,
           isWorkspaceCollapsed: { [workspace]: collapsed }
         }
       ),
@@ -596,8 +594,8 @@ describe('component: FleetDashboard', () => {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
         {
-          [FLEET.GIT_REPO]:     gitRepos,
-          [FLEET.HELM_OP]:      helmOps,
+          gitRepos,
+          helmOps,
           isWorkspaceCollapsed: {
             'fleet-local':   false,
             'fleet-default': true
@@ -635,8 +633,8 @@ describe('component: FleetDashboard', () => {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
         {
-          [FLEET.GIT_REPO]:     gitRepos,
-          [FLEET.HELM_OP]:      helmOps,
+          gitRepos,
+          helmOps,
           isWorkspaceCollapsed: {
             'fleet-local':   false,
             'fleet-default': true
@@ -688,7 +686,7 @@ describe('component: FleetDashboard', () => {
     const wrapper = mount(Dashboard, {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
-        { [FLEET.GIT_REPO]: gitRepos }
+        { gitRepos }
       ),
       stubs: ['Loading', 'NoWorkspaces', 'EmptyDashboard', 'RouterLinkStub'],
     });
@@ -705,7 +703,7 @@ describe('component: FleetDashboard', () => {
     const wrapper = mount(Dashboard, {
       ...requiredSetup(
         { workspaces: () => fleetWorkspaces },
-        { [FLEET.GIT_REPO]: gitRepos }
+        { gitRepos }
       ),
       stubs: ['Loading', 'NoWorkspaces', 'EmptyDashboard', 'RouterLinkStub'],
     });
@@ -719,5 +717,45 @@ describe('component: FleetDashboard', () => {
     // type="search" already exposes the implicit searchbox role, so no
     // explicit role should override it.
     expect(searchInput.attributes('role')).toBeUndefined();
+  });
+
+  it('should update the workspace search filter, debounced, when the search input changes', async() => {
+    jest.useFakeTimers();
+
+    try {
+      const wrapper = mount(Dashboard, {
+        ...requiredSetup(
+          { workspaces: () => fleetWorkspaces },
+          { gitRepos }
+        ),
+        stubs: ['Loading', 'NoWorkspaces', 'EmptyDashboard', 'RouterLinkStub'],
+      });
+
+      wrapper.vm.viewMode = 'cards';
+      await wrapper.vm.$nextTick();
+
+      const searchInput = wrapper.find('[data-testid="fleet-dashboard-search-input-fleet-local"]');
+
+      await searchInput.setValue('lots');
+
+      jest.advanceTimersByTime(100);
+      await searchInput.setValue('lots-a');
+
+      // 350ms after the first keystroke but only 250ms after the second. A
+      // single shared debounce has been pushed back to 400ms, so nothing has
+      // landed. One rebuilt per keystroke would have fired the first at 300ms
+      // and leaked the intermediate 'lots'.
+      jest.advanceTimersByTime(250);
+      await wrapper.vm.$nextTick();
+
+      expect((wrapper.vm.searchFilter as any)['fleet-local']).toBeUndefined();
+
+      jest.advanceTimersByTime(100);
+      await wrapper.vm.$nextTick();
+
+      expect((wrapper.vm.searchFilter as any)['fleet-local']).toBe('lots-a');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -78,8 +78,8 @@ export default {
 
     this.fleetWorkspaces = hash.fleetWorkspaces || [];
 
-    this[FLEET.GIT_REPO] = hash.gitRepos || [];
-    this[FLEET.HELM_OP] = hash.helmOps || [];
+    this.gitRepos = hash.gitRepos || [];
+    this.helmOps = hash.helmOps || [];
 
     try {
       const permissionsSchemas = {
@@ -104,13 +104,13 @@ export default {
 
   data() {
     return {
-      permissions:      {},
+      permissions:     {},
       FLEET,
-      [FLEET.GIT_REPO]: [],
-      [FLEET.HELM_OP]:  [],
-      fleetWorkspaces:  [],
+      gitRepos:        [],
+      helmOps:         [],
+      fleetWorkspaces: [],
       VIEW_MODE,
-      viewModeOptions:  [
+      viewModeOptions: [
         {
           tooltipKey: 'fleet.dashboard.viewMode.table',
           icon:       'icon-list-flat',
@@ -138,10 +138,6 @@ export default {
 
   created() {
     this.$store.dispatch('showWorkspaceSwitcher', false);
-
-    this.debouncedUpdateSearchFilter = debounce((workspace, value) => {
-      this.searchFilter[workspace] = value;
-    }, 300);
   },
 
   mounted() {
@@ -175,8 +171,8 @@ export default {
       return this.allNamespaces.filter((item) => {
         return item.metadata.annotations[WORKSPACE_ANNOTATION] === WORKSPACE;
       }).map(( obj ) => {
-        const repos = filterBy(this[FLEET.GIT_REPO], 'metadata.namespace', obj.id);
-        const helmOps = filterBy(this[FLEET.HELM_OP], 'metadata.namespace', obj.id);
+        const repos = filterBy(this.gitRepos, 'metadata.namespace', obj.id);
+        const helmOps = filterBy(this.helmOps, 'metadata.namespace', obj.id);
 
         return {
           ...obj,
@@ -222,11 +218,22 @@ export default {
     },
 
     isEmptyDashboard() {
-      return this[FLEET.GIT_REPO]?.length === 0 && this[FLEET.HELM_OP]?.length === 0;
+      return this.gitRepos?.length === 0 && this.helmOps?.length === 0;
     },
 
     allCardsExpanded() {
       return Object.keys(this.isWorkspaceCollapsed).every((key) => !this.isWorkspaceCollapsed[key]);
+    },
+
+    // Cached, so the debounced function is created once on first use. A
+    // computed also gives `this` the component's type, which an assignment in
+    // created() does not. Do not read reactive state in here: that would
+    // invalidate the computed and mint a new debounce, dropping keystrokes
+    // that are still pending.
+    debouncedUpdateSearchFilter() {
+      return debounce((workspace, value) => {
+        this.searchFilter[workspace] = value;
+      }, 300);
     },
   },
 
@@ -430,9 +437,12 @@ export default {
       });
     },
 
-    _checkInit(workspace, name) {
-      if (!this[name][workspace]) {
-        this[name][workspace] = {};
+    _checkInit(workspace: string, name: 'cardsCount' | 'isStateCollapsed' | 'stateFilter' | 'typeFilter') {
+      // These are all keyed by workspace id, which `data()` cannot express.
+      const byWorkspace = this[name] as Record<string, unknown>;
+
+      if (!byWorkspace[workspace]) {
+        byWorkspace[workspace] = {};
       }
     },
   },

--- a/shell/types/rancher/index.d.ts
+++ b/shell/types/rancher/index.d.ts
@@ -1,17 +1,3 @@
 declare module '@rancher/auto-import' {
   export function importTypes(ext: any): void;
 }
-
-/**
- * `shell/config/version` is plain JS. This shim, not the JS, is what TS resolves
- * an import of it against, so it has to list every export the module has. A
- * missing one reads as "no exported member" at each of its call sites.
- */
-declare module '@shell/config/version' {
-  export const CURRENT_RANCHER_VERSION: string;
-  export function getVersionData(): any;
-  export function setVersionData(v: any): void;
-  export function getKubeVersionData(): any;
-  export function setKubeVersionData(v: any): void;
-  export function isRancherPrime(): boolean;
-}

--- a/shell/types/vue-shim.d.ts
+++ b/shell/types/vue-shim.d.ts
@@ -16,6 +16,17 @@ declare module 'vue' {
       (key: string, args?: Record<string, any>, raw?: boolean): string;
       (options: { k: string; raw?: boolean; tag?: string | Record<string, any>; escapehtml?: boolean }): string;
     },
-    $store: VuexStore
+    $store: VuexStore,
+    /**
+     * Provided by the `fetch.client` mixin, which `shell/initialize/entry.js`
+     * registers globally, so every component has it. Keep in sync with what
+     * that mixin writes to its own `state`.
+     */
+    $fetchState: {
+      pending: boolean;
+      /** `normalizeError()` output, not an `Error` instance. */
+      error: { message: string; statusCode: number } | null;
+      timestamp: number;
+    }
   }
 }


### PR DESCRIPTION
### Summary
Fixes #18570

### Occurred changes and/or fixed issues
- Deleted the `@shell/config/version` ambient shim, declared `$fetchState` in `ComponentCustomProperties`, and fixed the 14 errors the shim was masking in the Fleet dashboard.
- Regenerated the type-check baseline (553 to 540) and added a unit test covering the dashboard's debounced workspace search.

### Technical notes summary
- One cause for all 14: the computed `data()` keys widen to `string`, adding a `{} | null` index signature that hid every dynamic lookup. Renaming them clears 10, the `$fetchState` declaration the rest. The drop is 13, not 20: master already declared all six exports.
- I skipped the issue's `error: Error | null`, since `normalizeError()` returns a plain object. The debounce became a computed to get a typed `this`. The shared-debounce bug across workspace search boxes is pre-existing, not from this PR.

### Areas or cases that should be tested
- As admin: local cluster, Continuous Delivery, Fleet dashboard, card view, with a workspace holding a GitRepo or HelmOp. - Fleet search should filter. 
- type and state filters, Expand/Collapse 
- all, the empty state, and the loading indicator on first paint.

### Areas which could experience regressions
- `$fetchState` is now typed for every component, since `entry.js` registers the fetch mixin globally. It clears 11 errors across 9 unrelated files, the widest surface here.
- The Fleet dashboard search, empty state and filters, where the renamed keys are read.

### Screenshot/Video
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Milestone and reviewer are yours. The template block is byte-identical to master, so both themes and the accessibility tree are unchanged; roles is unticked because I only exercised the dashboard as admin.
