### PR TITLE
Add pause and resume of the autoscaler per machine pool

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2380,6 +2380,26 @@ cluster:
       baseUnit: Machines
       min: Min
       max: Max
+      pauseAriaLabel: Pause autoscaling for machine pool {name}
+      resumeAriaLabel: Resume autoscaling for machine pool {name}
+      disableHint: Turning the autoscaler off discards the autoscaling range for this pool.
+      roleHint: Giving this pool the etcd or Control Plane role turns its autoscaler off and discards its autoscaling range.
+      status:
+        running: Autoscaling
+        paused: Autoscaling paused
+      announce:
+        paused: Autoscaling paused for machine pool {name}. The pool keeps the machine count it has now.
+        resumed: Autoscaling resumed for machine pool {name}.
+        pauseError: Autoscaling could not be paused for machine pool {name}.
+        resumeError: Autoscaling could not be resumed for machine pool {name}.
+      growl:
+        pauseError: Error pausing pool autoscaler
+        resumeError: Error resuming pool autoscaler
+      resumePrompt:
+        title: Resume autoscaling?
+        scaleDown: Machine pool {name} has {count} machines, above the maximum of {target} stored for it. Resuming hands the pool back to the autoscaler, which will scale it down to {target} machines.
+        scaleUp: Machine pool {name} has {count} machines, below the minimum of {target} stored for it. Resuming hands the pool back to the autoscaler, which will scale it up to {target} machines.
+      pausedBanner: Autoscaling is paused for this machine pool. Its machine count is yours to set until you resume autoscaling from the Machine Pools tab of the cluster.
       validation:
         isAutoscalerMaxGreaterThanMin: The max machines count must be equal or exceed the min machine count.
       etcdControlPlaneWarning: We don't recommend using Autoscaler with machine pools that have the etcd or Control Plane roles. You can modify the yaml if you want to override the current value.

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -80,9 +80,15 @@ export const CAPI = {
   /**
    * Annotations for autoscaler
    */
-  AUTOSCALER_CLUSTER_PAUSE:         'provisioning.cattle.io/cluster-autoscaler-paused',
-  AUTOSCALER_MACHINE_POOL_MIN_SIZE: 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size',
-  AUTOSCALER_MACHINE_POOL_MAX_SIZE: 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size'
+  AUTOSCALER_CLUSTER_PAUSE:                'provisioning.cattle.io/cluster-autoscaler-paused',
+  AUTOSCALER_MACHINE_POOL_MIN_SIZE:        'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size',
+  AUTOSCALER_MACHINE_POOL_MAX_SIZE:        'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size',
+  /**
+   * Machine pool level autoscaler pause. The live autoscaling range is stashed in these two keys, in the pool's own
+   * `machineDeploymentAnnotations`, while the pool is paused, and restored from them when it is resumed.
+   */
+  AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE: 'provisioning.cattle.io/cluster-autoscaler-paused-min-size',
+  AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE: 'provisioning.cattle.io/cluster-autoscaler-paused-max-size'
 };
 
 export const CATALOG = {

--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -364,4 +364,183 @@ describe('view: provisioning.cattle.io.cluster', () => {
       expect(result.metadataProps).toStrictEqual(metadataProps);
     });
   });
