### PR TITLE
[backport 2.14.6] fix: retry Harvester UI extension installation on catalog cache misses

### DIFF
--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -56,6 +56,16 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
     cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
     cy.intercept('POST', '/v3/clusters').as('createHarvesterCluster');
 
+    // create harvester repository and wait for repo downloaded
+    cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+      type:     'catalog.cattle.io.clusterrepo',
+      metadata: { name: harvesterGitRepoName },
+      spec:     {
+        clientSecret: null, gitRepo: harvesterGitRepoUrl, gitBranch: branchName
+      }
+    });
+    cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName);
+
     // verify install button and message displays
     harvesterPo.goTo();
     harvesterPo.waitForPage();
@@ -64,7 +74,6 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
 
     // install harvester extension
     harvesterPo.updateOrInstallButton().click();
-    cy.wait('@createHarvesterChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 201);
     cy.wait('@updateHarvesterChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
     // Wait for the installation request and handle 500 errors
     cy.wait('@installHarvesterExtension', MEDIUM_TIMEOUT_OPT).then((interception) => {

--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -38,9 +38,9 @@ harvesterManager:
       prompt: "Please update Rancher to get the latest compatible version of the Harvester UI extension or try to install it manually"
       prompt-standard-user: Please contact your system administrator
     error:
-      warning: "Warning, [[Harvester]] UI extension automatic installation failed"
-      prompt: "Please refresh the page and try again or install the [[Harvester]] UI extension manually"
-      prompt-standard-user: Please contact your system administrator to install or update the [[Harvester]] extension
+      warning: "Warning, Harvester UI extension automatic installation failed"
+      prompt: "Please refresh the page and try again or install the Harvester UI extension manually"
+      prompt-standard-user: Please contact your system administrator to install or update the Harvester extension
     action:
       retrying: "Retry installing...({attempt}/{max})"
   rke:

--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -38,9 +38,11 @@ harvesterManager:
       prompt: "Please update Rancher to get the latest compatible version of the Harvester UI extension or try to install it manually"
       prompt-standard-user: Please contact your system administrator
     error:
-      warning: "Warning, Harvester UI extension automatic installation failed"
-      prompt: "Please refresh the page and try again or install the Harvester UI extension manually"
-      prompt-standard-user: Please contact your system administrator to install or update the Harvester extension
+      warning: "Warning, [[Harvester]] UI extension automatic installation failed"
+      prompt: "Please refresh the page and try again or install the [[Harvester]] UI extension manually"
+      prompt-standard-user: Please contact your system administrator to install or update the [[Harvester]] extension
+    action:
+      retrying: "Retry installing...({attempt}/{max})"
   rke:
     templateError: Incorrect template format
   affinity:

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -247,19 +247,6 @@ export default {
       return null;
     },
 
-    // Return the logo information based on whether is is Harvester or SUSE Virtualization.
-    logo() {
-      const isSuseVirtualization = this.$store.getters['i18n/global']('Harvester') === 'SUSE Virtualization';
-
-      return !isSuseVirtualization ? {
-        name:   'harvester.png',
-        height: 64
-      } : {
-        name:   'suse-virtualization.svg',
-        height: 36
-      };
-    },
-
     // Overrides the AsyncButton's waiting label while an install/upgrade action is being retried
     harvesterActionRetryLabel() {
       if (!this.harvesterActionRetryAttempt) {

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -329,6 +329,7 @@ export default {
 
         installed = await waitForUIPackage(this.$store, extension, 20);
       } catch (error) {
+        console.error('Error installing Harvester UI extension', error); // eslint-disable-line no-console
       }
 
       this.harvesterActionRetryAttempt = 0;

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -23,7 +23,8 @@ import {
   getHelmRepositoryMatch,
   createHelmRepository,
   refreshHelmRepository,
-  installHelmChart,
+  installHelmChartWithRetry,
+  INSTALL_ACTION_MAX_RETRIES,
   waitForUIExtension,
   waitForUIPackage,
 } from '@shell/utils/uiplugins';
@@ -91,6 +92,7 @@ export default {
       harvesterRepositoryError:       false,
       harvesterExtensionInstallError: false,
       harvesterExtensionUpdateError:  false,
+      harvesterActionRetryAttempt:    0,
       clusterRepoLink:                {
         name:   'c-cluster-product-resource',
         params: {
@@ -243,7 +245,32 @@ export default {
 
       // No custom rows limit; 'Table Rows Per Page' preference will be used.
       return null;
-    }
+    },
+
+    // Return the logo information based on whether is is Harvester or SUSE Virtualization.
+    logo() {
+      const isSuseVirtualization = this.$store.getters['i18n/global']('Harvester') === 'SUSE Virtualization';
+
+      return !isSuseVirtualization ? {
+        name:   'harvester.png',
+        height: 64
+      } : {
+        name:   'suse-virtualization.svg',
+        height: 36
+      };
+    },
+
+    // Overrides the AsyncButton's waiting label while an install/upgrade action is being retried
+    harvesterActionRetryLabel() {
+      if (!this.harvesterActionRetryAttempt) {
+        return null;
+      }
+
+      return this.t('harvesterManager.extension.action.retrying', {
+        attempt: this.harvesterActionRetryAttempt,
+        max:     INSTALL_ACTION_MAX_RETRIES,
+      });
+    },
   },
 
   methods: {
@@ -274,6 +301,8 @@ export default {
     async installHarvesterExtension(btnCb) {
       let installed = false;
 
+      this.harvesterActionRetryAttempt = 0;
+
       try {
         let harvesterRepository = this.harvesterRepository;
 
@@ -295,7 +324,7 @@ export default {
           return;
         }
 
-        await installHelmChart(
+        await installHelmChartWithRetry(
           harvesterRepository,
           {
             ...HARVESTER_CHART,
@@ -303,7 +332,10 @@ export default {
           },
           {},
           UI_PLUGIN_NAMESPACE,
-          'install'
+          'install',
+          (attempt) => {
+            this.harvesterActionRetryAttempt = attempt;
+          },
         );
 
         const extension = await waitForUIExtension(this.$store, HARVESTER_CHART.name, 20);
@@ -312,6 +344,7 @@ export default {
       } catch (error) {
       }
 
+      this.harvesterActionRetryAttempt = 0;
       this.harvesterExtensionInstallError = !installed;
 
       btnCb(installed);
@@ -323,6 +356,8 @@ export default {
 
     async updateHarvesterExtension(btnCb) {
       let updated = false;
+
+      this.harvesterActionRetryAttempt = 0;
 
       try {
         if (this.harvester.missingRepository) {
@@ -337,7 +372,7 @@ export default {
           return;
         }
 
-        await installHelmChart(
+        await installHelmChartWithRetry(
           this.harvesterRepository,
           {
             ...HARVESTER_CHART,
@@ -345,7 +380,10 @@ export default {
           },
           {},
           UI_PLUGIN_NAMESPACE,
-          'upgrade'
+          'upgrade',
+          (attempt) => {
+            this.harvesterActionRetryAttempt = attempt;
+          },
         );
 
         const extension = await waitForUIExtension(this.$store, HARVESTER_CHART.name);
@@ -354,6 +392,7 @@ export default {
       } catch (error) {
       }
 
+      this.harvesterActionRetryAttempt = 0;
       this.harvesterExtensionUpdateError = !updated;
 
       btnCb(updated);
@@ -525,6 +564,7 @@ export default {
           >
             <AsyncButton
               :mode="harvester.toInstall ? 'install' : 'update'"
+              :waiting-label="harvesterActionRetryLabel"
               @click="harvester.action"
             />
           </div>

--- a/shell/utils/__tests__/uiplugins-extra.test.ts
+++ b/shell/utils/__tests__/uiplugins-extra.test.ts
@@ -370,23 +370,23 @@ describe('shell/utils/uiplugins', () => {
       expect(onRetry).toHaveBeenNthCalledWith(2, 2, INSTALL_ACTION_MAX_RETRIES);
     });
 
-    it('throws the transient error once retries are exhausted', async() => {
+    it('waits the full backoff schedule (1s, 2s, 4s, 8s) across all retries', async() => {
       const repo = { doAction: jest.fn().mockRejectedValue(transientError) };
-      const onRetry = jest.fn();
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
 
-      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install');
 
-      // Swallow the rejection so advancing timers below doesn't trigger an unhandled rejection;
-      // the actual assertion happens afterwards once all backoff waits have fired.
       promise.catch(() => {});
 
       await jest.advanceTimersByTimeAsync(30000);
 
       await expect(promise).rejects.toBe(transientError);
 
-      // Initial attempt + one retry per configured backoff delay
-      expect(repo.doAction).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES + 1);
-      expect(onRetry).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES);
+      const delays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+
+      expect(delays).toStrictEqual([1000, 2000, 4000, 8000]);
+
+      setTimeoutSpy.mockRestore();
     });
 
     it('passes through install/upgrade action and namespace like installHelmChart', async() => {

--- a/shell/utils/__tests__/uiplugins-extra.test.ts
+++ b/shell/utils/__tests__/uiplugins-extra.test.ts
@@ -91,7 +91,7 @@ describe('shell/utils/uiplugins', () => {
 
       await onExtensionsReady(store);
 
-      expect(onLogIn2).toHaveBeenCalled();
+      expect(onLogIn2).toHaveBeenCalledWith(store);
       expect(store.dispatch).toHaveBeenCalledWith('uiplugins/setReady', true);
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('failing-ext'),
@@ -318,13 +318,12 @@ describe('shell/utils/uiplugins', () => {
     };
     const transientError = { _status: 500, message: 'failed to find chart harvester-extension version 1.9.0 Not found 404' };
 
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
+    // Jest 27 lacks advanceTimersByTimeAsync, so run the backoff waits instantly while recording the delays
+    const stubBackoffTimers = () => jest.spyOn(global, 'setTimeout').mockImplementation(((cb: () => void) => {
+      cb();
 
-    afterEach(() => {
-      jest.useRealTimers();
-    });
+      return 0;
+    }) as any);
 
     it('resolves on the first try without retrying', async() => {
       const repo = { doAction: jest.fn().mockResolvedValue({ id: 'ok' }) };
@@ -356,33 +355,25 @@ describe('shell/utils/uiplugins', () => {
           .mockResolvedValueOnce({ id: 'ok-after-retry' }),
       };
       const onRetry = jest.fn();
+      const setTimeoutSpy = stubBackoffTimers();
 
-      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
-
-      // Flush the two backoff waits so the retried attempts get a chance to run
-      await jest.advanceTimersByTimeAsync(10000);
-
-      const result = await promise;
+      const result = await installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
 
       expect(result).toStrictEqual({ id: 'ok-after-retry' });
       expect(repo.doAction).toHaveBeenCalledTimes(3);
       expect(onRetry).toHaveBeenNthCalledWith(1, 1, INSTALL_ACTION_MAX_RETRIES);
       expect(onRetry).toHaveBeenNthCalledWith(2, 2, INSTALL_ACTION_MAX_RETRIES);
+
+      setTimeoutSpy.mockRestore();
     });
 
     it('waits the full backoff schedule (1s, 2s, 4s, 8s) across all retries', async() => {
       const repo = { doAction: jest.fn().mockRejectedValue(transientError) };
-      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      const setTimeoutSpy = stubBackoffTimers();
 
-      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install');
+      await expect(installHelmChartWithRetry(repo, chart, {}, 'default', 'install')).rejects.toBe(transientError);
 
-      promise.catch(() => {});
-
-      await jest.advanceTimersByTimeAsync(30000);
-
-      await expect(promise).rejects.toBe(transientError);
-
-      const delays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+      const delays = Array.from(setTimeoutSpy.mock.calls, ([, delay]) => delay);
 
       expect(delays).toStrictEqual([1000, 2000, 4000, 8000]);
 

--- a/shell/utils/__tests__/uiplugins-extra.test.ts
+++ b/shell/utils/__tests__/uiplugins-extra.test.ts
@@ -1,0 +1,400 @@
+import {
+  onExtensionsReady,
+  getLatestExtensionVersion,
+  installHelmChart,
+  installHelmChartWithRetry,
+  isTransientChartActionError,
+  INSTALL_ACTION_MAX_RETRIES,
+} from '@shell/utils/uiplugins';
+
+import { isSupportedChartVersion } from '@shell/config/uiplugins';
+
+// Mock dependencies with no real disk/network I/O
+jest.mock('@shell/config/uiplugins', () => ({
+  UI_PLUGIN_BASE_URL:      '/v1/uiplugins',
+  isSupportedChartVersion: jest.fn(),
+  UI_PLUGIN_LABELS:        { CATALOG_IMAGE: 'catalog.cattle.io/ui-catalog-image' },
+}));
+
+jest.mock('@shell/utils/string', () => ({ matchesSomeRegex: jest.fn() }));
+
+jest.mock('@shell/config/labels-annotations', () => ({
+  CATALOG: {
+    SOURCE_REPO_TYPE: 'catalog.cattle.io/ui-source-repo-type',
+    SOURCE_REPO_NAME: 'catalog.cattle.io/ui-source-repo',
+  },
+}));
+
+jest.mock('@shell/config/types', () => ({ CATALOG: { CLUSTER_REPO: 'catalog.cattle.io.clusterrepo' } }));
+
+const mockIsSupportedChartVersion = isSupportedChartVersion as jest.Mock;
+
+describe('shell/utils/uiplugins', () => {
+  describe('onExtensionsReady', () => {
+    it('returns early when already ready', async() => {
+      const store = {
+        getters:  { 'uiplugins/ready': true, 'uiplugins/plugins': [] },
+        dispatch: jest.fn(),
+      };
+
+      await onExtensionsReady(store);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches setReady when not yet ready and no plugins', async() => {
+      const store = {
+        getters:  { 'uiplugins/ready': false, 'uiplugins/plugins': [] },
+        dispatch: jest.fn(),
+      };
+
+      await onExtensionsReady(store);
+
+      expect(store.dispatch).toHaveBeenCalledWith('uiplugins/setReady', true);
+    });
+
+    it('calls onLogIn on each plugin', async() => {
+      const onLogIn1 = jest.fn().mockResolvedValue(undefined);
+      const onLogIn2 = jest.fn().mockResolvedValue(undefined);
+      const store = {
+        getters: {
+          'uiplugins/ready':   false,
+          'uiplugins/plugins': [
+            { name: 'ext1', onLogIn: onLogIn1 },
+            { name: 'ext2', onLogIn: onLogIn2 },
+          ],
+        },
+        dispatch: jest.fn(),
+      };
+
+      await onExtensionsReady(store);
+
+      expect(onLogIn1).toHaveBeenCalledWith(store);
+      expect(onLogIn2).toHaveBeenCalledWith(store);
+      expect(store.dispatch).toHaveBeenCalledWith('uiplugins/setReady', true);
+    });
+
+    it('continues to next plugin and dispatches setReady even when onLogIn throws', async() => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const onLogIn1 = jest.fn().mockRejectedValue(new Error('ext error'));
+      const onLogIn2 = jest.fn().mockResolvedValue(undefined);
+      const store = {
+        getters: {
+          'uiplugins/ready':   false,
+          'uiplugins/plugins': [
+            { name: 'failing-ext', onLogIn: onLogIn1 },
+            { name: 'working-ext', onLogIn: onLogIn2 },
+          ],
+        },
+        dispatch: jest.fn(),
+      };
+
+      await onExtensionsReady(store);
+
+      expect(onLogIn2).toHaveBeenCalled();
+      expect(store.dispatch).toHaveBeenCalledWith('uiplugins/setReady', true);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('failing-ext'),
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('treats null plugins getter as empty array', async() => {
+      const store = {
+        getters:  { 'uiplugins/ready': false, 'uiplugins/plugins': null },
+        dispatch: jest.fn(),
+      };
+
+      await onExtensionsReady(store);
+
+      expect(store.dispatch).toHaveBeenCalledWith('uiplugins/setReady', true);
+    });
+  });
+
+  describe('getLatestExtensionVersion', () => {
+    it('returns the first compatible version', async() => {
+      mockIsSupportedChartVersion.mockImplementation(({ version }) => version.version !== '1.0.0');
+
+      const store = {
+        dispatch: jest.fn().mockResolvedValue(undefined),
+        getters:  {
+          'catalog/chart': () => ({
+            versions: [
+              { version: '1.0.0' },
+              { version: '2.0.0' },
+              { version: '3.0.0' },
+            ],
+          }),
+        },
+      };
+
+      const result = await getLatestExtensionVersion(store, 'my-chart', '2.13.0', '1.26.0');
+
+      expect(result).toBe('2.0.0');
+    });
+
+    it('returns undefined when no compatible versions exist', async() => {
+      mockIsSupportedChartVersion.mockReturnValue(false);
+
+      const store = {
+        dispatch: jest.fn().mockResolvedValue(undefined),
+        getters:  { 'catalog/chart': () => ({ versions: [{ version: '1.0.0' }] }) },
+      };
+
+      const result = await getLatestExtensionVersion(store, 'my-chart', '2.13.0', '1.26.0');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when chart is not found', async() => {
+      const store = {
+        dispatch: jest.fn().mockResolvedValue(undefined),
+        getters:  { 'catalog/chart': () => undefined },
+      };
+
+      const result = await getLatestExtensionVersion(store, 'missing-chart', '2.13.0', '1.26.0');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('dispatches catalog/load with provided options', async() => {
+      const store = {
+        dispatch: jest.fn().mockResolvedValue(undefined),
+        getters:  { 'catalog/chart': () => ({ versions: [] }) },
+      };
+
+      const opt = { reset: false, force: false };
+
+      await getLatestExtensionVersion(store, 'my-chart', '2.13.0', '1.26.0', opt);
+
+      expect(store.dispatch).toHaveBeenCalledWith('catalog/load', opt);
+    });
+  });
+
+  describe('installHelmChart', () => {
+    it('calls doAction with install by default', async() => {
+      const mockResult = { id: 'install-123' };
+      const repo = { doAction: jest.fn().mockResolvedValue(mockResult) };
+      const chart = {
+        name:     'my-extension',
+        version:  '1.2.3',
+        repoType: 'helm',
+        repoName: 'rancher-ui-plugins',
+      };
+
+      const result = await installHelmChart(repo, chart);
+
+      expect(repo.doAction).toHaveBeenCalledWith('install', expect.objectContaining({
+        charts: expect.arrayContaining([
+          expect.objectContaining({
+            chartName:   'my-extension',
+            version:     '1.2.3',
+            releaseName: 'my-extension',
+          }),
+        ]),
+        namespace: 'default',
+        wait:      true,
+      }));
+      expect(result).toStrictEqual(mockResult);
+    });
+
+    it('calls doAction with upgrade action when specified', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+      const chart = {
+        name:     'my-extension',
+        version:  '2.0.0',
+        repoType: 'helm',
+        repoName: 'rancher-ui-plugins',
+      };
+
+      await installHelmChart(repo, chart, {}, 'default', 'upgrade');
+
+      expect(repo.doAction).toHaveBeenCalledWith('upgrade', expect.any(Object));
+    });
+
+    it('uses provided namespace', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+      const chart = {
+        name:     'my-extension',
+        version:  '1.0.0',
+        repoType: 'helm',
+        repoName: 'rancher-ui-plugins',
+      };
+
+      await installHelmChart(repo, chart, {}, 'cattle-ui-plugin-system');
+
+      expect(repo.doAction).toHaveBeenCalledWith('install', expect.objectContaining({ namespace: 'cattle-ui-plugin-system' }));
+    });
+
+    it('includes annotations with repo type and name from chart', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+      const chart = {
+        name:     'my-extension',
+        version:  '1.0.0',
+        repoType: 'helm',
+        repoName: 'official',
+      };
+
+      await installHelmChart(repo, chart);
+
+      const [, installRequest] = repo.doAction.mock.calls[0];
+      const chartInstall = installRequest.charts[0];
+
+      expect(chartInstall.annotations).toStrictEqual({
+        'catalog.cattle.io/ui-source-repo-type': 'helm',
+        'catalog.cattle.io/ui-source-repo':      'official',
+      });
+    });
+
+    it('passes provided values to the chart install', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+      const chart = {
+        name:     'my-extension',
+        version:  '1.0.0',
+        repoType: 'helm',
+        repoName: 'official',
+      };
+      const values = { global: { cattle: { systemDefaultRegistry: 'myregistry.example' } } };
+
+      await installHelmChart(repo, chart, values);
+
+      const [, installRequest] = repo.doAction.mock.calls[0];
+
+      expect(installRequest.charts[0].values).toStrictEqual(values);
+    });
+  });
+
+  describe('isTransientChartActionError', () => {
+    it('returns false when status is not 500', () => {
+      const error = { _status: 404, message: 'failed to find chart harvester version v1.8.1 Not found 404' };
+
+      expect(isTransientChartActionError(error)).toBe(false);
+    });
+
+    it('returns true for a 500 with the catalog "chart not found" wording (error.message)', () => {
+      const error = { _status: 500, message: 'failed to find chartName harvester version v1.8.1 Not found 404' };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('returns true when the message is nested under error.data.message', () => {
+      const error = { status: 500, data: { message: 'failed to find chart harvester version 1.0.0 not found' } };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('is case-insensitive and tolerant of extra whitespace before "found"', () => {
+      const error = { _status: 500, message: 'FAILED TO FIND CHART harvester VERSION 1.0.0 NOT   FOUND 404' };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+
+    it('returns false for a 500 with an unrelated message', () => {
+      const error = { _status: 500, message: 'permission denied' };
+
+      expect(isTransientChartActionError(error)).toBe(false);
+    });
+
+    it('returns false when there is no message at all', () => {
+      expect(isTransientChartActionError({ _status: 500 })).toBe(false);
+    });
+
+    it('prefers error._status over error.status', () => {
+      const error = {
+        _status: 500, status: 404, message: 'failed to find chart foo version 1.0.0 not found'
+      };
+
+      expect(isTransientChartActionError(error)).toBe(true);
+    });
+  });
+
+  describe('installHelmChartWithRetry', () => {
+    const chart = {
+      name:     'harvester-extension',
+      version:  '1.9.0',
+      repoType: 'helm',
+      repoName: 'official',
+    };
+    const transientError = { _status: 500, message: 'failed to find chart harvester-extension version 1.9.0 Not found 404' };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('resolves on the first try without retrying', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({ id: 'ok' }) };
+      const onRetry = jest.fn();
+
+      const result = await installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      expect(result).toStrictEqual({ id: 'ok' });
+      expect(repo.doAction).toHaveBeenCalledTimes(1);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('throws immediately without retrying for a non-transient error', async() => {
+      const error = { _status: 500, message: 'permission denied' };
+      const repo = { doAction: jest.fn().mockRejectedValue(error) };
+      const onRetry = jest.fn();
+
+      await expect(installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry)).rejects.toBe(error);
+
+      expect(repo.doAction).toHaveBeenCalledTimes(1);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('retries a transient error and eventually succeeds, notifying onRetry each time', async() => {
+      const repo = {
+        doAction: jest.fn()
+          .mockRejectedValueOnce(transientError)
+          .mockRejectedValueOnce(transientError)
+          .mockResolvedValueOnce({ id: 'ok-after-retry' }),
+      };
+      const onRetry = jest.fn();
+
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      // Flush the two backoff waits so the retried attempts get a chance to run
+      await jest.advanceTimersByTimeAsync(10000);
+
+      const result = await promise;
+
+      expect(result).toStrictEqual({ id: 'ok-after-retry' });
+      expect(repo.doAction).toHaveBeenCalledTimes(3);
+      expect(onRetry).toHaveBeenNthCalledWith(1, 1, INSTALL_ACTION_MAX_RETRIES);
+      expect(onRetry).toHaveBeenNthCalledWith(2, 2, INSTALL_ACTION_MAX_RETRIES);
+    });
+
+    it('throws the transient error once retries are exhausted', async() => {
+      const repo = { doAction: jest.fn().mockRejectedValue(transientError) };
+      const onRetry = jest.fn();
+
+      const promise = installHelmChartWithRetry(repo, chart, {}, 'default', 'install', onRetry);
+
+      // Swallow the rejection so advancing timers below doesn't trigger an unhandled rejection;
+      // the actual assertion happens afterwards once all backoff waits have fired.
+      promise.catch(() => {});
+
+      await jest.advanceTimersByTimeAsync(30000);
+
+      await expect(promise).rejects.toBe(transientError);
+
+      // Initial attempt + one retry per configured backoff delay
+      expect(repo.doAction).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES + 1);
+      expect(onRetry).toHaveBeenCalledTimes(INSTALL_ACTION_MAX_RETRIES);
+    });
+
+    it('passes through install/upgrade action and namespace like installHelmChart', async() => {
+      const repo = { doAction: jest.fn().mockResolvedValue({}) };
+
+      await installHelmChartWithRetry(repo, chart, {}, 'cattle-ui-plugin-system', 'upgrade');
+
+      expect(repo.doAction).toHaveBeenCalledWith('upgrade', expect.objectContaining({ namespace: 'cattle-ui-plugin-system' }));
+    });
+  });
+});

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -211,13 +211,14 @@ export async function installHelmChartWithRetry(
         throw error;
       }
 
+      const delay = ACTION_RETRY_DELAYS[attempt];
       const nextAttempt = attempt + 1;
 
-      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ ACTION_RETRY_DELAYS[nextAttempt] / 1000 } second(s) and retry... `); // eslint-disable-line no-console
+      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ delay / 1000 } second(s) and retry... `); // eslint-disable-line no-console
 
       onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
 
-      await new Promise((resolve) => setTimeout(resolve, ACTION_RETRY_DELAYS[nextAttempt]));
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 }

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -213,7 +213,7 @@ export async function installHelmChartWithRetry(
 
       const nextAttempt = attempt + 1;
 
-      console.log(`Installing harvester helm chart failed, attempt ${nextAttempt}, wait ${ACTION_RETRY_DELAYS[nextAttempt]/1000} second(s) and retry... `); // eslint-disable-line no-console
+      console.log(`Installing harvester helm chart failed, attempt ${ nextAttempt }, wait ${ ACTION_RETRY_DELAYS[nextAttempt] / 1000 } second(s) and retry... `); // eslint-disable-line no-console
 
       onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
 

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -6,6 +6,7 @@ import { Plugin, Version } from '@shell/types/uiplugins';
 
 const MAX_RETRIES = 10;
 const RETRY_WAIT = 2500;
+const ACTIVE_STATUS_TIMEOUT = 200000; // 20 seconds
 
 // Backoff schedule (ms) for retrying a chart install/upgrade action that failed because a
 // follower Rancher replica's in-memory catalog index cache hadn't caught up yet (see #17543)
@@ -74,6 +75,7 @@ export async function waitForUIExtension(store: any, name: string, maxRetries = 
         return extension;
       }
     } catch (e) {
+    console.error('waiting for UI extension to be available: error =', e); // eslint-disable-line no-console
     }
 
     tries++;
@@ -111,6 +113,7 @@ export async function waitForUIPackage(store: any, extension: any, maxRetries = 
 
       return true;
     } catch (error) {
+      console.error('waiting for UI extension package to be available: error =', error); // eslint-disable-line no-console  
     }
 
     tries++;
@@ -288,12 +291,13 @@ export async function refreshHelmRepository(store: any, url: string): Promise<vo
 
   await repository.save();
 
-  await repository.waitForState('active', 10000, 1000);
+  await repository.waitForState('active', ACTIVE_STATUS_TIMEOUT, RETRY_WAIT);
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
 }
 
 /**
+ * Create a Helm Repository and wait for it to be downloaded
  *
  * @param store Vue store
  * @param name Repository name
@@ -320,7 +324,7 @@ export async function createHelmRepository(store: any, name: string, url: string
 
   const helmRepo = await repo.save();
 
-  // Poll the repository until it says it has been downloaded
+  // Poll the repository status MAX_RETRIES times until it has been downloaded
   let fetched = false;
   let tries = 0;
 
@@ -335,14 +339,13 @@ export async function createHelmRepository(store: any, name: string, url: string
 
     const downloaded = repo.status.conditions.find((s: any) => s.type === 'Downloaded');
 
-    if (downloaded) {
-      if (downloaded.status === 'True') {
-        fetched = true;
-      }
+    console.log(`Waiting for helm repository to be downloaded... try ${ tries } time(s).`); // eslint-disable-line no-console
+
+    if (downloaded && downloaded.status === 'True') {
+      fetched = true;
     }
 
     if (!fetched) {
-      tries++;
 
       if (tries > MAX_RETRIES) {
         throw new Error('Failed to add Helm Chart Repository');
@@ -350,8 +353,6 @@ export async function createHelmRepository(store: any, name: string, url: string
 
       await new Promise((resolve) => setTimeout(resolve, RETRY_WAIT));
     }
-
-    fetched = true;
   }
 
   // Return the Helm Repository

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -75,7 +75,7 @@ export async function waitForUIExtension(store: any, name: string, maxRetries = 
         return extension;
       }
     } catch (e) {
-    console.error('waiting for UI extension to be available: error =', e); // eslint-disable-line no-console
+      console.error('waiting for UI extension to be available: error =', e); // eslint-disable-line no-console
     }
 
     tries++;
@@ -113,7 +113,7 @@ export async function waitForUIPackage(store: any, extension: any, maxRetries = 
 
       return true;
     } catch (error) {
-      console.error('waiting for UI extension package to be available: error =', error); // eslint-disable-line no-console  
+      console.error('waiting for UI extension package to be available: error =', error); // eslint-disable-line no-console
     }
 
     tries++;
@@ -346,7 +346,6 @@ export async function createHelmRepository(store: any, name: string, url: string
     }
 
     if (!fetched) {
-
       if (tries > MAX_RETRIES) {
         throw new Error('Failed to add Helm Chart Repository');
       }

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -7,6 +7,12 @@ import { Plugin, Version } from '@shell/types/uiplugins';
 const MAX_RETRIES = 10;
 const RETRY_WAIT = 2500;
 
+// Backoff schedule (ms) for retrying a chart install/upgrade action that failed because a
+// follower Rancher replica's in-memory catalog index cache hadn't caught up yet (see #17543)
+const ACTION_RETRY_DELAYS = [1000, 2000, 4000, 8000];
+
+export const INSTALL_ACTION_MAX_RETRIES = ACTION_RETRY_DELAYS.length;
+
 type Action = 'install' | 'upgrade';
 export type HelmRepository = any;
 export type HelmChart = any;
@@ -161,6 +167,59 @@ export async function installHelmChart(repo: any, chart: any, values: any = {}, 
   const res = await repo.doAction(action, installRequest);
 
   return res;
+}
+
+/**
+ * Whether a chart install/upgrade action error is a transient failure caused by a Rancher
+ * replica whose in-memory catalog index cache hasn't caught up with a just-created/updated
+ * repo yet, and is therefore safe to retry (as opposed to e.g. a validation or permission error).
+ */
+export function isTransientChartActionError(error: any): boolean {
+  const status = error?._status ?? error?.status;
+
+  if (status !== 500) {
+    return false;
+  }
+
+  const message = error?.message || error?.data?.message || '';
+
+  // Matches the Rancher catalog controller's own wording, e.g. "failed to find chartName
+  // harvester version v1.8.1 Not found 404", to avoid retrying (and masking) other 500s
+  return /failed to find chart.*version.*not\s*found/i.test(message);
+}
+
+/**
+ * Install/upgrade a Helm Chart, retrying with exponential backoff when the failure looks like a
+ * transient catalog index cache miss (see isTransientChartActionError). Other errors are thrown
+ * immediately without retrying.
+ *
+ * @param onRetry Called before each retry with the attempt number and the max number of retries
+ */
+export async function installHelmChartWithRetry(
+  repo: any,
+  chart: any,
+  values: any = {},
+  namespace = 'default',
+  action: Action = 'install',
+  onRetry?: (attempt: number, maxAttempts: number) => void,
+) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await installHelmChart(repo, chart, values, namespace, action);
+    } catch (error) {
+      if (attempt >= ACTION_RETRY_DELAYS.length || !isTransientChartActionError(error)) {
+        throw error;
+      }
+
+      const nextAttempt = attempt + 1;
+
+      console.log(`Installing harvester helm chart failed, attempt ${nextAttempt}, wait ${ACTION_RETRY_DELAYS[nextAttempt]/1000} second(s) and retry... `); // eslint-disable-line no-console
+
+      onRetry?.(nextAttempt, ACTION_RETRY_DELAYS.length);
+
+      await new Promise((resolve) => setTimeout(resolve, ACTION_RETRY_DELAYS[nextAttempt]));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
### Summary

Backport https://github.com/rancher/dashboard/pull/18953 to release-2.14




### Occurred changes and/or fixed issues
- Retry install and upgrade actions only for HTTP 500 responses matching the catalog's chart/version not-found error.
- Retry create helm chart process.
- unit tests


### Technical notes summary
- Add `isTransientChartActionError` and `installHelmChartWithRetry` without changing the existing `installHelmChart` API.
- Use delays of 1, 2, 4, and 8 seconds: at most four retries after the initial request.
- Immediately propagate non-transient errors; propagate the final error when retries are exhausted.
- Preserve action, namespace, and values when retrying, and notify the UI through an optional retry callback.

### Areas or cases that should be tested
Automated validation completed:
- Ran `yarn jest --runTestsByPath shell/utils/__tests__/uiplugins-extra.test.ts` 10 consecutive times; every run passed all 26 tests with exit code 0.
- Targeted ESLint passed after correcting the assertion matcher. Full-project lint was not rerun after that correction.
- `ts-jest` reports that TypeScript 5.6.3 is outside its tested version range; the targeted tests still pass.

Manual validation pending (no browser testing performed):
1. As an administrator, open Virtualization Management with a compatible Harvester cluster and no installed Harvester UI extension; trigger extension installation.
2. Simulate the chart action returning HTTP 500 with `failed to find chartName harvester version v1.8.1 Not found 404`, then succeeding. Verify retries follow the 1/2/4/8-second schedule, the button displays retry progress, and installation completes.
3. Repeat with an existing extension requiring an upgrade; verify the upgrade action and namespace are preserved.
4. Keep returning the matching transient error. Verify only five total requests occur, the existing failure UI appears, and retry progress clears.
5. Return a permission/validation error or an unrelated HTTP 500. Verify no retry occurs and the existing failure UI appears.
6. Verify successful first-attempt actions remain unchanged, product branding is correct for Harvester and SUSE Virtualization, and status text is legible in light/dark modes.
7. Verify Standard User and User Base access and administrator guidance remain unchanged.

### Areas which could experience regressions
- Harvester UI extension install/upgrade actions, loading labels, and final success/failure states.

### Screenshot/Video


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`