### PR TITLE
Disable viewing cloud credential as YAML

### DIFF
--- a/cypress/e2e/po/lists/kubeconfig-list.po.ts
+++ b/cypress/e2e/po/lists/kubeconfig-list.po.ts
@@ -1,0 +1,7 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class KubeconfigListPo extends BaseResourceList {
+  details(name: string, index: number) {
+    return this.resourceTable().sortableTable().rowWithName(name).column(index);
+  }
+}

--- a/cypress/e2e/po/pages/cluster-manager/kubeconfig.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/kubeconfig.po.ts
@@ -1,0 +1,20 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import KubeconfigListPo from '@/cypress/e2e/po/lists/kubeconfig-list.po';
+
+export default class KubeconfigPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/manager/ext.cattle.io.kubeconfig`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(KubeconfigPagePo.createPath(clusterId));
+  }
+
+  constructor(private clusterId = '_') {
+    super(KubeconfigPagePo.createPath(clusterId));
+  }
+
+  list(): KubeconfigListPo {
+    return new KubeconfigListPo('[data-testid="sortable-table-list-container"]');
+  }
+}

--- a/cypress/e2e/po/pages/cluster-manager/kubeconfig.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/kubeconfig.po.ts
@@ -2,16 +2,25 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import KubeconfigListPo from '@/cypress/e2e/po/lists/kubeconfig-list.po';
 
 export default class KubeconfigPagePo extends PagePo {
-  private static createPath(clusterId: string) {
-    return `/c/${ clusterId }/manager/ext.cattle.io.kubeconfig`;
+  private static createPath(clusterId: string, id?: string) {
+    const root = `/c/${ clusterId }/manager/ext.cattle.io.kubeconfig`;
+
+    return id ? `${ root }/${ id }` : root;
   }
 
   static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
     return super.goTo(KubeconfigPagePo.createPath(clusterId));
   }
 
-  constructor(private clusterId = '_') {
-    super(KubeconfigPagePo.createPath(clusterId));
+  /**
+   * @param clusterId
+   * @param id - kubeconfig resource id, e.g. from the create API response. When given, navigates
+   * straight to that resource's detail page (ext.cattle.io.kubeconfig is not namespaced) instead
+   * of the list, since the list's own columns (clusters/ttl/age) don't display the resource's
+   * name/id as visible text to match a row on.
+   */
+  constructor(clusterId = '_', id?: string) {
+    super(KubeconfigPagePo.createPath(clusterId, id));
   }
 
   list(): KubeconfigListPo {

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -312,6 +312,23 @@ describe('Cloud Credential', { tags: ['@manager', '@adminUser', '@clusterConfig'
       });
   });
 
+  it('does not offer "Show Configuration", since YAML viewing/editing is intentionally unavailable for cloud credentials', () => {
+    const credsName = `test-show-config-${ Date.now() }`;
+
+    cy.createRancherResource('v3', 'cloudcredentials', JSON.stringify(cloudCredentialCreatePayloadDO(credsName, 'token'))).then((resp: Cypress.Response<any>) => {
+      doCreatedCloudCredsIds.push(resp.body.id);
+
+      const cloudCredentialsPage = new CloudCredentialsPagePo();
+
+      cloudCredentialsPage.goTo();
+      cloudCredentialsPage.waitForPage();
+      cloudCredentialsPage.list().resourceTable().sortableTable().rowElementWithName(credsName)
+        .click();
+
+      cy.get('[data-testid="show-configuration-cta"]').should('not.exist');
+    });
+  });
+
   after(() => {
     cy.login(); // this is needed to avoid getting "Unauthorized 401: must authenticate" error
     for (let i = 0; i < doCreatedCloudCredsIds.length; i++) {

--- a/cypress/e2e/tests/pages/manager/kubeconfig.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kubeconfig.spec.ts
@@ -8,7 +8,7 @@ describe('Kubeconfig', { tags: ['@manager', '@adminUser'] }, () => {
 
   beforeEach(() => {
     cy.login();
-    HomePagePo.goTo();
+    HomePagePo.goTo(); // this is needed to ensure we have a valid authentication session
   });
 
   it('"Show Configuration" shows a working, non-blank YAML tab', () => {
@@ -18,12 +18,10 @@ describe('Kubeconfig', { tags: ['@manager', '@adminUser'] }, () => {
     })).then((resp: Cypress.Response<any>) => {
       createdKubeconfigId = resp.body.id;
 
-      const kubeconfigPage = new KubeconfigPagePo();
+      const kubeconfigDetailPage = new KubeconfigPagePo('_', createdKubeconfigId);
 
-      kubeconfigPage.goTo();
-      kubeconfigPage.waitForPage();
-      kubeconfigPage.list().resourceTable().sortableTable().rowElementWithName(createdKubeconfigId)
-        .click();
+      kubeconfigDetailPage.goTo();
+      kubeconfigDetailPage.waitForPage();
 
       cy.get('[data-testid="show-configuration-cta"]').should('be.visible').click();
 

--- a/cypress/e2e/tests/pages/manager/kubeconfig.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kubeconfig.spec.ts
@@ -1,0 +1,45 @@
+import KubeconfigPagePo from '@/cypress/e2e/po/pages/cluster-manager/kubeconfig.po';
+import DetailDrawer from '@/cypress/e2e/po/side-bars/detail-drawer.po';
+import ResourceYamlPo from '@/cypress/e2e/po/components/resource-yaml.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+
+describe('Kubeconfig', { tags: ['@manager', '@adminUser'] }, () => {
+  let createdKubeconfigId: string;
+
+  beforeEach(() => {
+    cy.login();
+    HomePagePo.goTo();
+  });
+
+  it('"Show Configuration" shows a working, non-blank YAML tab', () => {
+    cy.createRancherResource('v1', 'ext.cattle.io.kubeconfigs', JSON.stringify({
+      type: 'ext.cattle.io.kubeconfig',
+      spec: { clusters: ['local'], includeDefaultEntry: false }
+    })).then((resp: Cypress.Response<any>) => {
+      createdKubeconfigId = resp.body.id;
+
+      const kubeconfigPage = new KubeconfigPagePo();
+
+      kubeconfigPage.goTo();
+      kubeconfigPage.waitForPage();
+      kubeconfigPage.list().resourceTable().sortableTable().rowElementWithName(createdKubeconfigId)
+        .click();
+
+      cy.get('[data-testid="show-configuration-cta"]').should('be.visible').click();
+
+      const drawer = new DetailDrawer();
+
+      drawer.checkExists();
+      drawer.checkVisible();
+      drawer.tabs().clickTabWithName('yaml-tab');
+
+      new ResourceYamlPo(drawer.self()).codeMirror().value().should('not.be.empty');
+    });
+  });
+
+  after(() => {
+    if (createdKubeconfigId) {
+      cy.deleteRancherResource('v1', 'ext.cattle.io.kubeconfigs', createdKubeconfigId, false);
+    }
+  });
+});

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
@@ -18,33 +18,24 @@ describe('composables: ResourceDetailDrawer', () => {
   const yaml = 'YAML';
 
   describe('useDefaultYamlTabProps', () => {
-    const optionsFor = jest.fn();
-    const store: any = { getters: { 'type-map/optionsFor': optionsFor } };
-
     afterEach(() => {
       jest.clearAllMocks();
     });
 
-    it('should return the appropriate values based on input when the type allows yaml', async() => {
-      jest.spyOn(vuex, 'useStore').mockImplementation(() => store);
-      const optionsForSpy = optionsFor.mockImplementation(() => ({ canYaml: true }));
+    it('should return the appropriate values based on input when the resource instance allows yaml', async() => {
       const getYamlSpy = jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.resolve(yaml));
-      const props = await useDefaultYamlTabProps(resource);
+      const props = await useDefaultYamlTabProps({ ...resource, canYaml: true });
 
-      expect(optionsForSpy).toHaveBeenCalledWith(resource.type);
-      expect(getYamlSpy).toHaveBeenCalledWith(resource);
+      expect(getYamlSpy).toHaveBeenCalledWith({ ...resource, canYaml: true });
       expect(props?.yaml).toStrictEqual(yaml);
-      expect(props?.resource).toStrictEqual(resource);
+      expect(props?.resource).toStrictEqual({ ...resource, canYaml: true });
     });
 
-    it('should return undefined without fetching yaml when the type has canYaml: false', async() => {
-      jest.spyOn(vuex, 'useStore').mockImplementation(() => store);
-      const optionsForSpy = optionsFor.mockImplementation(() => ({ canYaml: false }));
+    it('should return undefined without fetching yaml when the resource instance has canYaml: false', async() => {
       const getYamlSpy = jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.resolve(yaml));
-      const props = await useDefaultYamlTabProps(resource);
+      const props = await useDefaultYamlTabProps({ ...resource, canYaml: false });
 
-      expect(optionsForSpy).toHaveBeenCalledWith(resource.type);
-      expect(getYamlSpy).not.toHaveBeenCalledWith(resource);
+      expect(getYamlSpy).not.toHaveBeenCalledWith({ ...resource, canYaml: false });
       expect(props).toBeUndefined();
     });
   });

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
@@ -35,7 +35,28 @@ describe('composables: ResourceDetailDrawer', () => {
       const getYamlSpy = jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.resolve(yaml));
       const props = await useDefaultYamlTabProps({ ...resource, canYaml: false });
 
-      expect(getYamlSpy).not.toHaveBeenCalledWith({ ...resource, canYaml: false });
+      expect(getYamlSpy).not.toHaveBeenCalled();
+      expect(props).toBeUndefined();
+    });
+
+    it('should return undefined instead of throwing when the resource canYaml getter throws', async() => {
+      const throwingResource = {};
+
+      Object.defineProperty(throwingResource, 'canYaml', {
+        get() {
+          throw new Error('boom, badly-behaved plugin model class');
+        }
+      });
+
+      const props = await useDefaultYamlTabProps(throwingResource);
+
+      expect(props).toBeUndefined();
+    });
+
+    it('should return undefined instead of throwing when getYaml itself rejects', async() => {
+      jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.reject(new Error('boom')));
+      const props = await useDefaultYamlTabProps({ ...resource, canYaml: true });
+
       expect(props).toBeUndefined();
     });
   });

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
@@ -18,13 +18,34 @@ describe('composables: ResourceDetailDrawer', () => {
   const yaml = 'YAML';
 
   describe('useDefaultYamlTabProps', () => {
-    it('should return the appropriate values based on input', async() => {
+    const optionsFor = jest.fn();
+    const store: any = { getters: { 'type-map/optionsFor': optionsFor } };
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return the appropriate values based on input when the type allows yaml', async() => {
+      jest.spyOn(vuex, 'useStore').mockImplementation(() => store);
+      const optionsForSpy = optionsFor.mockImplementation(() => ({ canYaml: true }));
       const getYamlSpy = jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.resolve(yaml));
       const props = await useDefaultYamlTabProps(resource);
 
+      expect(optionsForSpy).toHaveBeenCalledWith(resource.type);
       expect(getYamlSpy).toHaveBeenCalledWith(resource);
-      expect(props.yaml).toStrictEqual(yaml);
-      expect(props.resource).toStrictEqual(resource);
+      expect(props?.yaml).toStrictEqual(yaml);
+      expect(props?.resource).toStrictEqual(resource);
+    });
+
+    it('should return undefined without fetching yaml when the type has canYaml: false', async() => {
+      jest.spyOn(vuex, 'useStore').mockImplementation(() => store);
+      const optionsForSpy = optionsFor.mockImplementation(() => ({ canYaml: false }));
+      const getYamlSpy = jest.spyOn(helpers, 'getYaml').mockImplementation(() => Promise.resolve(yaml));
+      const props = await useDefaultYamlTabProps(resource);
+
+      expect(optionsForSpy).toHaveBeenCalledWith(resource.type);
+      expect(getYamlSpy).not.toHaveBeenCalledWith(resource);
+      expect(props).toBeUndefined();
     });
   });
 

--- a/shell/components/Drawer/ResourceDetailDrawer/composables.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/composables.ts
@@ -1,13 +1,16 @@
-import { useStore } from 'vuex';
 import { getYaml } from '@shell/components/Drawer/ResourceDetailDrawer/helpers';
 import { ConfigProps, YamlProps } from '@shell/components/Drawer/ResourceDetailDrawer/types';
 import { inject, provide } from 'vue';
+import { useStore } from 'vuex';
 
 export async function useDefaultYamlTabProps(resource: any): Promise<YamlProps | undefined> {
-  const store = useStore();
-  const { canYaml } = store.getters['type-map/optionsFor'](resource.type);
-
-  if (!canYaml) {
+  // Use the resource's own instance-level canYaml (hasLink('view')) rather than the type-map's
+  // static canYaml option: that option's meaning varies by type/author intent and isn't a
+  // reliable "can this type ever produce real yaml" signal - e.g. ext.cattle.io.kubeconfig sets
+  // canYaml: false purely to hide an unrelated button, while still genuinely supporting yaml
+  // (it has a real `view` link). The instance getter mirrors exactly what getYaml() itself
+  // checks, so it accurately reflects whether fetching yaml here will actually produce content.
+  if (!resource.canYaml) {
     return;
   }
 

--- a/shell/components/Drawer/ResourceDetailDrawer/composables.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/composables.ts
@@ -3,7 +3,14 @@ import { getYaml } from '@shell/components/Drawer/ResourceDetailDrawer/helpers';
 import { ConfigProps, YamlProps } from '@shell/components/Drawer/ResourceDetailDrawer/types';
 import { inject, provide } from 'vue';
 
-export async function useDefaultYamlTabProps(resource: any): Promise<YamlProps> {
+export async function useDefaultYamlTabProps(resource: any): Promise<YamlProps | undefined> {
+  const store = useStore();
+  const { canYaml } = store.getters['type-map/optionsFor'](resource.type);
+
+  if (!canYaml) {
+    return;
+  }
+
   const yaml = await getYaml(resource);
 
   return {

--- a/shell/components/Drawer/ResourceDetailDrawer/composables.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/composables.ts
@@ -4,22 +4,26 @@ import { inject, provide } from 'vue';
 import { useStore } from 'vuex';
 
 export async function useDefaultYamlTabProps(resource: any): Promise<YamlProps | undefined> {
-  // Use the resource's own instance-level canYaml (hasLink('view')) rather than the type-map's
-  // static canYaml option: that option's meaning varies by type/author intent and isn't a
-  // reliable "can this type ever produce real yaml" signal - e.g. ext.cattle.io.kubeconfig sets
-  // canYaml: false purely to hide an unrelated button, while still genuinely supporting yaml
-  // (it has a real `view` link). The instance getter mirrors exactly what getYaml() itself
-  // checks, so it accurately reflects whether fetching yaml here will actually produce content.
-  if (!resource.canYaml) {
-    return;
+  try {
+    // Use the resource's own instance-level canYaml (hasLink('view')) rather than the type-map's
+    // static canYaml option: that option's meaning varies by type/author intent and isn't a
+    // reliable "can this type ever produce real yaml" signal - e.g. ext.cattle.io.kubeconfig sets
+    // canYaml: false purely to hide an unrelated button, while still genuinely supporting yaml
+    // (it has a real `view` link). The instance getter mirrors exactly what getYaml() itself
+    // checks, so it accurately reflects whether fetching yaml here will actually produce content.
+    if (!resource.canYaml) {
+      return;
+    }
+
+    const yaml = await getYaml(resource);
+
+    return {
+      resource,
+      yaml
+    };
+  } catch (e) {
+    console.warn(`Could not determine/fetch yaml for '${ resource?.type }'`, e); // eslint-disable-line no-console
   }
-
-  const yaml = await getYaml(resource);
-
-  return {
-    resource,
-    yaml
-  };
 }
 
 export function useDefaultConfigTabProps(resource: any): ConfigProps | undefined {

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -23,6 +23,8 @@ const configTabProps = useDefaultConfigTabProps(props.resource);
 
 useDefaultYamlTabProps(props.resource).then((yamlProps) => {
   yamlTabProps.value = yamlProps ?? null;
+}).catch(() => {
+  yamlTabProps.value = null;
 });
 
 const title = computed(() => {

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -21,8 +21,8 @@ const i18n = useI18n(store);
 const yamlTabProps = ref<YamlProps | null>(null);
 const configTabProps = useDefaultConfigTabProps(props.resource);
 
-useDefaultYamlTabProps(props.resource).then((props) => {
-  yamlTabProps.value = props;
+useDefaultYamlTabProps(props.resource).then((yamlProps) => {
+  yamlTabProps.value = yamlProps ?? null;
 });
 
 const title = computed(() => {

--- a/shell/components/ResourceDetail/__tests__/index.test.ts
+++ b/shell/components/ResourceDetail/__tests__/index.test.ts
@@ -189,6 +189,28 @@ describe('component: ResourceDetail', () => {
 
       expect((wrapper.vm as any).canViewYaml).toBe(false);
     });
+
+    it('defaults to hiding the yaml toggle, without failing the page load, when the resource canYaml getter throws', async() => {
+      const throwingCanYaml = {};
+
+      Object.defineProperty(throwingCanYaml, 'canYaml', {
+        get() {
+          throw new Error('boom, badly-behaved plugin model class');
+        }
+      });
+
+      const store = createStore({
+        schema:     { id: 'bogus-resource-type' },
+        optionsFor: { canYaml: true },
+        findResult: throwingCanYaml,
+      });
+      const { wrapper, fetchState } = createWrapper(store);
+
+      await runFetch(wrapper, fetchState);
+
+      expect((wrapper.vm as any).resourceNotFoundError).toBeNull();
+      expect((wrapper.vm as any).canViewYaml).toBe(false);
+    });
   });
 
   // fullDetailPageOverride should only apply to the detail view, so the config/YAML

--- a/shell/components/ResourceDetail/__tests__/index.test.ts
+++ b/shell/components/ResourceDetail/__tests__/index.test.ts
@@ -23,16 +23,20 @@ jest.mock('@shell/composables/resourceDetail', () => ({ useResourceDetailPagePro
 type StoreOpts = {
   schema?: any;
   findError?: any;
+  findResult?: any;
+  optionsFor?: any;
 };
 
-const createStore = ({ schema, findError }: StoreOpts) => {
+const createStore = ({
+  schema, findError, findResult, optionsFor
+}: StoreOpts) => {
   const dispatch = jest.fn((action: string) => {
     if (action.endsWith('/find')) {
       if (findError) {
         return Promise.reject(findError);
       }
 
-      return Promise.resolve({});
+      return Promise.resolve(findResult ?? {});
     }
     if (action.endsWith('/clone') || action.endsWith('/cleanForDetail')) {
       return Promise.resolve({});
@@ -51,7 +55,7 @@ const createStore = ({ schema, findError }: StoreOpts) => {
       'type-map/hasCustomEdit':   () => false,
       'type-map/importDetail':    () => null,
       'type-map/importEdit':      () => null,
-      'type-map/optionsFor':      () => ({}),
+      'type-map/optionsFor':      () => (optionsFor ?? {}),
     },
     dispatch,
   };
@@ -144,6 +148,47 @@ describe('component: ResourceDetail', () => {
 
     expect((wrapper.vm as any).resourceNotFoundError).toBeNull();
     expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  describe('canViewYaml', () => {
+    it('is false when the live resource has no view link, even though the type-map default allows yaml', async() => {
+      const store = createStore({
+        schema:     { id: 'bogus-resource-type' },
+        optionsFor: { canYaml: true },
+        findResult: { canYaml: false },
+      });
+      const { wrapper, fetchState } = createWrapper(store);
+
+      await runFetch(wrapper, fetchState);
+
+      expect((wrapper.vm as any).canViewYaml).toBe(false);
+    });
+
+    it('stays true when the live resource does have a view link and the type-map default allows yaml', async() => {
+      const store = createStore({
+        schema:     { id: 'bogus-resource-type' },
+        optionsFor: { canYaml: true },
+        findResult: { canYaml: true },
+      });
+      const { wrapper, fetchState } = createWrapper(store);
+
+      await runFetch(wrapper, fetchState);
+
+      expect((wrapper.vm as any).canViewYaml).toBe(true);
+    });
+
+    it('stays false when the type-map default already disallows yaml, regardless of the live resource', async() => {
+      const store = createStore({
+        schema:     { id: 'bogus-resource-type' },
+        optionsFor: { canYaml: false },
+        findResult: { canYaml: true },
+      });
+      const { wrapper, fetchState } = createWrapper(store);
+
+      await runFetch(wrapper, fetchState);
+
+      expect((wrapper.vm as any).canViewYaml).toBe(false);
+    });
   });
 
   // fullDetailPageOverride should only apply to the detail view, so the config/YAML

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -214,7 +214,11 @@ export default {
       // new. Not applied during create/import: a brand new, unsaved resource never has any
       // links yet regardless of API family, so this check would incorrectly disable YAML
       // for every type while creating.
-      if ( canViewYaml && liveModel?.canYaml === false ) {
+      try {
+        if ( canViewYaml && liveModel?.canYaml === false ) {
+          canViewYaml = false;
+        }
+      } catch (e) {
         canViewYaml = false;
       }
 

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -131,7 +131,7 @@ export default {
     const options = store.getters[`type-map/optionsFor`](resourceType);
 
     this.showMasthead = [_CREATE, _EDIT].includes(mode) ? options.resourceEditMasthead : true;
-    const canViewYaml = options.canYaml;
+    let canViewYaml = options.canYaml;
 
     if ( options.resource ) {
       resourceType = options.resource;
@@ -203,6 +203,19 @@ export default {
         console.info(`Could not find '${ resourceType }' with id '${ id }''`, e); // eslint-disable-line no-console
         liveModel = {};
         notFound = fqid;
