### PR TITLE
Automation: Add project token to candidate-automation workflow

### DIFF
--- a/.github/workflows/automation-candidate.yaml
+++ b/.github/workflows/automation-candidate.yaml
@@ -24,9 +24,17 @@ jobs:
           secrets: |
             github/token/rancher--qa-tasks--issues--write token | QA_GH_TOKEN
 
+      - name: Read project secrets from Vault
+        uses: rancher-eio/read-vault-secrets@dfae8acd43a9e170fca5f90168da22f814fe4e9a # v3
+        with:
+          secrets: |
+            github/token/rancher--organization_projects--write token | GH_PROJECT_TOKEN
+
       - name: Create QA automation issue
         env:
           GH_TOKEN: ${{ env.QA_GH_TOKEN }}
+          GH_PROJECT_TOKEN: ${{ env.GH_PROJECT_TOKEN }}
+          PROJECT_NUMBER: ${{ vars.INSPECTOR_GITHUB_PROJECT_NUMBER }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           ORIGINAL_ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
@@ -50,6 +58,7 @@ jobs:
 
           if NEW_ISSUE=$(gh issue create -R "rancher/qa-tasks" --title "[UI Automation]: ${ORIGINAL_TITLE}" --body-file "${BODY}" "${additional_cmd[@]}"); then
               echo "QA task issue created: ${NEW_ISSUE}" >> $GITHUB_STEP_SUMMARY
+              GH_TOKEN=${GH_PROJECT_TOKEN} gh project item-add "${PROJECT_NUMBER}" --owner rancher --url "${NEW_ISSUE}"
           else
               echo "Failed to create issue"
               GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh issue comment ${ORIGINAL_ISSUE_URL} --body "No QA automation issue was created. Failed to create issue in rancher/qa-tasks."


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #rancher/qa-tasks#2540

When the `candidate-automation` label is added to an issue, the workflow creates a task in `rancher/qa-tasks` but never adds it to the UI project board.
Workflow now reads `rancher--organization_projects--write` from Vault and uses it to run
`gh project item-add` against the project after the issue is created.
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
