### PR TITLE
Automation: Fix Inspector tool batch anchor logic

### DIFF
--- a/.github/workflows/ci-failure-inspection.yaml
+++ b/.github/workflows/ci-failure-inspection.yaml
@@ -2,8 +2,8 @@ name: Jenkins CI Failure Inspection
 
 on:
   schedule:
-    # Runs Tue–Sat at 11:00 UTC (4:00 AM PST) — after all Jenkins jobs from the prior day complete
-    - cron: '0 11 * * 2-6'
+    # Runs Tue–Sat at 16:00 UTC (9:00 AM PST) — after all Jenkins jobs from the prior day complete
+    - cron: '0 16 * * 2-6'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/cypress/jenkins/inspector/README.md
+++ b/cypress/jenkins/inspector/README.md
@@ -35,7 +35,7 @@ Runs automatically **Tue–Sat at 4:00 AM PST** (11:00 UTC) via GitHub Actions, 
 | `UI_QA_SLACK_GROUP_ID` | Repo secret | Slack user group ID for `@ui-qa` mentions (e.g. `S01234ABC`) |
 | `INSPECTOR_GITHUB_PROJECT_NUMBER` | Repo variable | Project board number |
 | `INSPECTOR_BUILD_WINDOW` | Repo variable | Number of recent builds to scan for the batch anchor (default: `50`) |
-| `INSPECTOR_ANCHOR_DESCRIPTION` | Repo variable | Jenkins build description that marks the batch start (default: `head · community · @adminUser`) |
+| `INSPECTOR_ANCHOR_DESCRIPTION` | Repo variable | Jenkins build description that marks the batch start (default: `head · community · @adminUser`). Only the image tag and the Cypress tag prefix are matched — the build type field is ignored, since it is resolved at run time and reads `<kind> row` on a build that failed before resolution |
 | `INSPECTOR_SLACK_THRESHOLD` | Repo variable | Unique failure count above which a Slack alert is sent instead of creating issues (default: `10`). The alert breaks the failures down into ones with an open issue, ones whose issue would be reopened, and untracked ones |
 | `INSPECTOR_SLACK_NOTIFICATION` | Repo variable | Set to `false` to disable Slack alerts (default: `true`) |
 | `INSPECTOR_COPILOT_MODEL` | Repo variable | Copilot model used for AI fix suggestions (default: `gpt-5.6-luna`). Set this if the default model is retired — the model must support the `/responses` API |

--- a/cypress/jenkins/inspector/src/jenkins-client.js
+++ b/cypress/jenkins/inspector/src/jenkins-client.js
@@ -7,9 +7,9 @@
  *
  * How batch detection works:
  *   Jenkins runs multiple builds per day across different environments.
- *   A special "anchor" build (`head · community · @adminUser`) marks the
- *   start of each daily batch. This client finds the most recent anchor
- *   and collects all builds from that point forward as "today's batch".
+ *   A special "anchor" build (the `head` row running the `@adminUser` tag set)
+ *   marks the start of each daily batch. This client finds the most recent
+ *   anchor and collects all builds from that point forward as "today's batch".
  */
 
 import { fetchWithRetry } from './fetch-utils.js';
@@ -17,12 +17,28 @@ import { fetchWithRetry } from './fetch-utils.js';
 const JENKINS_BASE = process.env.JENKINS_BASE_URL || 'https://your-jenkins-instance';
 const JOB_PATH = process.env.JENKINS_JOB_PATH || 'rancher_qa/ui-automation-ansible-job';
 const ANCHOR_DESCRIPTION = process.env.INSPECTOR_ANCHOR_DESCRIPTION || 'head · community · @adminUser';
+
+// The description is "<image tag> · <build type> · <cypress tags>". Only the image tag
+// identifies the anchor row; the other two fields are no longer stable enough to
+// compare exactly:
+//   - the build type is resolved at run time, so it reads `community` or `prime` once
+//     the playbook has asked the deployed Rancher, but stays `<kind> row` on a build
+//     that failed before that point — which is exactly when the anchor must be found;
+//   - the tag set carries the full Cypress expression, e.g.
+//     `@adminUser+-@prime+-@noVai`, so it is matched by prefix.
+const [ANCHOR_VERSION, , ANCHOR_TAGS = ''] = ANCHOR_DESCRIPTION.split(' · ').map((p) => p.trim());
 const ANCHOR_MAX_AGE_MS = 36 * 60 * 60 * 1000; // 36 hours
 const VERSION_FILTER = process.env.INSPECTOR_VERSION_FILTER || null; // e.g. "head" to only process head builds
 
 // Converts "rancher_qa/ui-automation-ansible-job" → "/job/rancher_qa/job/ui-automation-ansible-job"
 function toJobUrl(jobPath) {
   return jobPath.split('/').map((p) => `job/${ p }`).join('/');
+}
+
+function isAnchor(description) {
+  const parts = (description || '').split(' · ').map((p) => p.trim());
+
+  return parts.length >= 3 && parts[0] === ANCHOR_VERSION && parts[2].startsWith(ANCHOR_TAGS);
 }
 
 export class JenkinsClient {
@@ -59,11 +75,11 @@ export class JenkinsClient {
     );
 
     const builds = data.builds;
-    const anchorIdx = builds.findIndex((b) => b.description === ANCHOR_DESCRIPTION);
+    const anchorIdx = builds.findIndex((b) => isAnchor(b.description));
 
     if (anchorIdx === -1) {
       throw new Error(
-        `Could not find batch anchor ("${ ANCHOR_DESCRIPTION }") in the last ${ window } builds. ` +
+        `Could not find batch anchor ("${ ANCHOR_VERSION } · … · ${ ANCHOR_TAGS }…") in the last ${ window } builds. ` +
         `If the job runs frequently, increase INSPECTOR_BUILD_WINDOW. ` +
         `If the description format changed, update INSPECTOR_ANCHOR_DESCRIPTION.`
       );


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2541

- Matches the anchor on the image tag and Cypress tag prefix, ignoring the build type. Build type is now resolved at run time.
- Moves the inspection to 16:00 UTC, since the Jenkins nightly finishes ~12:45 UTC and the old 11:00 UTC run fired mid-batch.

<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested

Verified against the live Jenkins API via `workflow_dispatch`, both dry run and [real run](https://github.com/rancher/dashboard/actions/runs/34512777008/job/102990754186) in production.

<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