+
+  describe('machine pool autoscaler controls', () => {
+    let dispatch: jest.Mock;
+
+    const autoscalerMocks = (featureEnabled = true) => ({
+      ...mocks,
+      $store: {
+        ...mockStore,
+        getters: {
+          ...mockStore.getters,
+          'features/get': () => featureEnabled,
+        },
+        dispatch,
+      },
+    });
+
+    const mountCluster = (featureEnabled = true) => shallowMount(ProvisioningCattleIoCluster, {
+      props:  { value: {} },
+      global: { mocks: autoscalerMocks(featureEnabled) },
+    });
+
+    beforeEach(() => {
+      dispatch = jest.fn();
+    });
+
+    const machinePool = (overrides: any = {}) => ({
+      id:                       'fleet-default/cluster-pool1',
+      nameDisplay:              'pool1',
+      isAutoscalerEnabled:      false,
+      isAutoscalerPaused:       false,
+      canPauseResumeAutoscaler: true,
+      toggleAutoscalerPause:    jest.fn(() => Promise.resolve({})),
+      ...overrides
+    });
+
+    describe('showPoolMachineControls', () => {
+      const testCases: [string, any, boolean][] = [
+        ['a pool the autoscaler does not manage', machinePool(), true],
+        ['a pool the autoscaler manages', machinePool({ isAutoscalerEnabled: true }), false],
+        ['a paused pool, which the user scales again', machinePool({ isAutoscalerEnabled: true, isAutoscalerPaused: true }), true],
+        ['no pool', undefined, false],
+      ];
+
+      it.each(testCases)('should be %s -> %s', (_label, pool, expected) => {
+        expect(mountCluster().vm.showPoolMachineControls(pool)).toBe(expected);
+      });
+
+      it('should scale by hand when the autoscaler feature is off, whatever the pool says', () => {
+        expect(mountCluster(false).vm.showPoolMachineControls(machinePool({ isAutoscalerEnabled: true }))).toBe(true);
+      });
+    });
+
+    describe('showPoolAutoscalerControls', () => {
+      it('should show for a pool the autoscaler manages', () => {
+        expect(mountCluster().vm.showPoolAutoscalerControls(machinePool({ isAutoscalerEnabled: true }))).toBe(true);
+      });
+
+      it('should show for a paused pool, so it can be resumed', () => {
+        expect(mountCluster().vm.showPoolAutoscalerControls(machinePool({ isAutoscalerEnabled: true, isAutoscalerPaused: true }))).toBe(true);
+      });
+
+      it('should not show for a pool the autoscaler does not manage', () => {
+        expect(mountCluster().vm.showPoolAutoscalerControls(machinePool())).toBe(false);
+      });
+
+      it('should not show when the autoscaler feature is off', () => {
+        expect(mountCluster(false).vm.showPoolAutoscalerControls(machinePool({ isAutoscalerEnabled: true }))).toBe(false);
+      });
+
+      it('should not show without a pool', () => {
+        expect(mountCluster().vm.showPoolAutoscalerControls(undefined)).toBe(false);
+      });
+    });
+
+    describe('togglePoolAutoscalerPause', () => {
+      it('should hold the control disabled until the save settles, then announce the pause', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({ isAutoscalerEnabled: true });
+
+        const done = wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        expect(wrapper.vm.isAutoscalerPauseSaving(pool)).toBe(true);
+
+        await done;
+
+        expect(pool.toggleAutoscalerPause).toHaveBeenCalledWith();
+        expect(wrapper.vm.isAutoscalerPauseSaving(pool)).toBe(false);
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('%cluster.machinePool.autoscaler.announce.paused%');
+      });
+
+      it('should announce the resume of a paused pool', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({ isAutoscalerEnabled: true, isAutoscalerPaused: true });
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('%cluster.machinePool.autoscaler.announce.resumed%');
+      });
+
+      it('should announce a failure, and free the control again', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({ isAutoscalerEnabled: true, toggleAutoscalerPause: jest.fn(() => Promise.reject(new Error('nope'))) });
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('%cluster.machinePool.autoscaler.announce.pauseError%');
+        expect(wrapper.vm.isAutoscalerPauseSaving(pool)).toBe(false);
+      });
+
+      it('should ignore a second click while the first save is in flight', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({ isAutoscalerEnabled: true });
+
+        const done = wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+        await done;
+
+        expect(pool.toggleAutoscalerPause).toHaveBeenCalledTimes(1);
+      });
+
+      it('should do nothing without a pool', async() => {
+        const wrapper = mountCluster();
+
+        await wrapper.vm.togglePoolAutoscalerPause(undefined);
+
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('');
+      });
+
+      it('should not announce a change the model did not make', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({ isAutoscalerEnabled: true, toggleAutoscalerPause: jest.fn(() => undefined) });
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('');
+        expect(wrapper.vm.isAutoscalerPauseSaving(pool)).toBe(false);
+      });
+
+      it.each([
+        ['down', 'scaleDown'],
+        ['up', 'scaleUp'],
+      ])('should confirm a resume that would scale the pool %s, rather than resuming it', async(direction, key) => {
+        const wrapper = mountCluster();
+        const pool = machinePool({
+          isAutoscalerEnabled:    true,
+          isAutoscalerPaused:     true,
+          autoscalerResumeResize: {
+            direction, target: 5, count: 10
+          }
+        });
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+
+        expect(pool.toggleAutoscalerPause).not.toHaveBeenCalled();
+        expect(dispatch).toHaveBeenCalledWith('management/promptModal', expect.objectContaining({
+          component:      'GenericPrompt',
+          componentProps: expect.objectContaining({ body: `%cluster.machinePool.autoscaler.resumePrompt.${ key }%` })
+        }));
+      });
+
+      it('should resume from the confirmation', async() => {
+        const wrapper = mountCluster();
+        const pool = machinePool({
+          isAutoscalerEnabled:    true,
+          isAutoscalerPaused:     true,
+          autoscalerResumeResize: {
+            direction: 'down', target: 5, count: 10
+          }
+        });
+
+        await wrapper.vm.togglePoolAutoscalerPause(pool);
+        await dispatch.mock.calls[0][1].componentProps.applyAction();
+
+        expect(pool.toggleAutoscalerPause).toHaveBeenCalledWith();
+        expect(wrapper.vm.autoscalerAnnouncement).toBe('%cluster.machinePool.autoscaler.announce.resumed%');
+      });
+    });
+  });
 });

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -318,6 +318,11 @@ export default {
 
       clusterToken: null,
 
+      // Ids of the machine pools with a pause or resume of their autoscaler in flight
+      autoscalerPauseSaving:  [],
+      // What the last pause or resume did, for the live region to announce
+      autoscalerAnnouncement: '',
+
       logOpen:   false,
       logSocket: null,
       logs:      [],
@@ -731,12 +736,96 @@ export default {
       return this.extDetailTabs?.conditions;
     },
 
+    isAutoscalerFeatureEnabled() {
+      return isAutoscalerFeatureFlagEnabled(this.$store);
+    },
+
     showAutoScalerTab() {
-      return isAutoscalerFeatureFlagEnabled(this.$store) && this.value.hasAccessToAutoscalerConfigMap && this.extDetailTabs.autoscaler;
+      return this.isAutoscalerFeatureEnabled && this.value.hasAccessToAutoscalerConfigMap && this.extDetailTabs.autoscaler;
     }
   },
 
   methods: {
+    /**
+     * The machine count of a pool is scaled by hand unless the autoscaler is actively managing it. A paused pool is the
+     * user's to scale again, and so is every pool while the autoscaler feature is off
+     */
+    showPoolMachineControls(pool) {
+      return !!pool && (!this.isAutoscalerFeatureEnabled || !pool.isAutoscalerEnabled || pool.isAutoscalerPaused);
+    },
+
+    /**
+     * Pause and resume are only offered for a pool the autoscaler knows about, and only while the feature is on
+     */
+    showPoolAutoscalerControls(pool) {
+      return !!pool && this.isAutoscalerFeatureEnabled && pool.isAutoscalerEnabled;
+    },
+
+    isAutoscalerPauseSaving(pool) {
+      return this.autoscalerPauseSaving.includes(pool?.id);
+    },
+
+    /**
+     * Pause or resume the autoscaler for one machine pool. Resuming a pool that was scaled outside its stored range
+     * while paused is confirmed first, because the autoscaler resizes the pool as soon as it takes it back
+     */
+    togglePoolAutoscalerPause(pool) {
+      if (!pool || this.isAutoscalerPauseSaving(pool)) {
+        return;
+      }
+
+      const resize = pool.autoscalerResumeResize;
+
+      if (resize) {
+        return this.$store.dispatch('management/promptModal', {
+          component:      'GenericPrompt',
+          componentProps: {
+            title: this.t('cluster.machinePool.autoscaler.resumePrompt.title'),
+            body:  this.t(`cluster.machinePool.autoscaler.resumePrompt.scale${ resize.direction === 'up' ? 'Up' : 'Down' }`, {
+              name: pool.nameDisplay, count: resize.count, target: resize.target
+            }),
+            applyMode:   'continue',
+            applyAction: () => this.setPoolAutoscalerPause(pool),
+          }
+        });
+      }
+
+      return this.setPoolAutoscalerPause(pool).catch(() => {
+        // Already announced and growled, and there is nowhere else for it to go from a click
+      });
+    },
+
+    /**
+     * Keeps the control disabled until the save settles so two clicks can't race each other, and announces the outcome
+     * of what is otherwise an optimistic change. Only what the model actually saved is announced, and a failure is
+     * rethrown so a confirmation prompt can report it too
+     */
+    async setPoolAutoscalerPause(pool) {
+      const wasPaused = pool.isAutoscalerPaused;
+      const name = pool.nameDisplay;
+
+      this.autoscalerPauseSaving = [...this.autoscalerPauseSaving, pool.id];
+
+      try {
+        const save = pool.toggleAutoscalerPause();
+
+        if (!save) {
+          return;
+        }
+
+        await save;
+
+        this.autoscalerAnnouncement = this.t(wasPaused ? 'cluster.machinePool.autoscaler.announce.resumed' : 'cluster.machinePool.autoscaler.announce.paused', { name });
+      } catch (err) {
+        // The model has already put the pool back and growled the error
+        this.autoscalerAnnouncement = this.t(wasPaused ? 'cluster.machinePool.autoscaler.announce.resumeError' : 'cluster.machinePool.autoscaler.announce.pauseError', { name });
+
+        throw err;
+      } finally {
+        this.autoscalerPauseSaving = this.autoscalerPauseSaving.filter((id) => id !== pool.id);
+      }
+    },
+
     toggleScaleDownModal( event, resources ) {
       // Check if the user held alt key when an action is clicked.
       const alt = isAlternate(event);
@@ -983,7 +1072,7 @@ export default {
                     </div>
                   </div>
                   <div
-                    v-if="group.ref && !group.ref.isAutoscalerEnabled"
+                    v-if="group.ref && (showPoolMachineControls(group.ref) || showPoolAutoscalerControls(group.ref))"
                     class="right group-header-buttons mr-20"
                   >
                     <MachineSummaryGraph
@@ -992,7 +1081,7 @@ export default {
                       :horizontal="true"
                       class="mr-20"
                     />
-                    <template v-if="value.hasLink('update') && group.ref.showScalePool">
+                    <template v-if="showPoolMachineControls(group.ref) && value.hasLink('update') && group.ref.showScalePool">
                       <button
                         v-clean-tooltip="t('node.list.scaleDown')"
                         :disabled="!group.ref.canScaleDownPool()"
@@ -1014,10 +1103,36 @@ export default {
                         <i class="icon icon-sm icon-plus" />
                       </button>
                     </template>
+                    <template v-if="showPoolAutoscalerControls(group.ref)">
+                      <span
+                        class="ml-20 text-no-break"
+                        data-testid="machine-pool-autoscaler-status"
+                      >
+                        {{ group.ref.isAutoscalerPaused ? t('cluster.machinePool.autoscaler.status.paused') : t('cluster.machinePool.autoscaler.status.running') }}
+                      </span>
+                      <button
+                        v-if="group.ref.canPauseResumeAutoscaler"
+                        :aria-label="group.ref.isAutoscalerPaused ? t('cluster.machinePool.autoscaler.resumeAriaLabel', { name: group.ref.nameDisplay }) : t('cluster.machinePool.autoscaler.pauseAriaLabel', { name: group.ref.nameDisplay })"
+                        :aria-disabled="isAutoscalerPauseSaving(group.ref)"
+                        :class="{ disabled: isAutoscalerPauseSaving(group.ref) }"
+                        type="button"
+                        class="btn btn-sm role-secondary ml-10"
+                        data-testid="machine-pool-autoscaler-pause-button"
+                        @click="togglePoolAutoscalerPause(group.ref)"
+                      >
+                        <i :class="group.ref.isAutoscalerPaused ? 'icon icon-sm icon-play' : 'icon icon-sm icon-pause'" />
+                        <span>{{ group.ref.isAutoscalerPaused ? t('autoscaler.card.resume') : t('autoscaler.card.pause') }}</span>
+                      </button>
+                    </template>
                   </div>
                 </div>
               </template>
             </ResourceTable>
+            <span
+              class="sr-only"
+              role="status"
+              data-testid="machine-pool-autoscaler-announcement"
+            >{{ autoscalerAnnouncement }}</span>
           </Tab>
 
           <Tab

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/MachinePool.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/MachinePool.test.ts
@@ -1,7 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import jsyaml from 'js-yaml';
 import { shallowMount } from '@vue/test-utils';
+import { escapeHtml } from '@shell/utils/string';
 import MachinePool from '@shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 const TRANSLATION_KEY = '%cluster.machinePool.name.unique%';
+const PAUSED_MIN = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE;
+const PAUSED_MAX = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE;
 
 function createPool(name: string, { remove = false } = {}) {
   return {
@@ -57,6 +64,60 @@ function mountMachinePool(currentPool: ReturnType<typeof createPool>, allPools: 
   });
 }
 
+/**
+ * Mount with the autoscaler feature enabled, and with the advanced section rendering its slot, which is where the
+ * autoscaler fields live
+ */
+function mountAutoscalerMachinePool(pool: any) {
+  return shallowMount(MachinePool, {
+    props: {
+      value: {
+        id: 'pool-1', pool, config: null
+      },
+      mode:           'edit',
+      provider:       'custom',
+      idx:            0,
+      machinePools:   [],
+      poolId:         'pool-1',
+      poolCreateMode: false,
+    },
+    global: {
+      mocks: {
+        $store: {
+          getters: {
+            'i18n/t':                                   (key: string) => key,
+            'i18n/exists':                              () => false,
+            'type-map/hasCustomMachineConfigComponent': () => false,
+            'type-map/importMachineConfig':             () => null,
+            'features/get':                             () => true,
+          },
+          dispatch: jest.fn(),
+        },
+      },
+      stubs: {
+        LabeledInput:    true,
+        Checkbox:        true,
+        Taints:          true,
+        KeyValue:        true,
+        AdvancedSection: { template: '<div><slot /></div>' },
+        Banner:          true,
+        UnitInput:       true,
+      },
+    },
+  });
+}
+
+/**
+ * The autoscaler bounds are computed proxies, and the inputs that write them emit null when they are cleared
+ */
+function setBound(wrapper: any, bound: string, value: number | null) {
+  wrapper.vm[bound] = value;
+}
+
+function extraRule(wrapper: any, name: string) {
+  return wrapper.vm.fvExtraRules[name];
+}
+
 describe('component: MachinePool', () => {
   describe('uniquePoolName validation', () => {
     it('should return undefined when the name is empty', () => {
@@ -100,5 +161,257 @@ describe('component: MachinePool', () => {
 
       expect(wrapper.vm.fvExtraRules.uniquePoolName(nameA)).toStrictEqual(TRANSLATION_KEY);
     });
+  });
+
+  describe('autoscaler', () => {
+    const autoscalerPool = (extra: any = {}) => ({
+      name:             'pool1',
+      etcdRole:         false,
+      controlPlaneRole: false,
+      workerRole:       true,
+      quantity:         1,
+      ...extra
+    });
+
+    it('should not be enabled for a pool with no autoscaling range', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool());
+
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(false);
+      expect(wrapper.vm.isAutoscalerPaused).toBe(false);
+    });
+
+    it('should be enabled for a pool with an autoscaling range', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 }));
+
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(true);
+      expect(wrapper.vm.isAutoscalerPaused).toBe(false);
+      expect(wrapper.vm.autoscalerRange).toStrictEqual({ min: 1, max: 4 });
+    });
+
+    it('should be enabled, and paused, for a pool that has been paused', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } }));
+
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(true);
+      expect(wrapper.vm.isAutoscalerPaused).toBe(true);
+      expect(wrapper.vm.autoscalerRange).toStrictEqual({ min: 1, max: 4 });
+    });
+
+    it('should show the stashed range, editable, with a banner, when the pool is paused', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } }));
+
+      const min = wrapper.find('[data-testid="machine-pool-autoscaler-min-input"]');
+      const max = wrapper.find('[data-testid="machine-pool-autoscaler-max-input"]');
+
+      expect(min.attributes().value).toBe('1');
+      expect(min.attributes().disabled).toBe('false');
+      expect(max.attributes().value).toBe('4');
+      expect(max.attributes().disabled).toBe('false');
+      expect(wrapper.find('[data-testid="machine-pool-autoscaler-paused-banner"]').exists()).toBe(true);
+    });
+
+    it('should not show the paused banner when the pool is not paused', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 }));
+
+      expect(wrapper.find('[data-testid="machine-pool-autoscaler-min-input"]').attributes().value).toBe('1');
+      expect(wrapper.find('[data-testid="machine-pool-autoscaler-paused-banner"]').exists()).toBe(false);
+    });
+
+    it('should write the stashed range when the range is edited while the pool is paused', () => {
+      const pool = autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      wrapper.vm.autoscalerMinSize = 3;
+      wrapper.vm.autoscalerMaxSize = 9;
+
+      expect(pool.machineDeploymentAnnotations).toStrictEqual({ [PAUSED_MIN]: '3', [PAUSED_MAX]: '9' });
+      expect(pool.autoscalingMinSize).toBeUndefined();
+      expect(wrapper.vm.isAutoscalerPaused).toBe(true);
+    });
+
+    it('should write the live range when the range is edited while the pool is running', () => {
+      const pool = autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      wrapper.vm.autoscalerMinSize = 3;
+
+      expect(pool.autoscalingMinSize).toBe(3);
+      expect(pool.machineDeploymentAnnotations).toBeUndefined();
+    });
+
+    it('should check max against min while the pool is paused', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '9', [PAUSED_MAX]: '2' } }));
+
+      expect(wrapper.vm.fvExtraRules.isAutoscalerMaxGreaterThanMin()).toStrictEqual('%cluster.machinePool.autoscaler.validation.isAutoscalerMaxGreaterThanMin%');
+    });
+
+    it('should let the machine count be set while the pool is paused', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ quantity: 7, machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } }));
+      const quantity = wrapper.find('[data-testid="machine-pool-quantity-input"]');
+
+      expect(quantity.attributes().value).toBe('7');
+      expect(quantity.attributes().disabled).toBe('false');
+    });
+
+    it('should hand the machine count to the autoscaler while the pool is running', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({
+        quantity: 7, autoscalingMinSize: 1, autoscalingMaxSize: 4
+      }));
+      const quantity = wrapper.find('[data-testid="machine-pool-quantity-input"]');
+
+      expect(quantity.attributes().value).toBe('%cluster.machinePool.autoscaler.machineCountValueOverride%');
+      expect(quantity.attributes().disabled).toBe('true');
+    });
+
+    it('should write the default range, and clear any stash, when the autoscaler is enabled', () => {
+      const pool = autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '5', [PAUSED_MAX]: '9' } });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      wrapper.vm.isAutoscalerEnabled = true;
+
+      expect(pool.autoscalingMinSize).toBe(1);
+      expect(pool.autoscalingMaxSize).toBe(2);
+      expect(pool.machineDeploymentAnnotations).toBeUndefined();
+      expect(wrapper.vm.isAutoscalerPaused).toBe(false);
+    });
+
+    it('should hold the section open while both bounds are empty', () => {
+      const pool = autoscalerPool({ autoscalingMinSize: 5, autoscalingMaxSize: 9 });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      setBound(wrapper, 'autoscalerMinSize', null);
+      setBound(wrapper, 'autoscalerMaxSize', null);
+
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(true);
+      expect(wrapper.vm.autoscalerRange).toStrictEqual({ min: undefined, max: undefined });
+    });
+
+    it('should keep a paused pool paused while both bounds are empty', () => {
+      const pool = autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      setBound(wrapper, 'autoscalerMinSize', null);
+      setBound(wrapper, 'autoscalerMaxSize', null);
+      setBound(wrapper, 'autoscalerMinSize', 2);
+
+      expect(wrapper.vm.isAutoscalerPaused).toBe(true);
+      expect(pool.machineDeploymentAnnotations).toStrictEqual({ [PAUSED_MIN]: '2' });
+      expect(pool.autoscalingMinSize).toBeUndefined();
+    });
+
+    it.each([
+      ['min', 'isAutoscalerMinSizeValid'],
+      ['max', 'isAutoscalerMaxSizeValid'],
+    ])('should require the %s while the autoscaler section is shown', (_label, rule) => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({ autoscalingMinSize: 5, autoscalingMaxSize: 9 }));
+
+      expect(extraRule(wrapper, rule)()).toBeUndefined();
+
+      setBound(wrapper, 'autoscalerMinSize', null);
+      setBound(wrapper, 'autoscalerMaxSize', null);
+
+      expect(extraRule(wrapper, rule)()).toStrictEqual('%validation.required%');
+    });
+
+    it.each([
+      ['a running pool', {}],
+      ['a paused pool', { paused: true }],
+    ])('should reject a negative bound on %s', (_label, { paused }: any) => {
+      const pool = paused ? autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } }) : autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      setBound(wrapper, 'autoscalerMinSize', -5);
+
+      expect(wrapper.vm.fvExtraRules.isAutoscalerMinSizeValid()).toStrictEqual('%validation.number.isPositive%');
+    });
+
+    it('should not check the bounds when the autoscaler section is hidden', () => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool());
+
+      expect(wrapper.vm.fvExtraRules.isAutoscalerMinSizeValid()).toBeUndefined();
+      expect(wrapper.vm.fvExtraRules.isAutoscalerMaxSizeValid()).toBeUndefined();
+    });
+
+    it('should show the discard hint next to the checkbox while the autoscaler is on', () => {
+      const on = mountAutoscalerMachinePool(autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 }));
+      const off = mountAutoscalerMachinePool(autoscalerPool());
+
+      expect(on.find('[data-testid="machine-pool-autoscaler-disable-hint"]').exists()).toBe(true);
+      expect(off.find('[data-testid="machine-pool-autoscaler-disable-hint"]').exists()).toBe(false);
+    });
+
+    it('should warn next to the role checkboxes, where taking a role turns the autoscaler off', () => {
+      const on = mountAutoscalerMachinePool(autoscalerPool({ autoscalingMinSize: 1, autoscalingMaxSize: 4 }));
+      const off = mountAutoscalerMachinePool(autoscalerPool());
+
+      expect(on.find('[data-testid="machine-pool-autoscaler-role-hint"]').exists()).toBe(true);
+      expect(off.find('[data-testid="machine-pool-autoscaler-role-hint"]').exists()).toBe(false);
+    });
+
+    it.each([
+      ['etcd', 'etcdRole'],
+      ['control plane', 'controlPlaneRole'],
+    ])('should drop both hints for a pool that already has the %s role, where neither action is possible', (_label, role) => {
+      const wrapper = mountAutoscalerMachinePool(autoscalerPool({
+        [role]: true, autoscalingMinSize: 1, autoscalingMaxSize: 4
+      }));
+
+      expect(wrapper.find('[data-testid="machine-pool-autoscaler-role-hint"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="machine-pool-autoscaler-disable-hint"]').exists()).toBe(false);
+    });
+
+    it.each([
+      ['etcd', 'etcdRole'],
+      ['control plane', 'controlPlaneRole'],
+    ])('should turn the autoscaler off, and discard the stash, when the pool takes the %s role', async(_label, role) => {
+      const pool = autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      // Through the component's own reference to the pool, so the watcher sees it
+      (wrapper.vm.value.pool as any)[role] = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(false);
+      expect(wrapper.vm.isAutoscalerPaused).toBe(false);
+      expect(pool.machineDeploymentAnnotations).toBeUndefined();
+    });
+
+    it('should leave no stashed range behind when the autoscaler is disabled for a paused pool', () => {
+      const pool = autoscalerPool({ machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '4' } });
+      const wrapper = mountAutoscalerMachinePool(pool);
+
+      wrapper.vm.isAutoscalerEnabled = false;
+
+      expect(pool.machineDeploymentAnnotations).toBeUndefined();
+      expect(wrapper.vm.isAutoscalerEnabled).toBe(false);
+    });
+  });
+});
+
+describe('translations: cluster.machinePool.autoscaler', () => {
+  const translations = jsyaml.load(fs.readFileSync(path.resolve(__dirname, '../../../assets/translations/en-us.yaml'), 'utf8')) as any;
+  const autoscaler = translations.cluster.machinePool.autoscaler;
+
+  /**
+   * `t` escapes its result unless it is asked for the raw string, and a mustache escapes again, so an apostrophe or a
+   * quote in one of these lands on screen as `&amp;#39;`. Every key here is rendered through a mustache or an attribute
+   * binding, so none of them may contain a character that escapes
+   */
+  const RENDERED_UNESCAPED = [
+    'min',
+    'max',
+    'baseUnit',
+    'disableHint',
+    'roleHint',
+    'pauseAriaLabel',
+    'resumeAriaLabel',
+    'status.running',
+    'status.paused',
+  ];
+
+  it.each(RENDERED_UNESCAPED)('should render %s without an escaped character', (key) => {
+    const value = key.split('.').reduce((acc, part) => acc?.[part], autoscaler);
+
+    expect(typeof value).toBe('string');
+    expect(escapeHtml(value)).toStrictEqual(value);
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -10,7 +10,15 @@ import UnitInput from '@shell/components/form/UnitInput.vue';
 import { randomStr } from '@shell/utils/string';
 import FormValidation from '@shell/mixins/form-validation';
 import { MACHINE_POOL_VALIDATION } from '@shell/utils/validators/machine-pool';
-import { isAutoscalerFeatureFlagEnabled } from '@shell/utils/autoscaler-utils';
+import {
+  disableMachinePoolAutoscaler,
+  enableMachinePoolAutoscaler,
+  isAutoscalerFeatureFlagEnabled,
+  isMachinePoolAutoscalerEnabled,
+  isMachinePoolAutoscalerPaused,
+  machinePoolAutoscalerRange,
+  setMachinePoolAutoscalerRange
+} from '@shell/utils/autoscaler-utils';
 import { RcSeparator } from '@components/RcSeparator';
 
 export default {
@@ -108,13 +116,30 @@ export default {
 
       validationErrors: [],
 
+      /**
+       * Whether the autoscaler section is shown, held here rather than derived from the pool's range. Deriving it would
+       * fold the section away the moment both bounds are empty, which is a state a user passes through whenever they
+       * clear a value to type another one. Only the checkbox changes it
+       */
+      autoscalerEnabled: false,
+
+      /**
+       * Whether this pool's autoscaler was paused when the form opened. Held here for the same reason: it decides where
+       * an edited range is written, and the pool's own answer disappears for as long as the stash is empty
+       */
+      autoscalerPaused: false,
+
       MACHINE_POOL_VALIDATION,
 
       fvFormRuleSets: MACHINE_POOL_VALIDATION.RULESETS,
       fvExtraRules:   {
+        isAutoscalerMinSizeValid: () => this.autoscalerSizeError(this.autoscalerRange.min, this.t('cluster.machinePool.autoscaler.min')),
+
+        isAutoscalerMaxSizeValid: () => this.autoscalerSizeError(this.autoscalerRange.max, this.t('cluster.machinePool.autoscaler.max')),
+
         isAutoscalerMaxGreaterThanMin: () => {
-          const min = this.value?.pool?.autoscalingMinSize || 0;
-          const max = this.value?.pool?.autoscalingMaxSize || 0;
+          // The range is read through the utils so it is still checked while the pool is paused and the range is stashed
+          const { min = 0, max = 0 } = machinePoolAutoscalerRange(this.value?.pool);
 
           return max - min >= 0 ? undefined : this.t('cluster.machinePool.autoscaler.validation.isAutoscalerMaxGreaterThanMin');
         },
@@ -149,18 +174,63 @@ export default {
       return isAutoscalerFeatureFlagEnabled(this.$store);
     },
 
+    /**
+     * The autoscaler is not the user's to change: the pool has a role the autoscaler should not manage, or the form is
+     * saving. Neither is a state to explain what turning the autoscaler off would do
+     */
+    isAutoscalerLocked() {
+      return !!(this.value?.pool?.etcdRole || this.value?.pool?.controlPlaneRole || this.busy);
+    },
+
     isAutoscalerEnabled: {
       get() {
-        return typeof this.value?.pool?.autoscalingMinSize !== 'undefined' || typeof this.value?.pool?.autoscalingMinSize !== 'undefined';
+        return this.autoscalerEnabled;
       },
       set(val) {
+        this.autoscalerEnabled = val;
+        // Either way the stash is gone: turning the autoscaler off discards it, turning it on replaces it with a live
+        // range, so the pool is no longer paused
+        this.autoscalerPaused = false;
+
         if (!val) {
-          delete this.value.pool.autoscalingMinSize;
-          delete this.value.pool.autoscalingMaxSize;
+          disableMachinePoolAutoscaler(this.value?.pool);
         } else {
-          this.value.pool.autoscalingMinSize = 1;
-          this.value.pool.autoscalingMaxSize = 2;
+          enableMachinePoolAutoscaler(this.value?.pool, { min: 1, max: 2 });
         }
+      }
+    },
+
+    /**
+     * The autoscaler has been paused for this pool from the cluster detail page, so its range is stashed away until it
+     * is resumed there
+     */
+    isAutoscalerPaused() {
+      return this.autoscalerEnabled && this.autoscalerPaused;
+    },
+
+    autoscalerRange() {
+      return machinePoolAutoscalerRange(this.value?.pool);
+    },
+
+    /**
+     * The autoscaling range, read and written wherever it currently lives. While the pool is paused that is the stash
+     * on the pool, so the range stays editable and the pool stays paused
+     */
+    autoscalerMinSize: {
+      get() {
+        return this.autoscalerRange.min;
+      },
+      set(min) {
+        setMachinePoolAutoscalerRange(this.value?.pool, { ...this.autoscalerRange, min }, this.isAutoscalerPaused);
+      }
+    },
+
+    autoscalerMaxSize: {
+      get() {
+        return this.autoscalerRange.max;
+      },
+      set(max) {
+        setMachinePoolAutoscalerRange(this.value?.pool, { ...this.autoscalerRange, max }, this.isAutoscalerPaused);
       }
     }
   },
@@ -208,6 +278,9 @@ export default {
   created() {
     this.unhealthyNodeTimeoutInteger = this.value.pool.unhealthyNodeTimeout ? this.parseDuration(this.value.pool.unhealthyNodeTimeout) : 0;
 
+    this.autoscalerEnabled = isMachinePoolAutoscalerEnabled(this.value?.pool);
+    this.autoscalerPaused = isMachinePoolAutoscalerPaused(this.value?.pool);
+
     this.$emit('validationChanged', true);
   },
 
@@ -217,6 +290,23 @@ export default {
   },
 
   methods: {
+    /**
+     * Both bounds are required while the autoscaler section is shown, so the pool cannot be saved with an empty range,
+     * and neither can be negative. Read through the range rather than the pool's fields, which are empty while it is
+     * paused
+     */
+    autoscalerSizeError(value, key) {
+      if (!this.isAutoscalerEnabled) {
+        return undefined;
+      }
+
+      if (value === undefined) {
+        return this.t('validation.required', { key });
+      }
+
+      return value < 0 ? this.t('validation.number.isPositive', { key }) : undefined;
+    },
+
     parseDuration(duration) {
       // The back end stores the timeout in Duration format, for example, "42d31h10m30s".
       // Here we convert that string to an integer and return the duration as seconds.
@@ -308,6 +398,12 @@ export default {
         {{ t('cluster.machinePool.truncationPool', { limit: value.pool.hostnameLengthLimit }) }}
       </div>
     </Banner>
+    <Banner
+      v-if="isAutoscalerFeatureEnabled && isAutoscalerPaused"
+      color="info"
+      label-key="cluster.machinePool.autoscaler.pausedBanner"
+      data-testid="machine-pool-autoscaler-paused-banner"
+    />
     <div class="row">
       <div class="col span-4">
         <LabeledInput
@@ -323,7 +419,7 @@ export default {
       </div>
       <div class="col span-4">
         <LabeledInput
-          v-if="!isAutoscalerFeatureEnabled || !isAutoscalerEnabled"
+          v-if="!isAutoscalerFeatureEnabled || !isAutoscalerEnabled || isAutoscalerPaused"
           v-model:value.number="value.pool.quantity"
           :mode="mode"
           :label="t('cluster.machinePool.quantity.label')"
@@ -366,6 +462,13 @@ export default {
           :label="t('cluster.machinePool.role.worker')"
           :disabled="busy"
         />
+        <p
+          v-if="isAutoscalerFeatureEnabled && isAutoscalerEnabled && !value.pool.etcdRole && !value.pool.controlPlaneRole"
+          class="text-muted text-small mt-5"
+          data-testid="machine-pool-autoscaler-role-hint"
+        >
+          {{ t('cluster.machinePool.autoscaler.roleHint') }}
+        </p>
       </div>
     </div>
     <RcSeparator class="mt-10" />
@@ -466,8 +569,15 @@ export default {
               v-model:value="isAutoscalerEnabled"
               :mode="mode"
               :label="t('cluster.machinePool.autoscaler.enable', undefined, true)"
-              :disabled="value.pool.etcdRole || value.pool.controlPlaneRole || busy"
+              :disabled="isAutoscalerLocked"
             />
+            <p
+              v-if="isAutoscalerEnabled && !isAutoscalerLocked"
+              class="text-muted text-small mt-5"
+              data-testid="machine-pool-autoscaler-disable-hint"
+            >
+              {{ t('cluster.machinePool.autoscaler.disableHint') }}
+            </p>
           </div>
         </div>
         <div
@@ -476,26 +586,30 @@ export default {
         >
           <div class="col span-4">
             <UnitInput
-              v-model:value="value.pool.autoscalingMinSize"
+              v-model:value="autoscalerMinSize"
               :label="t('cluster.machinePool.autoscaler.min')"
               :hide-arrows="true"
               :placeholder="t('containerResourceLimit.cpuPlaceholder')"
               :mode="mode"
               :base-unit="t('cluster.machinePool.autoscaler.baseUnit')"
               :rules="fvGetAndReportPathRules(MACHINE_POOL_VALIDATION.FIELDS.AUTOSCALER_MIN)"
-              :disabled="value.pool.etcdRole || value.pool.controlPlaneRole || busy"
+              :required="true"
+              :disabled="isAutoscalerLocked"
+              data-testid="machine-pool-autoscaler-min-input"
             />
           </div>
           <div class="col span-4">
             <UnitInput
-              v-model:value="value.pool.autoscalingMaxSize"
+              v-model:value="autoscalerMaxSize"
               :label="t('cluster.machinePool.autoscaler.max')"
               :hide-arrows="true"
               :placeholder="t('containerResourceLimit.cpuPlaceholder')"
               :mode="mode"
               :base-unit="t('cluster.machinePool.autoscaler.baseUnit')"
               :rules="fvGetAndReportPathRules(MACHINE_POOL_VALIDATION.FIELDS.AUTOSCALER_MAX)"
-              :disabled="value.pool.etcdRole || value.pool.controlPlaneRole || busy"
+              :required="true"
+              :disabled="isAutoscalerLocked"
+              data-testid="machine-pool-autoscaler-max-input"
             />
           </div>
         </div>

--- a/shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts
+++ b/shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts
@@ -1,0 +1,385 @@
+import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { CAPI } from '@shell/config/types';
+
+const PAUSED_MIN = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE;
+const PAUSED_MAX = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE;
+const MIN_SIZE = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MIN_SIZE;
+const MAX_SIZE = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MAX_SIZE;
+
+const MACHINE_TEMPLATE_NAME = 'nc-pool1';
+
+type Pool = {
+  name?: string,
+  quantity?: number,
+  machineConfigRef?: { name: string },
+  autoscalingMinSize?: number,
+  autoscalingMaxSize?: number,
+  machineDeploymentAnnotations?: { [key: string]: string },
+};
+
+/**
+ * A machine deployment wired up to a provisioning cluster containing the given machine pools
+ */
+function makeMachineDeployment({
+  pools = [] as Pool[],
+  rkeConfig = true,
+  canUpdate = true,
+  annotations = {} as { [key: string]: string },
+  replicas = undefined as number | undefined,
+  save = jest.fn(() => Promise.resolve({})),
+} = {}) {
+  const cluster = {
+    id:   'fleet-default/test-cluster',
+    spec: rkeConfig ? { rkeConfig: { machinePools: pools } } : {},
+    canUpdate,
+    save,
+  };
+
+  const dispatch = jest.fn();
+
+  const rootGetters = {
+    'management/byId': (type: string) => (type === CAPI.RANCHER_CLUSTER ? cluster : undefined),
+    'i18n/t':          (key: string) => key,
+  };
+
+  const machineDeployment = new CapiMachineDeployment({
+    type:     CAPI.MACHINE_DEPLOYMENT,
+    metadata: {
+      namespace: 'fleet-default', name: 'test-cluster-pool1', annotations
+    },
+    spec: {
+      clusterName: 'test-cluster',
+      replicas,
+      template:    { spec: { infrastructureRef: { kind: 'Amazonec2Config', name: MACHINE_TEMPLATE_NAME } } }
+    },
+  }, { rootGetters, dispatch });
+
+  return {
+    machineDeployment, cluster, dispatch, save
+  };
+}
+
+const livePool: Pool = {
+  name:               'pool1',
+  quantity:           1,
+  machineConfigRef:   { name: MACHINE_TEMPLATE_NAME },
+  autoscalingMinSize: 2,
+  autoscalingMaxSize: 5
+};
+const pausedPool: Pool = {
+  name:                         'pool1',
+  quantity:                     3,
+  machineConfigRef:             { name: MACHINE_TEMPLATE_NAME },
+  machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' }
+};
+const plainPool: Pool = {
+  name: 'pool1', quantity: 1, machineConfigRef: { name: MACHINE_TEMPLATE_NAME }
+};
+
+describe('class CapiMachineDeployment', () => {
+  describe('inClusterSpec', () => {
+    it('should find the pool matching the machine template', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [{ name: 'other', machineConfigRef: { name: 'nc-pool2' } }, livePool] });
+
+      expect(machineDeployment.inClusterSpec).toStrictEqual(livePool);
+    });
+
+    it('should be undefined for a cluster with no rkeConfig', () => {
+      const { machineDeployment } = makeMachineDeployment({ rkeConfig: false });
+
+      expect(machineDeployment.inClusterSpec).toBeUndefined();
+    });
+
+    it('should be undefined when a pool has no machineConfigRef', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [{ name: 'no-ref' }] });
+
+      expect(machineDeployment.inClusterSpec).toBeUndefined();
+    });
+  });
+
+  describe('isAutoscalerEnabled', () => {
+    it('should be true for a pool with a live autoscaling range', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [livePool] });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(true);
+    });
+
+    it('should stay true while the pool is paused', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [pausedPool] });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(true);
+    });
+
+    it('should be false for a pool with no autoscaler', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [plainPool] });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(false);
+    });
+
+    it('should read the CAPI node group annotations for a pool with no range of its own, as an upstream CAPI provider has', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [plainPool], annotations: { [MIN_SIZE]: '1', [MAX_SIZE]: '3' } });
+
+      expect(machineDeployment.inClusterSpec).toStrictEqual(plainPool);
+      expect(machineDeployment.isAutoscalerEnabled).toBe(true);
+    });
+
+    it('should read the CAPI node group annotations when the cluster has no machine pools at all', () => {
+      const { machineDeployment } = makeMachineDeployment({ rkeConfig: false, annotations: { [MIN_SIZE]: '1', [MAX_SIZE]: '3' } });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(true);
+    });
+
+    it('should be false for a paused pool that has not resolved yet, whose CAPI annotations are pruned', () => {
+      // Pins the store load window: the machine deployment's template has not loaded, so no pool matches it, and a
+      // paused pool has nothing on the machine deployment to be read instead. Transient, and the controls it drives
+      // render enabled and do nothing until the pool resolves
+      const { machineDeployment } = makeMachineDeployment({ pools: [{ name: 'other', machineConfigRef: { name: 'nc-pool2' } }] });
+
+      expect(machineDeployment.inClusterSpec).toBeUndefined();
+      expect(machineDeployment.isAutoscalerEnabled).toBe(false);
+    });
+
+    it('should return a boolean when falling back to the CAPI node group annotations', () => {
+      const { machineDeployment } = makeMachineDeployment({ rkeConfig: false });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(false);
+    });
+  });
+
+  describe('isAutoscalerPaused', () => {
+    const testCases: [string, Pool[], boolean][] = [
+      ['a pool autoscaling live', [livePool], false],
+      ['a paused pool', [pausedPool], true],
+      ['a pool with no autoscaler', [plainPool], false],
+      ['no matching pool', [], false],
+    ];
+
+    it.each(testCases)('should report %s correctly', (_label, pools, expected) => {
+      const { machineDeployment } = makeMachineDeployment({ pools });
+
+      expect(machineDeployment.isAutoscalerPaused).toBe(expected);
+    });
+  });
+
+  describe('canPauseResumeAutoscaler', () => {
+    it('should be true for an autoscaling pool on an updatable cluster', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [livePool], replicas: 3 });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(true);
+    });
+
+    it('should be true for a paused pool, so it can be resumed', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [pausedPool], replicas: 3 });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(true);
+    });
+
+    it('should be false until the machine deployment knows its replica count, which a pause has to record', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [livePool] });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(false);
+    });
+
+    it('should be false without permission to update the cluster', () => {
+      const { machineDeployment } = makeMachineDeployment({
+        pools: [livePool], canUpdate: false, replicas: 3
+      });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(false);
+    });
+
+    it('should be false for a pool with no autoscaler', () => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [plainPool], replicas: 3 });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(false);
+    });
+
+    it('should be false for a machine deployment autoscaled by its own CAPI annotations, which there is no pool range to pause', () => {
+      const { machineDeployment } = makeMachineDeployment({
+        pools: [plainPool], replicas: 3, annotations: { [MIN_SIZE]: '1', [MAX_SIZE]: '3' }
+      });
+
+      expect(machineDeployment.isAutoscalerEnabled).toBe(true);
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(false);
+    });
+
+    it('should be false when there is no pool in the cluster spec', () => {
+      const { machineDeployment } = makeMachineDeployment({
+        rkeConfig: false, replicas: 3, annotations: { [MIN_SIZE]: '1', [MAX_SIZE]: '3' }
+      });
+
+      expect(machineDeployment.canPauseResumeAutoscaler).toBe(false);
+    });
+  });
+
+  describe('autoscalerResumeResize', () => {
+    const stashed = (min: string, max: string) => ({ ...pausedPool, machineDeploymentAnnotations: { [PAUSED_MIN]: min, [PAUSED_MAX]: max } });
+
+    const testCases: [string, any, number | undefined, any][] = [
+      ['a count inside the stored range', stashed('2', '5'), 3, null],
+      ['a count above the stored max', stashed('2', '5'), 9, {
+        direction: 'down', target: 5, count: 9
+      }],
+      ['a count below the stored min', stashed('2', '5'), 1, {
+        direction: 'up', target: 2, count: 1
+      }],
+      ['a count on the stored max', stashed('2', '5'), 5, null],
+      ['an unknown count', stashed('2', '5'), undefined, null],
+      ['a pool that is not paused', livePool, 9, null],
+    ];
+
+    it.each(testCases)('should report %s', (_label, pool, replicas, expected) => {
+      const { machineDeployment } = makeMachineDeployment({ pools: [pool], replicas });
+
+      expect(machineDeployment.autoscalerResumeResize).toStrictEqual(expected);
+    });
+
+    it('should name the bound that is breached when only one is stored', () => {
+      const pool = { ...pausedPool, machineDeploymentAnnotations: { [PAUSED_MAX]: '5' } };
+      const { machineDeployment } = makeMachineDeployment({ pools: [pool], replicas: 9 });
+
+      expect(machineDeployment.autoscalerResumeResize).toStrictEqual({
+        direction: 'down', target: 5, count: 9
+      });
+    });
+  });
+
+  describe('toggleAutoscalerPause', () => {
+    it('should stash the range and save the cluster when pausing', async() => {
+      const pool = { ...livePool };
+      const { machineDeployment, save } = makeMachineDeployment({ pools: [pool], replicas: 7 });
+
+      await machineDeployment.toggleAutoscalerPause();
+
+      expect(save).toHaveBeenCalledWith();
+      expect(pool).toStrictEqual({
+        name:                         'pool1',
+        quantity:                     7,
+        machineConfigRef:             { name: MACHINE_TEMPLATE_NAME },
+        machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' }
+      });
+    });
+
+    it('should keep the pool at the machine count the autoscaler left it with', async() => {
+      const pool = { ...livePool, quantity: 1 };
+      const { machineDeployment } = makeMachineDeployment({ pools: [pool], replicas: 7 });
+
+      await machineDeployment.toggleAutoscalerPause();
+
+      expect(pool.quantity).toBe(7);
+    });
+
+    it('should leave the quantity alone when the machine deployment has no replica count', async() => {
+      const pool = { ...livePool, quantity: 1 };
+      const { machineDeployment } = makeMachineDeployment({ pools: [pool] });
+
+      await machineDeployment.toggleAutoscalerPause();
+
+      expect(pool.quantity).toBe(1);
+    });
+
+    it('should restore the range, and not touch the quantity, when resuming', async() => {
+      const pool = { ...pausedPool, machineDeploymentAnnotations: { ...pausedPool.machineDeploymentAnnotations } };
+      const { machineDeployment, save } = makeMachineDeployment({ pools: [pool], replicas: 9 });
+
+      await machineDeployment.toggleAutoscalerPause();
+
+      expect(save).toHaveBeenCalledWith();
+      expect(pool).toStrictEqual({
+        name:               'pool1',
+        quantity:           3,
+        machineConfigRef:   { name: MACHINE_TEMPLATE_NAME },
+        autoscalingMinSize: 2,
+        autoscalingMaxSize: 5
+      });
+    });
+
+    it('should revert the pool, growl and reject when the save fails', async() => {
+      const pool = { ...livePool, quantity: 1 };
+      const save = jest.fn(() => Promise.reject(new Error('nope')));
+      const { machineDeployment, dispatch } = makeMachineDeployment({
+        pools: [pool], replicas: 7, save
+      });
+
+      await expect(machineDeployment.toggleAutoscalerPause()).rejects.toThrow('nope');
+
+      expect(pool).toStrictEqual({
+        name:               'pool1',
+        quantity:           1,
+        machineConfigRef:   { name: MACHINE_TEMPLATE_NAME },
+        autoscalingMinSize: 2,
+        autoscalingMaxSize: 5
+      });
+      expect(machineDeployment.isAutoscalerPaused).toBe(false);
+      expect(dispatch).toHaveBeenCalledWith('growl/fromError', expect.objectContaining({ title: 'cluster.machinePool.autoscaler.growl.pauseError' }), { root: true });
+    });
+
+    it('should growl the resume error when a resume fails', async() => {
+      const pool = { ...pausedPool, machineDeploymentAnnotations: { ...pausedPool.machineDeploymentAnnotations } };
+      const save = jest.fn(() => Promise.reject(new Error('nope')));
+      const { machineDeployment, dispatch } = makeMachineDeployment({ pools: [pool], save });
+
+      await expect(machineDeployment.toggleAutoscalerPause()).rejects.toThrow('nope');
+
+      expect(machineDeployment.isAutoscalerPaused).toBe(true);
+      expect(pool.quantity).toBe(3);
+      expect(dispatch).toHaveBeenCalledWith('growl/fromError', expect.objectContaining({ title: 'cluster.machinePool.autoscaler.growl.resumeError' }), { root: true });
+    });
+
+    it('should retry a conflicting save, keeping the pause it was asked for', async() => {
+      const pool = { ...livePool };
+      // Steve rejects with the response body, which carries the status as `_status`
+      const conflict = Object.assign(new Error('conflict'), { _status: 409 });
+      const save = jest.fn()
+        .mockImplementationOnce(() => Promise.reject(conflict))
+        .mockImplementationOnce(() => Promise.resolve({}));
+      const { machineDeployment } = makeMachineDeployment({
+        pools: [pool], replicas: 7, save
+      });
+
+      await machineDeployment.toggleAutoscalerPause();
+
+      expect(save).toHaveBeenCalledTimes(2);
+      expect(pool.machineDeploymentAnnotations).toStrictEqual({ [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' });
+    });
+
+    it('should not revert onto the pool a conflict refetched', async() => {
+      const pool = { ...livePool };
+      const conflict = Object.assign(new Error('conflict'), { status: 409 });
+      const refetch: { cluster?: any } = {};
+      // A real 409 refetches the cluster before it rejects, so every attempt after the first works on a fresh pool and
+      // the optimistic change of the attempt before it is already gone
+      const save = jest.fn(() => {
+        refetch.cluster.spec.rkeConfig.machinePools = [{ ...livePool }];
+
+        return Promise.reject(conflict);
+      });
+      const made = makeMachineDeployment({
+        pools: [pool], replicas: 7, save
+      });
+
+      refetch.cluster = made.cluster;
+
+      await expect(made.machineDeployment.toggleAutoscalerPause()).rejects.toThrow('conflict');
+
+      expect(save).toHaveBeenCalledTimes(3);
+      expect(made.machineDeployment.inClusterSpec).toStrictEqual(livePool);
+      expect(made.dispatch).toHaveBeenCalledWith('growl/fromError', expect.objectContaining({ title: 'cluster.machinePool.autoscaler.growl.pauseError' }), { root: true });
+    });
+
+    it('should do nothing for a pool with no autoscaler', () => {
+      const { machineDeployment, save } = makeMachineDeployment({ pools: [{ ...plainPool }] });
+
+      expect(machineDeployment.toggleAutoscalerPause()).toBeUndefined();
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when there is no pool in the cluster spec', () => {
+      const { machineDeployment, save } = makeMachineDeployment({ rkeConfig: false });
+
+      expect(machineDeployment.toggleAutoscalerPause()).toBeUndefined();
+      expect(save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/shell/models/__tests__/management.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/management.cattle.io.cluster.test.ts
@@ -1,7 +1,11 @@
 import MgmtCluster from '@shell/models/management.cattle.io.cluster';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { EXT } from '@shell/config/types';
 import { copyTextToClipboard } from '@shell/utils/clipboard';
 import { downloadFile } from '@shell/utils/download';
+
+const PAUSED_MIN = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE;
+const PAUSED_MAX = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE;
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
@@ -309,6 +313,39 @@ describe('class MgmtCluster', () => {
       await cluster.downloadKubeConfigBulk([]);
 
       expect(downloadFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isAutoscalerEnabled', () => {
+    const clusterWithPools = (machinePools?: any[]) => {
+      const cluster = new MgmtCluster({ id: 'cluster-1' }) as any;
+
+      Object.defineProperty(cluster, 'provCluster', { value: machinePools ? { spec: { rkeConfig: { machinePools } } } : undefined });
+
+      return cluster;
+    };
+
+    it('should be false when there is no provisioning cluster', () => {
+      expect(clusterWithPools().isAutoscalerEnabled).toBe(false);
+    });
+
+    it('should be false when no pool has an autoscaling range', () => {
+      expect(clusterWithPools([{ name: 'pool1' }]).isAutoscalerEnabled).toBe(false);
+    });
+
+    it('should be true when a pool has an autoscaling range', () => {
+      expect(clusterWithPools([{
+        name: 'pool1', autoscalingMinSize: 1, autoscalingMaxSize: 3
+      }]).isAutoscalerEnabled).toBe(true);
+    });
+
+    it('should stay true when every pool is paused', () => {
+      const machinePools = [
+        { name: 'pool1', machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '3' } },
+        { name: 'pool2', machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '4' } }
+      ];
+
+      expect(clusterWithPools(machinePools).isAutoscalerEnabled).toBe(true);
     });
   });
 });

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -8,6 +8,13 @@ import { notOnlyOfRole } from '@shell/models/cluster.x-k8s.io.machine';
 import { KIND } from '../config/elemental-types';
 import { KIND as HARVESTER_KIND } from '../config/harvester-manager-types';
 import CapiMachineRoot from '@shell/models/base-cluster.x-k8s.io';
+import {
+  isMachinePoolAutoscalerEnabled,
+  isMachinePoolAutoscalerPaused,
+  machinePoolAutoscalerRange,
+  pauseMachinePoolAutoscaler,
+  resumeMachinePoolAutoscaler
+} from '@shell/utils/autoscaler-utils';
 
 export default class CapiMachineDeployment extends CapiMachineRoot {
   get groupByPoolLabel() {
@@ -96,14 +103,19 @@ export default class CapiMachineDeployment extends CapiMachineRoot {
   // use this pool's definition in the provisioning cluster spec to scale, not this.spec.replicas
   get inClusterSpec() {
     // infra from Rancher node driver: provisioning cluster has reference to Rancher-generated crd <provider name>Config from the rke-machine-config.cattle.io api group
-    const rkeMachineConfigName = this.template?.metadata?.annotations['rke.cattle.io/cloned-from-name'];
+    const rkeMachineConfigName = this.template?.metadata?.annotations?.['rke.cattle.io/cloned-from-name'];
     // infra from upstream CAPI provider: provisioning cluster has reference to an upstream provider-specific machine template crd in the infrastructure.cluster.x-k8s.io api group
     const infrastructureRefName = this.spec?.template?.spec?.infrastructureRef?.name;
     const machineTemplateName = rkeMachineConfigName || infrastructureRefName;
 
-    const machinePools = this.cluster.spec.rkeConfig.machinePools;
+    if (!machineTemplateName) {
+      return undefined;
+    }
 
-    return machinePools.find((pool) => pool.machineConfigRef.name === machineTemplateName);
+    // custom and imported clusters have no rkeConfig, so there's no pool to find
+    const machinePools = this.cluster?.spec?.rkeConfig?.machinePools || [];
+
+    return machinePools.find((pool) => pool?.machineConfigRef?.name === machineTemplateName);
   }
 
   scalePool(delta, save = true, depth = 0) {
@@ -160,8 +172,144 @@ export default class CapiMachineDeployment extends CapiMachineRoot {
     }, 1000);
   }
 
+  /**
+   * Is the autoscaler configured for this pool?
+   *
+   * The provisioning cluster's machine pool is the first answer, and it stays enabled while the pool is paused. The
+   * CAPI node group annotations on this machine deployment are the second: they are how an upstream CAPI provider's
+   * machine deployment is autoscaled without a range on the pool. A paused pool is already true from the pool, so the
+   * pruned annotations cannot flip it back
+   */
   get isAutoscalerEnabled() {
-    return this.annotations?.[CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MIN_SIZE] || this.annotations?.[CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MAX_SIZE];
+    const fromAnnotations = !!(this.annotations?.[CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MIN_SIZE] || this.annotations?.[CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_MAX_SIZE]);
+
+    return isMachinePoolAutoscalerEnabled(this.inClusterSpec) || fromAnnotations;
+  }
+
+  /**
+   * Is the autoscaler paused for this pool? Its range is stashed on the pool, and the CAPI node group annotations have
+   * been pruned from this machine deployment
+   */
+  get isAutoscalerPaused() {
+    return isMachinePoolAutoscalerPaused(this.inClusterSpec);
+  }
+
+  /**
+   * Pausing and resuming writes the pool's range on the provisioning cluster, so it needs a pool with a range to write
+   * and permission to update that cluster.
+   *
+   * Deliberately not `isAutoscalerEnabled`, which is also true for a machine deployment autoscaled by its own CAPI node
+   * group annotations. Those belong to an upstream provider, there is nothing on the pool to stash, and offering a
+   * button that cannot do anything is worse than offering none.
+   *
+   * A pause also has to record the number of machines the autoscaler left the pool with, so it waits for a machine
+   * deployment that knows its replica count rather than pausing the pool onto a stale quantity
+   */
+  get canPauseResumeAutoscaler() {
+    return isMachinePoolAutoscalerEnabled(this.inClusterSpec) && typeof this.spec?.replicas === 'number' && !!this.cluster?.canUpdate;
+  }
+
+  /**
+   * The resize resuming the autoscaler would cause, or null when it would cause none. The pool has been scaled, while
+   * paused, to a count outside the range that is about to be restored, and the autoscaler corrects that as soon as it
+   * takes the pool back. `direction` and `target` say which way and to what, so the user is told before it happens
+   *
+   * @returns {{direction: 'up'|'down', target: number, count: number}|null}
+   */
+  get autoscalerResumeResize() {
+    if (!this.isAutoscalerPaused || typeof this.spec?.replicas !== 'number') {
+      return null;
+    }
+
+    const { min, max } = machinePoolAutoscalerRange(this.inClusterSpec);
+    const count = this.spec.replicas;
+
+    if (max !== undefined && count > max) {
+      return {
+        direction: 'down', target: max, count
+      };
+    }
+
+    if (min !== undefined && count < min) {
+      return {
+        direction: 'up', target: min, count
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Pause or resume the autoscaler for this pool, in one save of the provisioning cluster that holds the pool's range.
+   *
+   * Returns the save, which rejects if it failed. The pool is put back as it was and the error growled first, so a
+   * caller only needs the rejection to tell the user what happened
+   */
+  toggleAutoscalerPause() {
+    const pool = this.inClusterSpec;
+
+    if (!pool || !isMachinePoolAutoscalerEnabled(pool)) {
+      return;
+    }
+
+    return this.setAutoscalerPaused(!isMachinePoolAutoscalerPaused(pool));
+  }
+
+  /**
+   * Pause or resume the autoscaler for this pool and save the provisioning cluster.
+   *
+   * A conflicting save is retried rather than reported: `save` has already refetched the cluster by the time this runs,
+   * so the pool is server truth again and applying the same intent to it is all that is needed. The intent is carried
+   * through the retry rather than re-derived, so a pause cannot turn into a resume because someone else got there first
+   */
+  setAutoscalerPaused(paused, depth = 0) {
+    const pool = this.inClusterSpec;
+
+    if (!pool) {
+      return;
+    }
+
+    const previousQuantity = pool.quantity;
+
+    if (paused) {
+      // The pool keeps the number of machines the autoscaler left it with, rather than snapping back to the quantity it
+      // was created with
+      pauseMachinePoolAutoscaler(pool, this.spec?.replicas);
+    } else {
+      resumeMachinePoolAutoscaler(pool);
+    }
+
+    return this.cluster.save().catch((err) => {
+      // Steve rejects with the response body, where the status is `_status`. Plain `status` is only there when the
+      // error body carried one, and `save` decides whether to refetch on `_status` alone
+      if ((err?.status === 409 || err?._status === 409) && depth < 2) {
+        return this.setAutoscalerPaused(paused, depth + 1);
+      }
+
+      // Put the pool back the way it was, so the control doesn't show a state that was never saved. Only while it is
+      // still the pool that was changed: a conflict refetches the cluster, and what came back is another writer's
+      // state, not a change of ours waiting to be undone
+      if (this.inClusterSpec === pool) {
+        if (paused) {
+          resumeMachinePoolAutoscaler(pool);
+        } else {
+          pauseMachinePoolAutoscaler(pool);
+        }
+
+        if (previousQuantity === undefined) {
+          delete pool.quantity;
+        } else {
+          pool.quantity = previousQuantity;
+        }
+      }
+
+      this.$dispatch('growl/fromError', {
+        title: this.t(paused ? 'cluster.machinePool.autoscaler.growl.pauseError' : 'cluster.machinePool.autoscaler.growl.resumeError'),
+        err:   exceptionToErrorsArray(err)
+      }, { root: true });
+
+      throw err;
+    });
   }
 
   // prevent scaling pool to 0 if it would scale down the only etcd or control plane node

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -21,6 +21,7 @@ import { isHostedProvider, isCAPIProvider } from '@shell/utils/provider';
 import { ucFirst } from '@shell/utils/string';
 import { sortBy } from '@shell/utils/sort';
 import { SETTING } from '@shell/config/settings';
+import { isMachinePoolAutoscalerEnabled } from '@shell/utils/autoscaler-utils';
 const DEFAULT_BADGE_COLOR = '#707070';
 
 // See translation file cluster.providers for list of providers
@@ -859,9 +860,9 @@ export default class MgmtCluster extends SteveModel {
       return false;
     }
 
-    return !!this.provCluster.spec?.rkeConfig?.machinePools?.some((pool) => {
-      return typeof pool.autoscalingMinSize !== 'undefined' || typeof pool.autoscalingMaxSize !== 'undefined';
-    });
+    // A paused pool still counts as enabled, otherwise pausing every pool would hide the autoscaler column, popover,
+    // tab and the cluster level pause action
+    return !!this.provCluster.spec?.rkeConfig?.machinePools?.some((pool) => isMachinePoolAutoscalerEnabled(pool));
   }
 
   _statusInfoWarned = false;

--- a/shell/utils/__tests__/autoscaler-utils.test.ts
+++ b/shell/utils/__tests__/autoscaler-utils.test.ts
@@ -1,0 +1,318 @@
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+import {
+  AutoscalerMachinePool,
+  disableMachinePoolAutoscaler,
+  enableMachinePoolAutoscaler,
+  isMachinePoolAutoscalerEnabled,
+  isMachinePoolAutoscalerPaused,
+  machinePoolAutoscalerRange,
+  pauseMachinePoolAutoscaler,
+  resumeMachinePoolAutoscaler,
+  setMachinePoolAutoscalerRange
+} from '@shell/utils/autoscaler-utils';
+
+const PAUSED_MIN = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE;
+const PAUSED_MAX = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE;
+
+describe('fx: isMachinePoolAutoscalerPaused', () => {
+  const testCases: [string, AutoscalerMachinePool | undefined, boolean][] = [
+    ['an undefined pool', undefined, false],
+    ['a pool with no autoscaler', {}, false],
+    ['a pool autoscaling live', { autoscalingMinSize: 1, autoscalingMaxSize: 3 }, false],
+    ['a pool with unrelated machine deployment annotations', { machineDeploymentAnnotations: { foo: 'bar' } }, false],
+    ['a paused pool', { machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '3' } }, true],
+    ['a pool with only a stashed min', { machineDeploymentAnnotations: { [PAUSED_MIN]: '1' } }, true],
+    ['a pool with a stashed range that does not parse', { machineDeploymentAnnotations: { [PAUSED_MIN]: 'not-a-number' } }, false],
+  ];
+
+  it.each(testCases)('should report %s correctly', (_label, pool, expected) => {
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(expected);
+  });
+});
+
+describe('fx: isMachinePoolAutoscalerEnabled', () => {
+  const testCases: [string, AutoscalerMachinePool | undefined, boolean][] = [
+    ['an undefined pool', undefined, false],
+    ['a pool with no autoscaler', {}, false],
+    ['a pool autoscaling live', { autoscalingMinSize: 1, autoscalingMaxSize: 3 }, true],
+    ['a pool with only a min size', { autoscalingMinSize: 1 }, true],
+    ['a pool with only a max size', { autoscalingMaxSize: 3 }, true],
+    ['a paused pool', { machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '3' } }, true],
+    ['a pool with unrelated machine deployment annotations', { machineDeploymentAnnotations: { foo: 'bar' } }, false],
+  ];
+
+  it.each(testCases)('should report %s correctly', (_label, pool, expected) => {
+    expect(isMachinePoolAutoscalerEnabled(pool)).toBe(expected);
+  });
+});
+
+describe('fx: machinePoolAutoscalerRange', () => {
+  it('should return an empty range for an undefined pool', () => {
+    expect(machinePoolAutoscalerRange(undefined)).toStrictEqual({ min: undefined, max: undefined });
+  });
+
+  it('should return the live range of a running pool', () => {
+    expect(machinePoolAutoscalerRange({ autoscalingMinSize: 2, autoscalingMaxSize: 5 })).toStrictEqual({ min: 2, max: 5 });
+  });
+
+  it('should return the stashed range of a paused pool', () => {
+    const pool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } };
+
+    expect(machinePoolAutoscalerRange(pool)).toStrictEqual({ min: 2, max: 5 });
+  });
+
+  it('should ignore a stashed value that does not parse as a number', () => {
+    const pool = { machineDeploymentAnnotations: { [PAUSED_MIN]: 'three', [PAUSED_MAX]: '5' } };
+
+    expect(machinePoolAutoscalerRange(pool)).toStrictEqual({ min: undefined, max: 5 });
+  });
+});
+
+describe('fx: enableMachinePoolAutoscaler', () => {
+  it('should write the given range', () => {
+    const pool: AutoscalerMachinePool = {};
+
+    enableMachinePoolAutoscaler(pool, { min: 1, max: 2 });
+
+    expect(pool).toStrictEqual({ autoscalingMinSize: 1, autoscalingMaxSize: 2 });
+  });
+
+  it('should clear anything stashed by an earlier pause', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '4', [PAUSED_MAX]: '9' } };
+
+    enableMachinePoolAutoscaler(pool, { min: 1, max: 2 });
+
+    expect(pool).toStrictEqual({ autoscalingMinSize: 1, autoscalingMaxSize: 2 });
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(false);
+  });
+
+  it('should not throw for an undefined pool', () => {
+    expect(() => enableMachinePoolAutoscaler(undefined, { min: 1, max: 2 })).not.toThrow();
+  });
+});
+
+describe('fx: disableMachinePoolAutoscaler', () => {
+  it('should remove the live range', () => {
+    const pool: AutoscalerMachinePool = { autoscalingMinSize: 1, autoscalingMaxSize: 2 };
+
+    disableMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({});
+    expect(isMachinePoolAutoscalerEnabled(pool)).toBe(false);
+  });
+
+  it('should remove the stashed range of a paused pool, leaving other annotations alone', () => {
+    const pool: AutoscalerMachinePool = {
+      machineDeploymentAnnotations: {
+        [PAUSED_MIN]: '1', [PAUSED_MAX]: '2', foo: 'bar'
+      }
+    };
+
+    disableMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { foo: 'bar' } });
+    expect(isMachinePoolAutoscalerEnabled(pool)).toBe(false);
+  });
+
+  it('should remove a machine deployment annotations map that held nothing but the stash', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '2' } };
+
+    disableMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({});
+  });
+
+  it('should not throw for an undefined pool', () => {
+    expect(() => disableMachinePoolAutoscaler(undefined)).not.toThrow();
+  });
+});
+
+describe('fx: pauseMachinePoolAutoscaler', () => {
+  it('should stash the live range and remove it from the pool', () => {
+    const pool: AutoscalerMachinePool = { autoscalingMinSize: 2, autoscalingMaxSize: 5 };
+
+    pauseMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } });
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(true);
+    expect(isMachinePoolAutoscalerEnabled(pool)).toBe(true);
+  });
+
+  it('should keep the pool at the size the autoscaler left it', () => {
+    const pool: AutoscalerMachinePool = {
+      quantity: 1, autoscalingMinSize: 1, autoscalingMaxSize: 9
+    };
+
+    pauseMachinePoolAutoscaler(pool, 7);
+
+    expect(pool.quantity).toBe(7);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['not a number', 'three'],
+  ])('should leave the quantity alone when the current count is %s', (_label, count) => {
+    const pool: AutoscalerMachinePool = {
+      quantity: 1, autoscalingMinSize: 1, autoscalingMaxSize: 9
+    };
+
+    pauseMachinePoolAutoscaler(pool, count as any);
+
+    expect(pool.quantity).toBe(1);
+  });
+
+  it('should not touch the quantity of a pool it does not pause', () => {
+    const pool: AutoscalerMachinePool = { quantity: 1 };
+
+    pauseMachinePoolAutoscaler(pool, 7);
+
+    expect(pool).toStrictEqual({ quantity: 1 });
+  });
+
+  it('should be a no-op for a pool with no autoscaler', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { foo: 'bar' } };
+
+    pauseMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { foo: 'bar' } });
+  });
+
+  it('should be a no-op for a pool that is already paused', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } };
+
+    pauseMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } });
+  });
+
+  it('should not throw for an undefined pool', () => {
+    expect(() => pauseMachinePoolAutoscaler(undefined)).not.toThrow();
+  });
+});
+
+describe('fx: resumeMachinePoolAutoscaler', () => {
+  it('should restore the stashed range', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } };
+
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ autoscalingMinSize: 2, autoscalingMaxSize: 5 });
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(false);
+  });
+
+  it('should ignore a stashed value that does not parse as a number', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: 'nonsense', [PAUSED_MAX]: '5' } };
+
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ autoscalingMaxSize: 5 });
+    expect(pool.autoscalingMinSize).toBeUndefined();
+  });
+
+  it('should be a no-op for a pool that is not paused', () => {
+    const pool: AutoscalerMachinePool = { autoscalingMinSize: 2, autoscalingMaxSize: 5 };
+
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({ autoscalingMinSize: 2, autoscalingMaxSize: 5 });
+  });
+
+  it('should leave the quantity alone, so the autoscaler takes the pool over at the size it has', () => {
+    const pool: AutoscalerMachinePool = { quantity: 7, machineDeploymentAnnotations: { [PAUSED_MIN]: '2', [PAUSED_MAX]: '5' } };
+
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({
+      quantity: 7, autoscalingMinSize: 2, autoscalingMaxSize: 5
+    });
+  });
+
+  it('should not throw for an undefined pool', () => {
+    expect(() => resumeMachinePoolAutoscaler(undefined)).not.toThrow();
+  });
+});
+
+describe('machine pool autoscaler pause round trip', () => {
+  it('should return the identical range after enable, pause and resume', () => {
+    const pool: AutoscalerMachinePool = {};
+
+    enableMachinePoolAutoscaler(pool, { min: 3, max: 7 });
+    const enabledRange = machinePoolAutoscalerRange(pool);
+
+    pauseMachinePoolAutoscaler(pool);
+
+    expect(machinePoolAutoscalerRange(pool)).toStrictEqual(enabledRange);
+    expect(pool.autoscalingMinSize).toBeUndefined();
+    expect(pool.autoscalingMaxSize).toBeUndefined();
+
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(machinePoolAutoscalerRange(pool)).toStrictEqual(enabledRange);
+    expect(pool.autoscalingMinSize).toBe(3);
+    expect(pool.autoscalingMaxSize).toBe(7);
+  });
+
+  it('should leave the pool exactly as it was after a pause and a resume', () => {
+    const pool: AutoscalerMachinePool = {
+      quantity: 4, autoscalingMinSize: 3, autoscalingMaxSize: 7
+    };
+
+    pauseMachinePoolAutoscaler(pool, 4);
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({
+      quantity: 4, autoscalingMinSize: 3, autoscalingMaxSize: 7
+    });
+  });
+
+  it('should keep machine deployment annotations that are not the autoscaler stash', () => {
+    const pool: AutoscalerMachinePool = {
+      autoscalingMinSize:           3,
+      autoscalingMaxSize:           7,
+      machineDeploymentAnnotations: { 'some.io/annotation': 'a-value' }
+    };
+
+    pauseMachinePoolAutoscaler(pool);
+    resumeMachinePoolAutoscaler(pool);
+
+    expect(pool).toStrictEqual({
+      autoscalingMinSize:           3,
+      autoscalingMaxSize:           7,
+      machineDeploymentAnnotations: { 'some.io/annotation': 'a-value' }
+    });
+  });
+});
+
+describe('fx: setMachinePoolAutoscalerRange', () => {
+  it('should write the live range of a running pool', () => {
+    const pool: AutoscalerMachinePool = { autoscalingMinSize: 1, autoscalingMaxSize: 2 };
+
+    setMachinePoolAutoscalerRange(pool, { min: 3, max: 9 });
+
+    expect(pool).toStrictEqual({ autoscalingMinSize: 3, autoscalingMaxSize: 9 });
+  });
+
+  it('should write the stash of a paused pool, and keep it paused', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '2' } };
+
+    setMachinePoolAutoscalerRange(pool, { min: 3, max: 9 });
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { [PAUSED_MIN]: '3', [PAUSED_MAX]: '9' } });
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(true);
+    expect(machinePoolAutoscalerRange(pool)).toStrictEqual({ min: 3, max: 9 });
+  });
+
+  it('should remove a bound that has been cleared', () => {
+    const pool: AutoscalerMachinePool = { machineDeploymentAnnotations: { [PAUSED_MIN]: '1', [PAUSED_MAX]: '2' } };
+
+    setMachinePoolAutoscalerRange(pool, { min: undefined, max: 2 });
+
+    expect(pool).toStrictEqual({ machineDeploymentAnnotations: { [PAUSED_MAX]: '2' } });
+    expect(isMachinePoolAutoscalerPaused(pool)).toBe(true);
+  });
+
+  it('should not throw for an undefined pool', () => {
+    expect(() => setMachinePoolAutoscalerRange(undefined, { min: 1, max: 2 })).not.toThrow();
+  });
+});