+      }
+
+      // options.canYaml is a static per-type default and can't know whether the API family
+      // backing this resource can actually produce YAML (e.g. Norman resources never expose
+      // a `view` link, unlike Steve). Fall back to the live resource's own instance-level
+      // canYaml (hasLink('view')) so a type that forgets to opt out via configureType still
+      // doesn't offer a YAML toggle that can only ever render blank. Only narrows an already
+      // allowed default to false - never overrides an explicit opt-out or offers something
+      // new. Not applied during create/import: a brand new, unsaved resource never has any
+      // links yet regardless of API family, so this check would incorrectly disable YAML
+      // for every type while creating.
+      if ( canViewYaml && liveModel?.canYaml === false ) {
+        canViewYaml = false;
       }
 
       try {

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -78,6 +78,8 @@ export function init(store) {
     'providers',
   ]);
 
+  configureType(NORMAN.CLOUD_CREDENTIAL, { canYaml: false });
+
   configureType(SNAPSHOT, { depaginate: true });
   configureType(CATALOG.CLUSTER_REPO, { listCreateButtonLabelKey: 'catalog.repo.add' });
 

--- a/shell/models/__tests__/cloudcredential.test.ts
+++ b/shell/models/__tests__/cloudcredential.test.ts
@@ -1,0 +1,19 @@
+import CloudCredential from '@shell/models/cloudcredential';
+
+describe('class CloudCredential', () => {
+  describe('doneRoute', () => {
+    it('points at the cloud credential list, not the unrelated (and non-existent) secret list route', () => {
+      const cc = new CloudCredential({ id: 'cattle-global-data:cc-abc123' } as any);
+
+      expect(cc.doneRoute).toBe('c-cluster-manager-cloudCredential');
+    });
+  });
+
+  describe('disableResourceDetailDrawer', () => {
+    it('is true, hiding "Show Configuration" since it has no custom detail component and YAML is intentionally unavailable', () => {
+      const cc = new CloudCredential({ id: 'cattle-global-data:cc-abc123' } as any);
+
+      expect(cc.disableResourceDetailDrawer).toBe(true);
+    });
+  });
+});

