### PR TITLE
Add RcModal, the shared modal layout component

### DIFF
--- a/cypress/e2e/po/prompts/promptRemove.po.ts
+++ b/cypress/e2e/po/prompts/promptRemove.po.ts
@@ -4,7 +4,7 @@ import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 
 export default class PromptRemove extends ComponentPo {
   constructor() {
-    super(cy.get('[data-testid="card"].prompt-remove'));
+    super(cy.get('[data-testid="rc-modal"].prompt-remove'));
   }
 
   confirmField() {
@@ -29,7 +29,7 @@ export default class PromptRemove extends ComponentPo {
 
   // Get the warning message
   warning() {
-    return this.self().get('.card-body .text-warning');
+    return this.self().get('[data-testid="rc-modal-body"] .text-warning');
   }
 
   checkbox() {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -71,6 +71,14 @@ beforeAll(() => {
       disconnect: jest.fn(),
     })),
   });
+  Object.defineProperty(window, 'ResizeObserver', {
+    writable: true,
+    value:    jest.fn().mockImplementation(() => ({
+      observe:    jest.fn(),
+      unobserve:  jest.fn(),
+      disconnect: jest.fn(),
+    })),
+  });
 });
 jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => (key) => key }));
 // eslint-disable-next-line no-console

--- a/pkg/rancher-components/src/components/RcModal/RcModal.test.ts
+++ b/pkg/rancher-components/src/components/RcModal/RcModal.test.ts
@@ -1,0 +1,325 @@
+import { mount } from '@vue/test-utils';
+import { h, ref } from 'vue';
+import RcModal from './RcModal.vue';
+
+// jest.setup stubs ResizeObserver away for every suite, because jsdom has none.
+// The scrolling body needs more than a stub: it needs to be told when a resize
+// happened and what the boxes measure, since jsdom reports every box as zero.
+const observerCallbacks: (() => void)[] = [];
+const disconnect = jest.fn();
+
+// Say what the body's boxes measure, then let the observer report it.
+const resizeBodyTo = async(wrapper: { find: (s: string) => { element: Element } }, { scrollHeight, clientHeight }: { scrollHeight: number, clientHeight: number }) => {
+  const body = wrapper.find('[data-testid="rc-modal-body"]').element;
+
+  Object.defineProperty(body, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(body, 'clientHeight', { value: clientHeight, configurable: true });
+
+  observerCallbacks.forEach((callback) => callback());
+
+  await Promise.resolve();
+};
+
+describe('component: RcModal', () => {
+  const mountModal = (options = {}) => mount(RcModal, options);
+
+  beforeEach(() => {
+    observerCallbacks.length = 0;
+    disconnect.mockClear();
+
+    window.ResizeObserver = jest.fn().mockImplementation((callback: () => void) => {
+      observerCallbacks.push(callback);
+
+      return {
+        observe: jest.fn(), unobserve: jest.fn(), disconnect
+      };
+    });
+  });
+
+  describe('header', () => {
+    it('renders the title prop in the header', () => {
+      const wrapper = mountModal({ props: { title: 'Move to a new project?' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-title"]').text()).toBe('Move to a new project?');
+    });
+
+    it('prefers the title slot over the title prop', () => {
+      const wrapper = mountModal({
+        props: { title: 'From the prop' },
+        slots: { title: '<span>From the slot</span>' }
+      });
+
+      expect(wrapper.find('[data-testid="rc-modal-title"]').text()).toBe('From the slot');
+    });
+
+    it('omits the header, and its rule, when there is no title at all', () => {
+      const wrapper = mountModal({ slots: { default: '<p>Body</p>' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-header"]').exists()).toBe(false);
+      expect(wrapper.findAll('hr')).toHaveLength(0);
+    });
+
+    it('renders the header, and one rule beneath it, when there is a title', () => {
+      const wrapper = mountModal({ props: { title: 'Are you sure?' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-header"]').exists()).toBe(true);
+      expect(wrapper.findAll('hr')).toHaveLength(1);
+    });
+  });
+
+  describe('body', () => {
+    it('renders the default slot as the body', () => {
+      const wrapper = mountModal({ slots: { default: '<p class="content">Body content</p>' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"] p.content').text()).toBe('Body content');
+    });
+
+    it('renders the body even when it is empty, so the chrome keeps its shape', () => {
+      const wrapper = mountModal({ props: { title: 'Title only' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"]').exists()).toBe(true);
+    });
+  });
+
+  describe('actions', () => {
+    it('renders the actions slot in the footer', () => {
+      const wrapper = mountModal({ slots: { actions: '<button>Cancel</button><button>Delete</button>' } });
+
+      expect(wrapper.findAll('[data-testid="rc-modal-actions"] button')).toHaveLength(2);
+    });
+
+    it('omits the footer, and its rule, when there are no actions', () => {
+      const wrapper = mountModal({ props: { title: 'Are you sure?' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-actions"]').exists()).toBe(false);
+      expect(wrapper.findAll('hr')).toHaveLength(1);
+    });
+
+    it('renders a rule above the footer as well as below the header', () => {
+      const wrapper = mountModal({
+        props: { title: 'Are you sure?' },
+        slots: { actions: '<button>Delete</button>' }
+      });
+
+      expect(wrapper.findAll('hr')).toHaveLength(2);
+    });
+
+    it('shows the footer when the actions slot only appears later', async() => {
+      const show = ref(false);
+      const wrapper = mount({
+        setup() {
+          return () => h(RcModal, { title: 'Are you sure?' }, show.value ? { actions: () => h('button', 'Delete') } : {});
+        }
+      });
+
+      expect(wrapper.find('[data-testid="rc-modal-actions"]').exists()).toBe(false);
+
+      show.value = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="rc-modal-actions"]').exists()).toBe(true);
+    });
+
+    it('renders a rule above the footer even when there is no header', () => {
+      const wrapper = mountModal({ slots: { actions: '<button>Delete</button>' } });
+
+      expect(wrapper.findAll('hr')).toHaveLength(1);
+      expect(wrapper.find('[data-testid="rc-modal-actions"]').exists()).toBe(true);
+    });
+  });
+
+  describe('accessible name', () => {
+    // RcModal sits inside the host's role="dialog" element, so it is mounted
+    // into one here the way AppModal and PromptModal both provide it.
+    // The name is claimed in a post-flush watcher, so it lands on the tick
+    // after mount rather than during it.
+    const mountInDialog = async(props = {}, attrs: Record<string, string> = {}, role = 'dialog') => {
+      const dialog = document.createElement('div');
+
+      dialog.setAttribute('role', role);
+      Object.entries(attrs).forEach(([k, v]) => dialog.setAttribute(k, v));
+      document.body.appendChild(dialog);
+
+      const wrapper = mount(RcModal, { props, attachTo: dialog });
+
+      await wrapper.vm.$nextTick();
+
+      return { dialog, wrapper };
+    };
+
+    it('names the surrounding dialog with its own title', async() => {
+      const { dialog, wrapper } = await mountInDialog({ title: 'Are you sure?' });
+      const titleId = wrapper.find('[data-testid="rc-modal-title"]').attributes('id');
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe(titleId);
+
+      wrapper.unmount();
+    });
+
+    it('leaves a dialog the host has already named alone', async() => {
+      const { dialog, wrapper } = await mountInDialog({ title: 'Are you sure?' }, { 'aria-labelledby': 'host-owned-title' });
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe('host-owned-title');
+
+      wrapper.unmount();
+    });
+
+    it('gives up the name again when it unmounts, so a later modal can claim it', async() => {
+      const { dialog, wrapper } = await mountInDialog({ title: 'Are you sure?' });
+
+      wrapper.unmount();
+
+      expect(dialog.getAttribute('aria-labelledby')).toBeNull();
+    });
+
+    it('does not name the dialog when there is no title to name it with', async() => {
+      const { dialog, wrapper } = await mountInDialog({});
+
+      expect(dialog.getAttribute('aria-labelledby')).toBeNull();
+
+      wrapper.unmount();
+    });
+
+    it('names the dialog when the title only arrives later', async() => {
+      const dialog = document.createElement('div');
+
+      dialog.setAttribute('role', 'dialog');
+      document.body.appendChild(dialog);
+
+      const title = ref('');
+      const wrapper = mount({
+        setup() {
+          return () => h(RcModal, { title: title.value });
+        }
+      }, { attachTo: dialog });
+
+      expect(dialog.getAttribute('aria-labelledby')).toBeNull();
+
+      title.value = 'Loaded from a fetch';
+      await wrapper.vm.$nextTick();
+
+      const titleId = wrapper.find('[data-testid="rc-modal-title"]').attributes('id');
+
+      expect(titleId).toBeTruthy();
+      expect(dialog.getAttribute('aria-labelledby')).toBe(titleId);
+
+      wrapper.unmount();
+    });
+
+    it('re-points the dialog when the titleId changes', async() => {
+      const dialog = document.createElement('div');
+
+      dialog.setAttribute('role', 'dialog');
+      document.body.appendChild(dialog);
+
+      const titleId = ref('first-id');
+      const wrapper = mount({
+        setup() {
+          return () => h(RcModal, { title: 'Are you sure?', titleId: titleId.value });
+        }
+      }, { attachTo: dialog });
+
+      await wrapper.vm.$nextTick();
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe('first-id');
+
+      titleId.value = 'second-id';
+      await wrapper.vm.$nextTick();
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe('second-id');
+
+      wrapper.unmount();
+    });
+
+    it('names an alertdialog too, which a destructive confirm carries instead', async() => {
+      const { dialog, wrapper } = await mountInDialog({ title: 'Are you sure?' }, {}, 'alertdialog');
+      const titleId = wrapper.find('[data-testid="rc-modal-title"]').attributes('id');
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe(titleId);
+
+      wrapper.unmount();
+    });
+
+    it('leaves a name the host set after mount alone when it unmounts', async() => {
+      const { dialog, wrapper } = await mountInDialog({ title: 'Are you sure?' });
+
+      dialog.setAttribute('aria-labelledby', 'set-by-the-host-later');
+      wrapper.unmount();
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe('set-by-the-host-later');
+    });
+
+    it('puts the given titleId on the title, so a host can reference it directly', () => {
+      const wrapper = mountModal({ props: { title: 'Are you sure?', titleId: 'prompt-remove-title' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-title"]').attributes('id')).toBe('prompt-remove-title');
+    });
+
+    it('generates a title id when none is given', () => {
+      const wrapper = mountModal({ props: { title: 'Are you sure?' } });
+
+      expect(wrapper.find('[data-testid="rc-modal-title"]').attributes('id')).toBeTruthy();
+    });
+
+    it('gives two modals in the same app different generated title ids', () => {
+      const wrapper = mount({
+        components: { RcModal },
+        template:   '<div><RcModal title="First" /><RcModal title="Second" /></div>'
+      });
+
+      const ids = wrapper.findAll('[data-testid="rc-modal-title"]').map((el) => el.attributes('id'));
+
+      expect(ids).toHaveLength(2);
+      expect(ids[0]).not.toBe(ids[1]);
+    });
+  });
+
+  // A body taller than the space it has is only readable with a mouse unless
+  // something can put keyboard focus in it. Chromium will not, because the body
+  // usually holds focusable content, and the modal's focus trap tabs by
+  // tabindex, so the attribute has to be there while there is overflow.
+  describe('scrolling body', () => {
+    it('is not a tab stop while its content fits', async() => {
+      const wrapper = mountModal({ props: { title: 'Short' }, slots: { default: '<p>Body</p>' } });
+
+      await resizeBodyTo(wrapper, { scrollHeight: 200, clientHeight: 200 });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"]').attributes('tabindex')).toBeUndefined();
+    });
+
+    it('becomes a tab stop once its content overflows', async() => {
+      const wrapper = mountModal({ props: { title: 'Tall' }, slots: { default: '<p>Body</p>' } });
+
+      await resizeBodyTo(wrapper, { scrollHeight: 1000, clientHeight: 400 });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"]').attributes('tabindex')).toBe('0');
+    });
+
+    it('stops being a tab stop when the overflow goes away', async() => {
+      const wrapper = mountModal({ props: { title: 'Tall' }, slots: { default: '<p>Body</p>' } });
+
+      await resizeBodyTo(wrapper, { scrollHeight: 1000, clientHeight: 400 });
+      await resizeBodyTo(wrapper, { scrollHeight: 400, clientHeight: 400 });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"]').attributes('tabindex')).toBeUndefined();
+    });
+
+    it('ignores a sub-pixel difference, which nobody can scroll to', async() => {
+      const wrapper = mountModal({ props: { title: 'Tall' }, slots: { default: '<p>Body</p>' } });
+
+      await resizeBodyTo(wrapper, { scrollHeight: 400.5, clientHeight: 400 });
+
+      expect(wrapper.find('[data-testid="rc-modal-body"]').attributes('tabindex')).toBeUndefined();
+    });
+
+    it('stops observing when it unmounts', async() => {
+      const wrapper = mountModal({ props: { title: 'Tall' } });
+
+      await resizeBodyTo(wrapper, { scrollHeight: 1000, clientHeight: 400 });
+
+      wrapper.unmount();
+
+      expect(disconnect).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/pkg/rancher-components/src/components/RcModal/RcModal.vue
+++ b/pkg/rancher-components/src/components/RcModal/RcModal.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+/**
+ * The standard chrome for a modal's contents: a titled header, a body that
+ * scrolls when it has to, and a footer whose actions sit in one place at one
+ * size. It owns padding, dividers and button placement so that individual
+ * modals stop deciding those for themselves. The background is deliberately
+ * not painted here - it stays with `AppModal`, so nothing inside a modal ever
+ * puts a second surface on top of it.
+ *
+ * It is layout only. Overlay, teleport, focus trap, `Esc` and click-outside
+ * close, and width all stay with `AppModal`, which is either supplied by the
+ * host or written around this component:
+ *
+ * <AppModal :width="600" :trigger-focus-trap="true" @close="close">
+ *   <RcModal :title="t('some.title')">
+ *     <p>Body content</p>
+ *     <template #actions>
+ *       <button class="btn role-secondary" @click="close">{{ t('generic.cancel') }}</button>
+ *       <AsyncButton mode="apply" @click="apply" />
+ *     </template>
+ *   </RcModal>
+ * </AppModal>
+ *
+ * A component registered in `shell/dialog/` writes the `RcModal` alone -
+ * `PromptModal` already supplies the `AppModal` around it. Do not reach for
+ * `Card` inside a modal; this replaces it.
+ *
+ * Host requirement: pinning the header and the actions while the body scrolls
+ * needs the dialog box to be a flex column, which `AppModal` does for any modal
+ * containing an `RcModal` (see the `.modal-container:has(.rc-modal)` rule in
+ * `AppModal.vue`). In any other host the chrome still renders correctly, but
+ * the whole modal scrolls rather than just the body.
+ *
+ * A body that does scroll becomes a tab stop of its own, so its overflow can be
+ * reached with a keyboard and not only with a pointer. A body that fits does
+ * not, so no modal gains a stop that does nothing.
+ */
+import {
+  computed, onBeforeUnmount, ref, useId, useTemplateRef, watch
+} from 'vue';
+import RcSeparator from '@components/RcSeparator/RcSeparator.vue';
+import type { RcModalProps } from './types';
+
+const props = withDefaults(defineProps<RcModalProps>(), { title: '' });
+
+const generatedTitleId = useId();
+
+const resolvedTitleId = computed(() => props.titleId || generatedTitleId);
+
+const titleEl = useTemplateRef<HTMLElement>('titleEl');
+
+// A modal needs an accessible name, and the name lives here while `role="dialog"`
+// is on the host's element. A dialog reached through `PromptModal` cannot be
+// given one by the component inside it, so the title claims the nearest dialog
+// itself. A host that labelled its dialog already keeps its own wiring.
+//
+// Watched rather than done once on mount, because a title is often only known
+// after the modal has fetched something, and a header that appears later has to
+// name the dialog too.
+let labelledDialog: Element | null = null;
+let writtenId = '';
+
+// Only ever take back the exact name this modal wrote, so a host that labels
+// its own dialog later is not quietly stripped of it.
+function releaseName() {
+  if (labelledDialog?.getAttribute('aria-labelledby') === writtenId) {
+    labelledDialog.removeAttribute('aria-labelledby');
+  }
+
+  labelledDialog = null;
+  writtenId = '';
+}
+
+watch([titleEl, resolvedTitleId], ([el, id]) => {
+  releaseName();
+
+  // alertdialog too, because a destructive confirm carries that role instead
+  // and it sits closer than the container AppModal renders.
+  const dialog = el?.closest('[role="dialog"], [role="alertdialog"]');
+
+  if (dialog && !dialog.getAttribute('aria-labelledby')) {
+    dialog.setAttribute('aria-labelledby', id);
+    labelledDialog = dialog;
+    writtenId = id;
+  }
+}, { immediate: true, flush: 'post' });
+
+// A body that scrolls has to be reachable by keyboard, or its overflow is
+// readable with a mouse only. Chromium focuses such a scroller by itself, but
+// only when it holds nothing else focusable, and the focus trap around a modal
+// tabs to elements with a tabindex rather than to whatever the browser would
+// focus, so neither route reaches it here. An explicit tabindex, and only while
+// there is something to scroll to, is what both of them do agree on.
+const bodyEl = useTemplateRef<HTMLElement>('bodyEl');
+const contentEl = useTemplateRef<HTMLElement>('contentEl');
+
+const scrollable = ref(false);
+
+// The body's own box changes with the viewport and the content's with the
+// slot, and either can start or stop the overflow, so both are watched.
+// Sub-pixel differences are not overflow anyone can scroll to.
+function measure() {
+  const el = bodyEl.value;
+
+  scrollable.value = !!el && el.scrollHeight - el.clientHeight > 1;
+}
+
+let observer: ResizeObserver | null = null;
+
+watch([bodyEl, contentEl], ([body, content]) => {
+  observer?.disconnect();
+  observer = null;
+
+  if (!body || !content) {
+    scrollable.value = false;
+
+    return;
+  }
+
+  observer = new ResizeObserver(measure);
+  observer.observe(body);
+  observer.observe(content);
+  measure();
+}, { immediate: true, flush: 'post' });
+
+onBeforeUnmount(() => {
+  observer?.disconnect();
+  observer = null;
+  releaseName();
+});
+</script>
+
+<template>
+  <div
+    class="rc-modal"
+    data-testid="rc-modal"
+  >
+    <template v-if="props.title || $slots.title">
+      <div
+        class="rc-modal-header"
+        data-testid="rc-modal-header"
+      >
+        <h3
+          :id="resolvedTitleId"
+          ref="titleEl"
+          class="rc-modal-title"
+          data-testid="rc-modal-title"
+        >
+          <slot name="title">
+            {{ props.title }}
+          </slot>
+        </h3>
+      </div>
+      <RcSeparator />
+    </template>
+
+    <div
+      ref="bodyEl"
+      class="rc-modal-body"
+      data-testid="rc-modal-body"
+      :tabindex="scrollable ? 0 : undefined"
+    >
+      <div ref="contentEl">
+        <slot />
+      </div>
+    </div>
+
+    <template v-if="$slots.actions">
+      <RcSeparator />
+      <div
+        class="rc-modal-actions"
+        data-testid="rc-modal-actions"
+      >
+        <slot name="actions" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.rc-modal {
+  display: flex;
+  flex-direction: column;
+  // As a flex item of the modal container, this has to be allowed to shrink
+  // below its content height or the body can never become the scroller.
+  min-height: 0;
+  max-height: 100%;
+  color: var(--body-text);
+
+  hr {
+    margin: 0;
+    flex: 0 0 auto;
+  }
+}
+
+.rc-modal-header,
+.rc-modal-actions {
+  flex: 0 0 auto;
+  padding: var(--gap-md) var(--gap-lg);
+}
+
+.rc-modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.rc-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--gap-lg);
+
+  // Inset, because an outline on the scroller would otherwise sit under the
+  // rules above and below it.
+  &:focus-visible {
+    @include focus-outline;
+    outline-offset: -2px;
+  }
+}
+
+.rc-modal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/pkg/rancher-components/src/components/RcModal/index.ts
+++ b/pkg/rancher-components/src/components/RcModal/index.ts
@@ -1,0 +1,2 @@
+export { default as RcModal } from './RcModal.vue';
+export type { RcModalProps } from './types';

--- a/pkg/rancher-components/src/components/RcModal/types.ts
+++ b/pkg/rancher-components/src/components/RcModal/types.ts
@@ -1,0 +1,15 @@
+export interface RcModalProps {
+  /**
+   * The modal's title. Can also be supplied through the `title` slot when it
+   * needs markup. The header, and the rule beneath it, are omitted entirely
+   * when neither is given.
+   */
+  title?: string;
+
+  /**
+   * The `id` put on the title element. The modal names its surrounding dialog
+   * on its own, so this is only needed when something else wants to reference
+   * the title by a known id. Defaults to a generated one.
+   */
+  titleId?: string;
+}

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -16,6 +16,7 @@ export { RcIconTooltip } from './components/RcIconTooltip';
 export { RcSection } from './components/RcSection';
 export { RcSeparator } from './components/RcSeparator';
 export { RcItemCard, RcItemCardAction } from './components/RcItemCard';
+export { RcModal } from './components/RcModal';
 export { default as RcCounterBadge } from './components/Pill/RcCounterBadge';
 export { default as RcStatusBadge } from './components/Pill/RcStatusBadge';
 export { default as RcStatusIndicator } from './components/Pill/RcStatusIndicator';

--- a/pkg/rancher-components/types/index.d.ts
+++ b/pkg/rancher-components/types/index.d.ts
@@ -18,6 +18,7 @@ export const RcDropdownSeparator: DefineComponent;
 export const RcDropdownTrigger: DefineComponent;
 export const RcItemCard: DefineComponent;
 export const RcSeparator: DefineComponent;
+export const RcModal: DefineComponent;
 
 type ArrayListRow = {
     value: string;

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -232,6 +232,16 @@ export default defineComponent({
       max-height: 95vh;
       overflow: auto;
       border: 2px solid var(--modal-border);
+
+      // RcModal pins its header and its actions and lets only its body scroll,
+      // which needs this box to be a column that does not scroll itself. At
+      // three levels of specificity this beats the `overflow` above it and any
+      // per-modal `customClass`.
+      &:has(.rc-modal) {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
     }
   }
 

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -3,7 +3,7 @@ import { shallowRef } from 'vue';
 import { mapState, mapGetters } from 'vuex';
 import { get, isEmpty } from '@shell/utils/object';
 import { escapeHtml, resourceNames } from '@shell/utils/string';
-import { Card } from '@components/Card';
+import { RcModal } from '@components/RcModal';
 import { Checkbox } from '@components/Form/Checkbox';
 import { alternateLabel } from '@shell/utils/platform';
 import { uniq } from '@shell/utils/array';
@@ -17,7 +17,7 @@ export default {
   name: 'PromptRemove',
 
   components: {
-    Card, Checkbox, AsyncButton, LabeledInput, AppModal
+    RcModal, Checkbox, AsyncButton, LabeledInput, AppModal
   },
   props: {
     /**
@@ -346,92 +346,85 @@ export default {
     :trigger-focus-trap="true"
     @close="close"
   >
-    <Card
+    <RcModal
       class="prompt-remove"
-      :show-highlight-border="false"
+      :title="t('promptRemove.title')"
     >
-      <template #title>
-        <h4 class="text-default-text">
-          {{ t('promptRemove.title') }}
-        </h4>
-      </template>
-      <template #body>
-        <div class="mb-10">
-          <template v-if="!hasCustomRemove">
-            {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-              v-clean-html="resourceNames(names, null, t)"
-            />
-          </template>
-
-          <component
-            :is="removeComponent"
-            v-if="hasCustomRemove"
-            ref="customPrompt"
-            v-model:value="toRemove"
-            v-bind="$data"
-            :close="close"
-            :needs-confirm="needsConfirm"
-            :value="toRemove"
-            :names="names"
-            :type="type"
-            :done-location="doneLocation"
-            @errors="e => error = e"
-            @done="done"
+      <div class="mb-10">
+        <template v-if="!hasCustomRemove">
+          {{ t('promptRemove.attemptingToRemove', { type }) }} <span
+            v-clean-html="resourceNames(names, null, t)"
           />
-          <div
-            v-if="needsConfirm"
-            class="mt-10"
-          >
-            <span
-              v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
-              class="confirm-text"
-            />
-          </div>
-        </div>
-        <LabeledInput
-          v-if="needsConfirm"
-          id="confirm"
-          v-model:value="confirmName"
-          v-focus
-          :data-testid="componentTestid + '-input'"
-          type="text"
-          :aria-label="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) })"
-        >
-          <div class="text-warning mb-10 mt-10">
-            {{ warning }}
-          </div>
-          <div class="text-error mb-10 mt-10">
-            {{ error }}
-          </div>
-          <div
-            v-if="!needsConfirm"
-            class="text-info mt-20"
-          >
-            {{ protip }}
-          </div>
-        </LabeledInput>
-        <div v-else-if="!hasCustomRemove">
-          <div
-            v-if="warning"
-            class="text-warning mb-10 mt-10"
-          >
-            {{ warning }}
-          </div>
-          <div
-            v-if="error"
-            class="text-error mb-10 mt-10"
-          >
-            {{ error }}
-          </div>
-        </div>
-        <Checkbox
-          v-if="chartsToRemoveIsApp"
-          v-model:value="chartsDeleteCrd"
-          label-key="promptRemoveApp.removeCrd"
-          class="mt-10 type"
-          @update:value="chartAddCrdToRemove"
+        </template>
+
+        <component
+          :is="removeComponent"
+          v-if="hasCustomRemove"
+          ref="customPrompt"
+          v-model:value="toRemove"
+          v-bind="$data"
+          :close="close"
+          :needs-confirm="needsConfirm"
+          :value="toRemove"
+          :names="names"
+          :type="type"
+          :done-location="doneLocation"
+          @errors="e => error = e"
+          @done="done"
         />
-      </template>
+        <div
+          v-if="needsConfirm"
+          class="mt-10"
+        >
+          <span
+            v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+            class="confirm-text"
+          />
+        </div>
+      </div>
+      <LabeledInput
+        v-if="needsConfirm"
+        id="confirm"
+        v-model:value="confirmName"
+        v-focus
+        :data-testid="componentTestid + '-input'"
+        type="text"
+        :aria-label="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) })"
+      >
+        <div class="text-warning mb-10 mt-10">
+          {{ warning }}
+        </div>
+        <div class="text-error mb-10 mt-10">
+          {{ error }}
+        </div>
+        <div
+          v-if="!needsConfirm"
+          class="text-info mt-20"
+        >
+          {{ protip }}
+        </div>
+      </LabeledInput>
+      <div v-else-if="!hasCustomRemove">
+        <div
+          v-if="warning"
+          class="text-warning mb-10 mt-10"
+        >
+          {{ warning }}
+        </div>
+        <div
+          v-if="error"
+          class="text-error mb-10 mt-10"
+        >
+          {{ error }}
+        </div>
+      </div>
+      <Checkbox
+        v-if="chartsToRemoveIsApp"
+        v-model:value="chartsDeleteCrd"
+        label-key="promptRemoveApp.removeCrd"
+        class="mt-10 type"
+        @update:value="chartAddCrdToRemove"
+      />
       <template #actions>
         <button
           class="btn role-secondary"
@@ -439,43 +432,37 @@ export default {
         >
           {{ t('generic.cancel') }}
         </button>
-        <div class="spacer" />
         <AsyncButton
           mode="delete"
-          class="btn bg-error ml-10"
+          class="btn bg-error"
           :disabled="deleteDisabled"
           :data-testid="componentTestid + '-confirm-button'"
           @click="remove"
         />
       </template>
-    </Card>
+    </RcModal>
   </app-modal>
 </template>
 
 <style lang='scss'>
   .prompt-remove {
-    &.card-container {
-      box-shadow: none;
-    }
-    #confirm {
-      width: 90%;
-      margin-left: 3px;
-    }
-
-    .actions {
-      text-align: right;
-    }
-
-    .card-actions {
-      display: flex;
-
-      .spacer {
-        flex: 1;
-      }
-    }
-
     .confirm-text b {
       user-select: all;
+    }
+  }
+
+  // ScalePoolDownDialog and SloDialog also carry `prompt-remove`, on a Card,
+  // and rely on these two rules being global. They stay until those dialogs
+  // move onto RcModal, which takes both jobs over.
+  .prompt-remove.card-container {
+    box-shadow: none;
+  }
+
+  .prompt-remove .card-actions {
+    display: flex;
+
+    .spacer {
+      flex: 1;
     }
   }
 </style>

--- a/shell/components/__tests__/PromptRemove.test.ts
+++ b/shell/components/__tests__/PromptRemove.test.ts
@@ -1,0 +1,111 @@
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import PromptRemove from '@shell/components/PromptRemove.vue';
+
+// PromptRemove is the highest-traffic modal in the product and the one that
+// drives every delete. These cover the chrome it hands to RcModal - that the
+// title, the body and the two actions land in the right slots - rather than
+// the removal logic, which is unchanged.
+describe('component: PromptRemove', () => {
+  const mountPrompt = (toRemove: any[] = []) => {
+    const store = createStore({
+      getters: {
+        'type-map/importCustomPromptRemove': () => () => null,
+        'type-map/labelFor':                 () => () => 'Namespace',
+        'i18n/t':                            () => (key: string) => `%${ key }%`,
+        currentProduct:                      () => ({ inStore: 'cluster' }),
+      },
+      modules: {
+        'action-menu': {
+          namespaced: true,
+          state:      () => ({ showPromptRemove: false, toRemove }),
+          mutations:  {
+            togglePromptRemove: (state: any) => {
+              state.showPromptRemove = false;
+            }
+          },
+        },
+      },
+    });
+
+    const wrapper = mount(PromptRemove, {
+      global: {
+        mocks: {
+          $store:  store,
+          $route:  { params: { resource: 'namespace' } },
+          $router: { push: jest.fn() },
+        },
+        directives: { focus: {} },
+        stubs:      {
+          // Teleporting to #modals has nowhere to land in jsdom, and the
+          // chrome under test does not depend on the overlay.
+          AppModal:     { template: '<div><slot /></div>' },
+          AsyncButton:  { template: '<button></button>' },
+          LabeledInput: { template: '<input>' },
+          Checkbox:     true,
+        },
+      },
+    });
+
+    // showPromptRemove/toRemove come from a vuex module the mock store does not
+    // run, so the modal is opened directly.
+    wrapper.vm.showModal = true;
+
+    return wrapper;
+  };
+
+  const resource = (nameDisplay: string) => ({
+    nameDisplay,
+    type:         'namespace',
+    schema:       { id: 'namespace' },
+    currentRoute: () => ({ params: {} }),
+  });
+
+  it('renders its chrome through RcModal rather than a Card', async() => {
+    const wrapper = mountPrompt([resource('my-namespace')]);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="rc-modal"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card"]').exists()).toBe(false);
+  });
+
+  it('puts the prompt title in the header slot', async() => {
+    const wrapper = mountPrompt([resource('my-namespace')]);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="rc-modal-title"]').text()).toBe('%promptRemove.title%');
+  });
+
+  it('puts the names of what is being removed in the body slot', async() => {
+    const wrapper = mountPrompt([resource('my-namespace')]);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="rc-modal-body"]').text()).toContain('%promptRemove.attemptingToRemove%');
+  });
+
+  it('puts cancel and delete in the actions slot, cancel first', async() => {
+    const wrapper = mountPrompt([resource('my-namespace')]);
+
+    await wrapper.vm.$nextTick();
+
+    const buttons = wrapper.findAll('[data-testid="rc-modal-actions"] button');
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].text()).toBe('%generic.cancel%');
+    expect(buttons[0].classes()).toContain('role-secondary');
+    expect(buttons[1].attributes('data-testid')).toBe('prompt-remove-confirm-button');
+    expect(buttons[1].classes()).toContain('bg-error');
+  });
+
+  it('closes through the store when cancel is clicked', async() => {
+    const wrapper = mountPrompt([resource('my-namespace')]);
+
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-testid="rc-modal-actions"] button.role-secondary').trigger('click');
+
+    expect(wrapper.vm.$store.state['action-menu'].showPromptRemove).toBe(false);
+  });
+});

--- a/shell/dialog/MoveNamespaceDialog.vue
+++ b/shell/dialog/MoveNamespaceDialog.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
-import { Card } from '@components/Card';
+import { RcModal } from '@components/RcModal';
 import AsyncButton from '@shell/components/AsyncButton';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { MANAGEMENT } from '@shell/config/types';
@@ -12,7 +12,7 @@ export default {
   emits: ['close'],
 
   components: {
-    AsyncButton, Card, LabeledSelect
+    AsyncButton, RcModal, LabeledSelect
   },
 
   props: {
@@ -107,33 +107,23 @@ export default {
 };
 </script>
 <template>
-  <Card
-    class="move-modal-card"
-    :show-highlight-border="false"
-  >
-    <template #title>
-      <h4 class="text-default-text">
-        {{ t('moveModal.title') }}
-      </h4>
-    </template>
-    <template #body>
-      <div>
-        {{ t('moveModal.description') }}
-        <ul class="namespaces">
-          <li
-            v-for="(namespace, i) in toMove"
-            :key="i"
-          >
-            {{ namespace.nameDisplay }}
-          </li>
-        </ul>
-      </div>
-      <LabeledSelect
-        v-model:value="targetProject"
-        :options="projectOptions"
-        :label="t('moveModal.targetProject')"
-      />
-    </template>
+  <RcModal :title="t('moveModal.title')">
+    <div>
+      {{ t('moveModal.description') }}
+      <ul class="namespaces">
+        <li
+          v-for="(namespace, i) in toMove"
+          :key="i"
+        >
+          {{ namespace.nameDisplay }}
+        </li>
+      </ul>
+    </div>
+    <LabeledSelect
+      v-model:value="targetProject"
+      :options="projectOptions"
+      :label="t('moveModal.targetProject')"
+    />
     <template #actions>
       <button
         class="btn role-secondary"
@@ -143,31 +133,17 @@ export default {
       </button>
       <AsyncButton
         :action-label="t('moveModal.moveButtonLabel')"
-        class="btn bg-primary ml-10"
+        class="btn bg-primary"
         :disabled="targetProject === null"
         @click="move"
       />
     </template>
-  </Card>
+  </RcModal>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
   .namespaces {
     max-height: 200px;
-    overflow-y: scroll;
-  }
-
-  .move-modal-card {
-      box-shadow: none;
-
-      border-radius: var(--border-radius);
-  }
-
-  .actions {
-    text-align: right;
-  }
-  .card-actions {
-    display: flex;
-    justify-content: center;
+    overflow-y: auto;
   }
 </style>

--- a/shell/dialog/RotateCertificatesDialog.vue
+++ b/shell/dialog/RotateCertificatesDialog.vue
@@ -1,5 +1,5 @@
 <script>
-import { Card } from '@components/Card';
+import { RcModal } from '@components/RcModal';
 import AsyncButton from '@shell/components/AsyncButton';
 import { Banner } from '@components/Banner';
 
@@ -15,7 +15,7 @@ export default {
   components: {
     Select,
     RadioGroup,
-    Card,
+    RcModal,
     AsyncButton,
     Banner
   },
@@ -125,72 +125,52 @@ export default {
 </script>
 
 <template>
-  <Card
-    class="prompt-rotate"
-    :show-highlight-border="false"
-    :style="{'height':'100%'}"
-  >
-    <template #title>
-      <h3>{{ t('cluster.rotateCertificates.modalTitle') }}</h3>
-    </template>
-    <template #body>
-      <Banner
-        v-for="(error, i) in errors"
-        :key="i"
-        class=""
-        color="error"
-        :label="error"
+  <RcModal :title="t('cluster.rotateCertificates.modalTitle')">
+    <Banner
+      v-for="(error, i) in errors"
+      :key="i"
+      color="error"
+      :label="error"
+    />
+    <div class="options">
+      <RadioGroup
+        v-model:value="rotateAllServices"
+        name="service-mode"
+        :options="[
+          {
+            value: true,
+            label:t('cluster.rotateCertificates.allServices')
+          },
+          {
+            value: false,
+            label:t('cluster.rotateCertificates.selectService')
+          }
+        ]"
       />
-      <div class="options">
-        <RadioGroup
-          v-model:value="rotateAllServices"
-          name="service-mode"
-          :options="[
-            {
-              value: true,
-              label:t('cluster.rotateCertificates.allServices')
-            },
-            {
-              value: false,
-              label:t('cluster.rotateCertificates.selectService')
-            }
-          ]"
-        />
-        <Select
-          v-model:value="selectedService"
-          :options="serviceOptions"
-          class="service-select"
-          :class="{'invisible': rotateAllServices}"
-        />
-      </div>
-    </template>
+      <Select
+        v-model:value="selectedService"
+        :options="serviceOptions"
+        class="service-select"
+        :class="{'invisible': rotateAllServices}"
+      />
+    </div>
     <template #actions>
-      <div class="buttons">
-        <button
-          class="btn role-secondary mr-20"
-          @click="close"
-        >
-          {{ t('generic.cancel') }}
-        </button>
-        <AsyncButton
-          mode="rotate"
-          :disabled="!rotateAllServices && !selectedService"
-          @click="rotate"
-        />
-      </div>
+      <button
+        class="btn role-secondary"
+        @click="close"
+      >
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton
+        mode="rotate"
+        :disabled="!rotateAllServices && !selectedService"
+        @click="rotate"
+      />
     </template>
-  </Card>
+  </RcModal>
 </template>
 
 <style lang='scss' scoped>
-  .prompt-rotate {
-    margin: 0;
-  }
-  .buttons {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
   .options {
     display: flex;
     flex-direction: column;

--- a/shell/dialog/UninstallExtensionDialog.vue
+++ b/shell/dialog/UninstallExtensionDialog.vue
@@ -2,13 +2,14 @@
 import { mapGetters } from 'vuex';
 
 import AsyncButton from '@shell/components/AsyncButton';
+import { RcModal } from '@components/RcModal';
 import { CATALOG } from '@shell/config/types';
 import { UI_PLUGIN_NAMESPACE } from '@shell/config/uiplugins';
 
 export default {
   emits: ['close'],
 
-  components: { AsyncButton },
+  components: { AsyncButton, RcModal },
 
   props: {
     /**
@@ -101,40 +102,28 @@ export default {
 </script>
 
 <template>
-  <div class="plugin-install-dialog">
-    <h4 class="mt-10">
+  <RcModal>
+    <template #title>
       {{ t('plugins.uninstall.title', { name: `"${plugin?.label}"` }, true) }}
-    </h4>
-    <div class="mt-10 dialog-panel">
-      <div class="dialog-info">
-        <p>
-          {{ t('plugins.uninstall.prompt') }}
-        </p>
-      </div>
-      <div class="dialog-buttons">
-        <button
-          :disabled="busy"
-          class="btn role-secondary"
-          data-testid="uninstall-ext-modal-cancel-btn"
-          @click="closeDialog(false)"
-        >
-          {{ t('generic.cancel') }}
-        </button>
-        <AsyncButton
-          mode="uninstall"
-          :icon="busy ? '' : 'icon-delete'"
-          data-testid="uninstall-ext-modal-uninstall-btn"
-          @click="uninstall()"
-        />
-      </div>
-    </div>
-  </div>
+    </template>
+    <p>
+      {{ t('plugins.uninstall.prompt') }}
+    </p>
+    <template #actions>
+      <button
+        :disabled="busy"
+        class="btn role-secondary"
+        data-testid="uninstall-ext-modal-cancel-btn"
+        @click="closeDialog(false)"
+      >
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton
+        mode="uninstall"
+        :icon="busy ? '' : 'icon-delete'"
+        data-testid="uninstall-ext-modal-uninstall-btn"
+        @click="uninstall()"
+      />
+    </template>
+  </RcModal>
 </template>
-
-<style lang="scss" scoped>
-  @import '@shell/assets/styles/base/_mixins.scss';
-
-  .plugin-install-dialog {
-    @include extension-dialog;
-  }
-</style>

--- a/storybook/src/stories/Components/RcModal.stories.ts
+++ b/storybook/src/stories/Components/RcModal.stories.ts
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { RcModal } from '@components/RcModal';
+
+/**
+ * `RcModal` is the standard chrome for a modal's contents: a titled header, a
+ * body that scrolls when it has to, and a footer whose actions sit in one place
+ * at one size.
+ *
+ * It is layout only. Overlay, teleport, focus trap, `Esc` and click-outside
+ * close, and width stay with `AppModal`. A component registered in
+ * `shell/dialog/` writes the `RcModal` alone, because `PromptModal` already
+ * supplies the `AppModal` around it. A standalone modal writes both:
+ *
+ * ```html
+ * <AppModal :width="600" :trigger-focus-trap="true" @close="close">
+ *   <RcModal :title="t('some.title')">
+ *     ...
+ *   </RcModal>
+ * </AppModal>
+ * ```
+ *
+ * The title gives the surrounding dialog its accessible name on its own, so
+ * there is nothing to wire up. Do not reach for `Card` inside a modal; this
+ * replaces it.
+ *
+ * The stories below render the chrome on its own, inside a box standing in for
+ * the dialog `AppModal` would provide.
+ */
+const meta: Meta<typeof RcModal> = {
+  component: RcModal,
+  argTypes:  {
+    title:   { control: 'text' },
+    titleId: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RcModal>;
+
+// Stands in for the box AppModal renders. The three layout declarations are the
+// ones AppModal puts on `.modal-container:has(.rc-modal)`; the rest is just so
+// the chrome is shown at a realistic width against the modal background.
+const DIALOG = `
+  background: var(--modal-bg);
+  border: 1px solid var(--modal-border);
+  border-radius: var(--border-radius);
+  width: 600px;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const render = (body: string, actions: string) => (args: Record<string, unknown>) => ({
+  components: { RcModal },
+  setup() {
+    return { args, DIALOG };
+  },
+  template: `
+    <div :style="DIALOG">
+      <RcModal v-bind="args">
+        ${ body }
+        ${ actions ? `<template #actions>${ actions }</template>` : '' }
+      </RcModal>
+    </div>
+  `,
+});
+
+const CONFIRM_ACTIONS = `
+  <button class="btn role-secondary">Cancel</button>
+  <button class="btn role-primary">Move</button>
+`;
+
+/**
+ * The shape almost every modal wants: a title, some body copy, and a secondary
+ * then primary action right-aligned in the footer.
+ */
+export const Default: Story = {
+  args:   { title: 'Move to a new project?' },
+  render: render('<p>You are moving the following namespaces.</p>', CONFIRM_ACTIONS),
+};
+
+/**
+ * A destructive confirm. The chrome is identical; only the primary button's
+ * role changes, so delete prompts line up with everything else.
+ */
+export const Destructive: Story = {
+  args:   { title: 'Are you sure?' },
+  render: render(
+    '<p>You are attempting to delete the Namespace <b>my-namespace</b>.</p>',
+    `
+      <button class="btn role-secondary">Cancel</button>
+      <button class="btn bg-error">Delete</button>
+    `
+  ),
+};
+
+/**
+ * With no actions slot the footer, and the rule above it, are left out.
+ */
+export const WithoutActions: Story = {
+  args:   { title: 'Diagnostic timings' },
+  render: render('<p>Nothing here needs confirming.</p>', ''),
+};
+
+/**
+ * With no title the header, and the rule beneath it, are left out. Used by
+ * modals that are all content, such as the search dialog.
+ */
+export const WithoutHeader: Story = {
+  args:   {},
+  render: render('<p>All content, no chrome above it.</p>', CONFIRM_ACTIONS),
+};
+
+/**
+ * When the body outgrows the dialog it is the body that scrolls. The header and
+ * the actions stay where they are, and the body becomes a tab stop so that a
+ * keyboard can reach the overflow. A body that fits does not become one.
+ */
+export const ScrollingBody: Story = {
+  args:   { title: 'Move to a new project?' },
+  render: render(
+    `<p v-for="n in 30" :key="n">Namespace {{ n }}</p>`,
+    CONFIRM_ACTIONS
+  ),
+};


### PR DESCRIPTION
### Summary
Fixes #18264

### Occurred changes and/or fixed issues

- New `RcModal` in `pkg/rancher-components`: the header, body and footer chrome every modal was deciding for itself.
- Migrated four of the six modals the issue names, covering all three body patterns in the tree.
- `AppModal` now lets a modal holding an `RcModal` scroll in the body rather than as a whole.
- Storybook page with six stories.
- Supersedes #18866, which wrapped `AppModal` instead.

### Technical notes summary

- **Layout only, not a wrapper around `AppModal`.** `PromptModal` already renders `AppModal` for 36 of the 42 modals, so a wrapper would teleport a second overlay and block migrating them one at a time.
- **The title names the surrounding dialog itself**, because `role="dialog"` sits on `AppModal`'s element and a dialog reached through `PromptModal` cannot be labelled from inside. All four gain a name they lacked.
- **A scrolling body becomes a tab stop.** Chromium focuses a scroller only when it holds nothing else focusable, and the focus trap tabs by tabindex, so neither reached the overflow.
- **Figma could not be opened from this environment**, so the values are the repo's own tokens. Worth a design pass before the rest of the migration follows.

### Areas or cases that should be tested

```bash
npx jest --ci pkg/rancher-components/src/components/RcModal shell/components/__tests__/PromptRemove.test.ts
```

1. Explorer > Projects/Namespaces > tick one > **Move**. The target-project menu must open unclipped.
2. Same row > **Delete**. This is every delete in the product: check the name field, the warning and error text, and the per-type bodies in `shell/promptRemove/`.
3. A downstream cluster > ⋮ > **Rotate Certificates**, and Extensions > installed extension > **Uninstall**.
4. Shrink the window until a body overflows: `Tab` must reach it, `PageDown` must scroll it, header and actions must stay put.

Correct result: all four wear the same chrome, in light and dark.

### Areas which could experience regressions

- `PromptRemove` backs every delete, and `shell/promptRemove/` is a public extension folder, so third-party bodies render in the new body slot.
- `.prompt-remove` is shared: `ScalePoolDownDialog` and `SloDialog` lean on two of its global rules, which stay until those migrate.
- `jest.setup.js` now stubs `ResizeObserver` for every suite.

### Screenshot/Video

<!-- TODO(manual upload): the browser sidecar has no GitHub session here; drag-drop each file into this section. -->
- Before, `/workspace/artifacts/reproduce/before.webm` - Move then Delete, two sets of chrome.
- After, `/workspace/artifacts/verify/after.webm` - the same walk, one frame.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