--- a/shell/utils/autoscaler-utils.ts
+++ b/shell/utils/autoscaler-utils.ts
@@ -1,7 +1,264 @@
 import { AUTOSCALER } from '@shell/store/features';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 export function isAutoscalerFeatureFlagEnabled(store: any): boolean {
   const rootGetters = store.rootGetters || store.getters;
 
   return rootGetters['features/get'](AUTOSCALER);
+}
+
+/**
+ * A machine pool entry of a provisioning cluster's `spec.rkeConfig.machinePools`, reduced to the fields the pool level
+ * autoscaler cares about
+ */
+export interface AutoscalerMachinePool {
+  quantity?: number;
+  autoscalingMinSize?: number;
+  autoscalingMaxSize?: number;
+  machineDeploymentAnnotations?: { [key: string]: string };
+}
+
+/**
+ * The number of machines the autoscaler is allowed to scale a machine pool between
+ */
+export interface AutoscalerRange {
+  min?: number;
+  max?: number;
+}
+
+const PAUSED_MIN_SIZE = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MIN_SIZE;
+const PAUSED_MAX_SIZE = CAPI_ANNOTATIONS.AUTOSCALER_MACHINE_POOL_PAUSED_MAX_SIZE;
+
+/**
+ * Coerce a stored size to a number, treating anything that does not parse as absent.
+ *
+ * Annotation values are always strings, and can be hand edited, so a value that isn't a number must not end up in
+ * `autoscalingMinSize` / `autoscalingMaxSize` as `NaN`
+ */
+function toSize(value?: string | number): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  return isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * The range stashed on the pool while it is paused
+ */
+function stashedRange(pool?: AutoscalerMachinePool | null): AutoscalerRange {
+  const annotations = pool?.machineDeploymentAnnotations || {};
+
+  return {
+    min: toSize(annotations[PAUSED_MIN_SIZE]),
+    max: toSize(annotations[PAUSED_MAX_SIZE])
+  };
+}
+
+/**
+ * The range the pool is currently autoscaling with
+ */
+function liveRange(pool?: AutoscalerMachinePool | null): AutoscalerRange {
+  return {
+    min: toSize(pool?.autoscalingMinSize),
+    max: toSize(pool?.autoscalingMaxSize)
+  };
+}
+
+function hasRange(range: AutoscalerRange): boolean {
+  return range.min !== undefined || range.max !== undefined;
+}
+
+/**
+ * Remove the stashed range from the pool, leaving any other machine deployment annotations alone.
+ *
+ * The map itself goes when nothing is left in it, so a pause and resume round trip leaves the pool exactly as it was
+ * rather than an empty map the pool never had
+ */
+function clearStashedRange(pool: AutoscalerMachinePool) {
+  if (!pool.machineDeploymentAnnotations) {
+    return;
+  }
+
+  delete pool.machineDeploymentAnnotations[PAUSED_MIN_SIZE];
+  delete pool.machineDeploymentAnnotations[PAUSED_MAX_SIZE];
+
+  if (!Object.keys(pool.machineDeploymentAnnotations).length) {
+    delete pool.machineDeploymentAnnotations;
+  }
+}
+
+/**
+ * Write the range the pool autoscales with, removing a bound that has no value
+ */
+function writeLiveRange(pool: AutoscalerMachinePool, range: AutoscalerRange) {
+  const min = toSize(range?.min);
+  const max = toSize(range?.max);
+
+  if (min === undefined) {
+    delete pool.autoscalingMinSize;
+  } else {
+    pool.autoscalingMinSize = min;
+  }
+
+  if (max === undefined) {
+    delete pool.autoscalingMaxSize;
+  } else {
+    pool.autoscalingMaxSize = max;
+  }
+}
+
+/**
+ * Write the range stashed while the pool is paused. Annotation values are strings, so each bound is stringified, and a
+ * bound with no value is removed
+ */
+function writeStashedRange(pool: AutoscalerMachinePool, range: AutoscalerRange) {
+  const min = toSize(range?.min);
+  const max = toSize(range?.max);
+
+  if (min !== undefined || max !== undefined) {
+    pool.machineDeploymentAnnotations = pool.machineDeploymentAnnotations || {};
+  }
+
+  if (min === undefined) {
+    delete pool.machineDeploymentAnnotations?.[PAUSED_MIN_SIZE];
+  } else {
+    (pool.machineDeploymentAnnotations as { [key: string]: string })[PAUSED_MIN_SIZE] = String(min);
+  }
+
+  if (max === undefined) {
+    delete pool.machineDeploymentAnnotations?.[PAUSED_MAX_SIZE];
+  } else {
+    (pool.machineDeploymentAnnotations as { [key: string]: string })[PAUSED_MAX_SIZE] = String(max);
+  }
+
+  if (pool.machineDeploymentAnnotations && !Object.keys(pool.machineDeploymentAnnotations).length) {
+    delete pool.machineDeploymentAnnotations;
+  }
+}
+
+/**
+ * Is the autoscaler paused for this machine pool? True when a range has been stashed on the pool
+ */
+export function isMachinePoolAutoscalerPaused(pool?: AutoscalerMachinePool | null): boolean {
+  return hasRange(stashedRange(pool));
+}
+
+/**
+ * Is the autoscaler configured for this machine pool? True while the pool is paused, given the pool's range is only
+ * stashed away and not forgotten
+ */
+export function isMachinePoolAutoscalerEnabled(pool?: AutoscalerMachinePool | null): boolean {
+  return hasRange(liveRange(pool)) || isMachinePoolAutoscalerPaused(pool);
+}
+
+/**
+ * The machine pool's autoscaling range, taken from the stash when the pool is paused
+ */
+export function machinePoolAutoscalerRange(pool?: AutoscalerMachinePool | null): AutoscalerRange {
+  const live = liveRange(pool);
+
+  return hasRange(live) ? live : stashedRange(pool);
+}
+
+/**
+ * Configure the autoscaler for this machine pool with the given range
+ */
+export function enableMachinePoolAutoscaler(pool: AutoscalerMachinePool | null | undefined, range: AutoscalerRange) {
+  if (!pool) {
+    return;
+  }
+
+  writeLiveRange(pool, range);
+
+  clearStashedRange(pool);
+}
+
+/**
+ * Change the machine pool's autoscaling range, writing wherever the range currently lives. A paused pool's range is
+ * stashed, so editing it while paused updates the stash and the pool stays paused.
+ *
+ * `paused` says where to write. It defaults to where the pool's range is now, and a form editing a paused pool passes
+ * its own state instead: clearing both bounds empties the stash, and without it the next keystroke would silently turn
+ * a paused pool into a running one
+ */
+export function setMachinePoolAutoscalerRange(
+  pool: AutoscalerMachinePool | null | undefined,
+  range: AutoscalerRange,
+  paused?: boolean
+) {
+  if (!pool) {
+    return;
+  }
+
+  if (paused === undefined ? isMachinePoolAutoscalerPaused(pool) : paused) {
+    writeStashedRange(pool, range);
+  } else {
+    writeLiveRange(pool, range);
+  }
+}
+
+/**
+ * Remove the autoscaler from this machine pool, both the live range and anything stashed by a pause
+ */
+export function disableMachinePoolAutoscaler(pool?: AutoscalerMachinePool | null) {
+  if (!pool) {
+    return;
+  }
+
+  delete pool.autoscalingMinSize;
+  delete pool.autoscalingMaxSize;
+
+  clearStashedRange(pool);
+}
+
+/**
+ * Pause the autoscaler for this machine pool by stashing its range and removing the live values, which prunes the CAPI
+ * node group annotations from the pool's machine deployment and so takes the pool out of the autoscaler's hands.
+ *
+ * `currentQuantity` is the number of machines the pool has right now. The pool's `quantity` is what drives the machine
+ * count once the autoscaler is no longer managing the pool, so it is set to the size the autoscaler left behind and the
+ * pause changes nothing but who is in control. A count that isn't a number is ignored rather than written.
+ *
+ * A no-op for a pool that has no autoscaler configured, or that is paused already
+ */
+export function pauseMachinePoolAutoscaler(pool?: AutoscalerMachinePool | null, currentQuantity?: number) {
+  if (!pool || isMachinePoolAutoscalerPaused(pool)) {
+    return;
+  }
+
+  const range = liveRange(pool);
+
+  if (!hasRange(range)) {
+    return;
+  }
+
+  writeStashedRange(pool, range);
+
+  delete pool.autoscalingMinSize;
+  delete pool.autoscalingMaxSize;
+
+  const quantity = toSize(currentQuantity);
+
+  if (quantity !== undefined) {
+    pool.quantity = quantity;
+  }
+}
+
+/**
+ * Resume the autoscaler for this machine pool, restoring the range stashed by the pause.
+ *
+ * A no-op for a pool that is not paused
+ */
+export function resumeMachinePoolAutoscaler(pool?: AutoscalerMachinePool | null) {
+  if (!pool || !isMachinePoolAutoscalerPaused(pool)) {
+    return;
+  }
+
+  // The pool's `quantity` is left alone: the autoscaler takes the pool over again from the size it has now
+  writeLiveRange(pool, stashedRange(pool));
+
+  clearStashedRange(pool);
 }