--- a/shell/models/cloudcredential.js
+++ b/shell/models/cloudcredential.js
@@ -14,6 +14,10 @@ export default class CloudCredential extends NormanModel {
     return true;
   }
 
+  get disableResourceDetailDrawer() {
+    return true;
+  }
+
   get _detailLocation() {
     return {
       name:   `c-cluster-manager-cloudCredential-id`,
@@ -175,6 +179,6 @@ export default class CloudCredential extends NormanModel {
   }
 
   get doneRoute() {
-    return 'c-cluster-manager-secret';
+    return 'c-cluster-manager-cloudCredential';
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18831 
<!-- Define findings related to the feature or bug issue. -->
Cloud credentials could reach an "Edit as YAML" view via the masthead toggle, but it always rendered blank since Norman API resources never expose the view link that the YAML editor relies on to fetch content. Rather than making that view work, YAML viewing/editing has been disabled entirely for cloud credentials (canYaml: false) to match pre-2.14 behavior. As a related fix, Cancel from that (now-removed) YAML view pointed at a non-existent route (c-cluster-manager-secret) and has been corrected to the actual cloud credential list route in case we want to implement it in the future; the "Show Configuration" drawer action, which had nothing valid to display for this type, is now hidden too.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Disabled 'View Configuration' for cloud credentials
- Added fallback behavior for other resources

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

CloudCredential.disableResourceDetailDrawer now returns true, since that resource has no custom detail component (so the drawer's Config tab can never render) and YAML is intentionally disallowed (so the YAML tab shouldn't either) — without this override, showConfigEnabled still evaluates true via canCustomEdit. ResourceDetail's masthead YAML-toggle visibility (canViewYaml) now also falls back to the loaded resource's own instance-level canYaml (hasLink('view')) when viewing/editing an existing resource, so any other Norman-backed type that forgets to set canYaml: false in its product config doesn't silently offer a YAML toggle that can only render blank; this intentionally doesn't apply during create/import, since a new unsaved resource never has links regardless of API family. The ResourceDetailDrawer's YAML tab (useDefaultYamlTabProps) now checks the same type-map canYaml option before fetching/rendering YAML, closing an equivalent gap in that separate surface.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Go to credential page -> click on action menu for any credential -> neither "Edit/View YAML" nor "Show Configuration" should appear
2. View and edit a plain core resource (e.g. ConfigMap or Secret) → YAML toggle should still appear and work, both directions (view→edit and edit→view)
3.  Create a new resource of a type that supports "Edit as YAML" during creation (e.g. new ConfigMap) → toggle must still work, since the fallback intentionally skips create/import
4. If any UI extension/plugin is installed with a custom resource model class, open its detail page → confirm the page loads without error (this is the scenario the try/catch was added to guard against) and that YAML shows/hides as expected for that type.
5. Open a resource that 404s/403s (e.g. delete something in another tab, then revisit its old URL) → confirm the in-context error page still renders correctly, unaffected.
6. Open "Show Configuration" from a list row for a few different resource types (not cloud credential) → both Config and YAML tabs should still appear/work as before.
7. Inside the drawer, switch between Config/YAML tabs and use the primary "Edit"/"Edit YAML" footer button → confirm it acts on the currently active tab correctly

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
These changes could affect all resources that shoul/shouldn't be viewed as yaml :
Additionally, not being able to check 'canYaml' hides YAML for reasons unrelated to actual YAML capability

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