--- a/shell/utils/validators/machine-pool.ts
+++ b/shell/utils/validators/machine-pool.ts
@@ -14,13 +14,15 @@ const RULESETS = [
     path:  FIELDS.NAME,
     rules: ['required', 'uniquePoolName'],
   },
+  // The autoscaler bounds live on the pool while it is autoscaling and in the pool's stash while it is paused, so they
+  // are checked by rules that read the range rather than the value at the path
   {
     path:  FIELDS.AUTOSCALER_MIN,
-    rules: ['isPositive', 'isAutoscalerMaxGreaterThanMin'],
+    rules: ['isAutoscalerMinSizeValid', 'isAutoscalerMaxGreaterThanMin'],
   },
   {
     path:  FIELDS.AUTOSCALER_MAX,
-    rules: ['isPositive', 'isAutoscalerMaxGreaterThanMin'],
+    rules: ['isAutoscalerMaxSizeValid', 'isAutoscalerMaxGreaterThanMin'],
   },
 ];
 


### PR DESCRIPTION
### Summary
Fixes #15656

### Occurred changes and/or fixed issues
- Autoscaled pool rows on the cluster detail page show their state and a Pause/Resume button.
- A paused pool gets its scale buttons and editable Machine Count back.
- Resuming a pool outside its stored range asks first.

### Technical notes summary
- Pause moves the pool's autoscaling min/max into its `machineDeploymentAnnotations` and resume moves them back. Removing the live range is what drops the pool from the autoscaler. One save, so it cannot half apply.
- Pause writes the current replica count into `quantity`. Rancher sets replicas from it and never writes the live count back, so a pause could otherwise scale to a stale count.
- `isAutoscalerEnabled` counts paused pools, so the cluster-level autoscaler UI stays.

### Areas or cases that should be tested
Needs `cluster-autoscaling` and an RKE2 worker pool with an autoscaling range.

```
Cluster Management > <cluster> > Machine Pools > Pause on the autoscaled pool
Cluster Management > <cluster> > Edit Config > Machine Pools > <paused pool>
```

- Pause: machine count unchanged, another autoscaled pool keeps autoscaling.
- Resume: the pool spec matches the pre-pause spec.
- Scale a paused pool outside its range, then resume: it asks first.
- Edit form, paused pool: Machine Count and range are editable.

```bash
npx jest --ci shell/utils/__tests__/autoscaler-utils.test.ts shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts shell/models/__tests__/management.cattle.io.cluster.test.ts shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts shell/edit/provisioning.cattle.io.cluster/__tests__/MachinePool.test.ts
```

### Areas which could experience regressions
- Autoscaler column, tab and cluster-level pause (they key off `isAutoscalerEnabled`).
- Detail page rows for pools without an autoscaler.
- `inClusterSpec` on Harvester, custom, imported and CAPI clusters.

### Screenshot/Video
**Before** - no per-pool pause: [reproduce-issue-15656.mp4](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/reproduce-issue-15656.mp4)

**After** - the same walk, pausing one pool: [verify-issue-15656.mp4](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/verify-issue-15656.mp4)

| | Light | Dark |
|---|---|---|
| Autoscaling | ![](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/pool-autoscaling-light.png) | ![](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/pool-autoscaling-dark.png) |
| Paused | ![](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/pool-paused-light.png) | ![](https://github.com/codyrancher/dashboard/releases/download/issue-15656-media/pool-paused-dark.png) |

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
