### PR TITLE
Removed Ingress option for community

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2709,6 +2709,7 @@ cluster:
     enableIngress: Install Ingress controller to enable external routing
     nginx:
       header: Ingress-NGINX
+      contentCommunity: This option is only available in SUSE Rancher Prime.
       content: Choose this only if your workloads are not yet ready for Traefik.
     dual:
       header: Dual Mode

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
@@ -8,6 +8,10 @@ import { RKE2_INGRESS_NGINX, RKE2_TRAEFIK } from '@shell/edit/provisioning.cattl
 // Payload of the component's `cilium-values-changed` event.
 type CiliumValues = { bandwidthManager: { enabled: boolean, test?: boolean } };
 
+const mockGetVersionData = jest.fn(() => ({ RancherPrime: 'false' }));
+
+jest.mock('@shell/config/version', () => ({ getVersionData: () => mockGetVersionData() }));
+
 const defaultStubs = {
   Banner:          true,
   LabeledSelect:   true,
@@ -436,6 +440,92 @@ describe('component: Basics', () => {
       const expected = '{"bandwidthManager":{"test":true,"enabled":true}}';
 
       expect(JSON.stringify(latest)).toStrictEqual(expected);
+    });
+  });
+
+  describe('kubernetesVersionOptions', () => {
+    const versionOptionsWithV136 = [
+      {
+        id: 'v1.37.0+rke2r1', value: 'v1.37.0+rke2r1', label: 'v1.37.0+rke2r1', serverArgs: mockServerArgs
+      },
+      {
+        id: 'v1.36.0+rke2r1', value: 'v1.36.0+rke2r1', label: 'v1.36.0+rke2r1', serverArgs: mockServerArgs
+      },
+      {
+        id: 'v1.35.0+rke2r1', value: 'v1.35.0+rke2r1', label: 'v1.35.0+rke2r1', serverArgs: mockServerArgs
+      },
+      { kind: 'group', label: 'RKE2' }
+    ];
+
+    function mountBasics(ingressController: string | string[], versionOptions = versionOptionsWithV136) {
+      return mount(Basics, {
+        props: {
+          mode:  'create',
+          value: {
+            spec: {
+              ...defaultSpec,
+              rkeConfig:         { ...defaultSpec.rkeConfig, machineGlobalConfig: { cni: 'calico', 'ingress-controller': ingressController } },
+              kubernetesVersion: 'v1.35.0+rke2r1'
+            },
+            agentConfig: { 'cloud-provider-name': '' },
+          },
+          provider:                    'custom',
+          userChartValues:             {},
+          addonVersions:               [],
+          versionInfo:                 {},
+          cisOverride:                 false,
+          cisPsaChangeBanner:          true,
+          allPsas:                     [],
+          selectedVersion:             versionOptions[0],
+          versionOptions,
+          isHarvesterDriver:           false,
+          isHarvesterIncompatible:     false,
+          showDeprecatedPatchVersions: false,
+          isElementalCluster:          false,
+          hasPsaTemplates:             false,
+          haveArgInfo:                 false,
+          showCni:                     true,
+          showCloudProvider:           false,
+          unsupportedCloudProvider:    false,
+          cloudProviderOptions:        [{ label: 'Default - RKE2 Embedded', value: '' }],
+          isAzureProviderUnsupported:  false,
+          canAzureMigrateOnEdit:       false,
+          complianceOverride:          false,
+        },
+
+        global: {
+          mocks: {
+            ...defaultMocks,
+            $store: { getters: defaultGetters },
+          },
+          stubs: defaultStubs,
+        },
+      });
+    }
+
+    // eslint-disable-next-line jest/no-hooks
+    afterEach(() => {
+      mockGetVersionData.mockReturnValue({ RancherPrime: 'false' });
+    });
+
+    it('does not disable any versions or show a restriction banner when a prime instance is using traefik ingress', () => {
+      mockGetVersionData.mockReturnValue({ RancherPrime: 'true' });
+
+      const wrapper = mountBasics('traefik');
+      const options = (wrapper.vm as unknown as any).kubernetesVersionOptions;
+
+      expect(options.every((o: any) => !o.disabled)).toBe(true);
+      expect(wrapper.find('[data-testid="clusterBasics__ingressVersionRestrictedBanner"]').exists()).toBe(false);
+    });
+
+    it('does not disable any versions or show a restriction banner when a non-prime instance is using nginx ingress', () => {
+      mockGetVersionData.mockReturnValue({ RancherPrime: 'false' });
+
+      const wrapper = mountBasics('ingress-nginx');
+      const options = (wrapper.vm as unknown as any).kubernetesVersionOptions;
+
+      expect(options.every((o: any) => !o.disabled)).toBe(true);
+      expect(wrapper.find('[data-testid="clusterBasics__ingressVersionRestrictedBanner"]').exists()).toBe(false);
     });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
@@ -1,6 +1,7 @@
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Basics from '@shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue';
+import Ingress from '@shell/edit/provisioning.cattle.io.cluster/ingress/index.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 // import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import { RKE2_INGRESS_NGINX, RKE2_TRAEFIK } from '@shell/edit/provisioning.cattle.io.cluster/shared';
@@ -443,29 +444,23 @@ describe('component: Basics', () => {
     });
   });
 
-  describe('kubernetesVersionOptions', () => {
-    const versionOptionsWithV136 = [
-      {
-        id: 'v1.37.0+rke2r1', value: 'v1.37.0+rke2r1', label: 'v1.37.0+rke2r1', serverArgs: mockServerArgs
-      },
-      {
-        id: 'v1.36.0+rke2r1', value: 'v1.36.0+rke2r1', label: 'v1.36.0+rke2r1', serverArgs: mockServerArgs
-      },
-      {
-        id: 'v1.35.0+rke2r1', value: 'v1.35.0+rke2r1', label: 'v1.35.0+rke2r1', serverArgs: mockServerArgs
-      },
-      { kind: 'group', label: 'RKE2' }
-    ];
+  describe('ingress', () => {
+    function mountBasics(ingressController: string | string[], kubernetesVersion = 'v1.35.0+rke2r1') {
+      const versionOptions = [
+        {
+          id: kubernetesVersion, value: kubernetesVersion, label: kubernetesVersion, serverArgs: mockServerArgs
+        },
+        { kind: 'group', label: 'RKE2' }
+      ];
 
-    function mountBasics(ingressController: string | string[], versionOptions = versionOptionsWithV136) {
       return mount(Basics, {
         props: {
           mode:  'create',
           value: {
             spec: {
               ...defaultSpec,
-              rkeConfig:         { ...defaultSpec.rkeConfig, machineGlobalConfig: { cni: 'calico', 'ingress-controller': ingressController } },
-              kubernetesVersion: 'v1.35.0+rke2r1'
+              rkeConfig: { ...defaultSpec.rkeConfig, machineGlobalConfig: { cni: 'calico', 'ingress-controller': ingressController } },
+              kubernetesVersion
             },
             agentConfig: { 'cloud-provider-name': '' },
           },
@@ -503,29 +498,12 @@ describe('component: Basics', () => {
       });
     }
 
-    // eslint-disable-next-line jest/no-hooks
-    afterEach(() => {
-      mockGetVersionData.mockReturnValue({ RancherPrime: 'false' });
-    });
+    it('forwards the selected kubernetes version to the Ingress component', () => {
+      const wrapper = mountBasics('traefik', 'v1.37.0+rke2r1');
+      const ingress = wrapper.findComponent(Ingress);
 
-    it('does not disable any versions or show a restriction banner when a prime instance is using traefik ingress', () => {
-      mockGetVersionData.mockReturnValue({ RancherPrime: 'true' });
-
-      const wrapper = mountBasics('traefik');
-      const options = (wrapper.vm as unknown as any).kubernetesVersionOptions;
-
-      expect(options.every((o: any) => !o.disabled)).toBe(true);
-      expect(wrapper.find('[data-testid="clusterBasics__ingressVersionRestrictedBanner"]').exists()).toBe(false);
-    });
-
-    it('does not disable any versions or show a restriction banner when a non-prime instance is using nginx ingress', () => {
-      mockGetVersionData.mockReturnValue({ RancherPrime: 'false' });
-
-      const wrapper = mountBasics('ingress-nginx');
-      const options = (wrapper.vm as unknown as any).kubernetesVersionOptions;
-
-      expect(options.every((o: any) => !o.disabled)).toBe(true);
-      expect(wrapper.find('[data-testid="clusterBasics__ingressVersionRestrictedBanner"]').exists()).toBe(false);
+      expect(ingress.exists()).toBe(true);
+      expect(ingress.props('kubernetesVersion')).toBe('v1.37.0+rke2r1');
     });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts
@@ -1,7 +1,11 @@
 import { mount } from '@vue/test-utils';
-import Ingress from '@shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue';
-import { _EDIT } from '@shell/config/query-params';
+import Ingress from '@shell/edit/provisioning.cattle.io.cluster/ingress/index.vue';
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { INGRESS_DUAL, TRAEFIK, INGRESS_NGINX, INGRESS_NONE } from '@shell/edit/provisioning.cattle.io.cluster/shared';
+
+const mockGetVersionData = jest.fn(() => ({ RancherPrime: 'false' }));
+
+jest.mock('@shell/config/version', () => ({ getVersionData: () => mockGetVersionData() }));
 
 jest.mock('vuex', () => ({
   useStore:   () => ({ getters: { 'i18n/t': (key: string) => key } }),
@@ -45,12 +49,15 @@ jest.mock('@shell/edit/provisioning.cattle.io.cluster/shared', () => ({
     doc:       { url: 'https://docs.rke2.io/networking/networking_services?_highlight=ingress#ingress-controller' }
   },
   {
-    id:        'ingress-nginx',
-    image:     { src: '', alt: 'NGINX' },
-    header:    { title: { key: 'cluster.ingress.nginx.header' } },
-    subHeader: { label: { key: 'cluster.ingress.legacy' } },
-    content:   { key: 'cluster.ingress.nginx.content' },
-    doc:       { url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' }
+    id:         'ingress-nginx',
+    image:      { src: '', alt: 'NGINX' },
+    header:     { title: { key: 'cluster.ingress.nginx.header' } },
+    subHeader:  { label: { key: 'cluster.ingress.legacy' } },
+    newContent: { key: 'cluster.ingress.nginx.contentCommunity' },
+    oldContent: { key: 'cluster.ingress.nginx.content' },
+    newDoc:     { url: 'https://www.suse.com/c/trade-the-ingress-nginx-retirement-for-up-to-2-years-of-rke2-support-stability/' },
+    oldDoc:     { url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' },
+    prime:      true
   },
   {
     id:        'dual',
@@ -355,6 +362,60 @@ describe('ingress.vue', () => {
       const emitted = wrapper.emitted('update-values');
 
       expect(emitted).toBeFalsy();
+    });
+  });
+
+  describe('ingress-nginx prime-only restriction', () => {
+    // eslint-disable-next-line jest/no-hooks
+    afterEach(() => {
+      mockGetVersionData.mockReturnValue({ RancherPrime: 'false' });
+    });
+
+    const nginxOption = (props = {}) => {
+      const wrapper = createWrapper({ value: TRAEFIK, ...props });
+      const options = wrapper.findComponent({ name: 'IngressCards' }).props('options') as any[];
+
+      return options.find((o) => o.id === INGRESS_NGINX);
+    };
+
+    it('disables the nginx card and shows community content/doc on a non-prime instance creating a cluster with k8s >= v1.37.0', () => {
+      const nginx = nginxOption({ mode: _CREATE, kubernetesVersion: 'v1.37.0+rke2r1' });
+
+      expect(nginx.disabled).toBe(true);
+      expect(nginx.content).toStrictEqual({ key: 'cluster.ingress.nginx.contentCommunity' });
+      expect(nginx.doc).toStrictEqual({ url: 'https://www.suse.com/c/trade-the-ingress-nginx-retirement-for-up-to-2-years-of-rke2-support-stability/' });
+    });
+
+    it('leaves the nginx card enabled with the default content/doc when k8s is below v1.37.0', () => {
+      const nginx = nginxOption({ mode: _CREATE, kubernetesVersion: 'v1.36.0+rke2r1' });
+
+      expect(nginx.disabled).toBe(false);
+      expect(nginx.content).toStrictEqual({ key: 'cluster.ingress.nginx.content' });
+      expect(nginx.doc).toStrictEqual({ url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' });
+    });
+
+    it('leaves the nginx card enabled with the default content/doc on a prime instance even when k8s is >= v1.37.0', () => {
+      mockGetVersionData.mockReturnValue({ RancherPrime: 'true' });
+
+      const nginx = nginxOption({ mode: _CREATE, kubernetesVersion: 'v1.37.0+rke2r1' });
+
+      expect(nginx.disabled).toBe(false);
+      expect(nginx.content).toStrictEqual({ key: 'cluster.ingress.nginx.content' });
+      expect(nginx.doc).toStrictEqual({ url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' });
+    });
+
+    it('does not apply the restriction outside of create mode', () => {
+      const nginx = nginxOption({ mode: _EDIT, kubernetesVersion: 'v1.37.0+rke2r1' });
+
+      expect(nginx.disabled).toBe(false);
+      expect(nginx.content).toStrictEqual({ key: 'cluster.ingress.nginx.content' });
+    });
+
+    it('disables every card in view mode', () => {
+      const wrapper = createWrapper({ value: TRAEFIK, mode: _VIEW });
+      const options = wrapper.findComponent({ name: 'IngressCards' }).props('options') as any[];
+
+      expect(options.every((o) => o.disabled)).toBe(true);
     });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { _CREATE } from '@shell/config/query-params';
 import { PropType } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
@@ -13,6 +13,7 @@ interface IngressCard {
   content: { key: string };
   doc?: {url: string};
   selected?: boolean;
+  disabled?: boolean;
 }
 
 defineProps({
@@ -20,7 +21,7 @@ defineProps({
     type:     Array as PropType<IngressCard[]>,
     required: true
   },
-  mode: { type: String, default: _CREATE },
+  mode: { type: String, default: _CREATE }
 });
 
 const emit = defineEmits(['select']);
@@ -42,9 +43,9 @@ const { t } = useI18n(store);
       :selected="card.selected"
       variant="small"
       role="link"
-      :disabled="mode === _VIEW"
+      :disabled="card.disabled"
       :class="{ 'single-card': options.length === 1 }"
-      :clickable="mode !== _VIEW"
+      :clickable="!card.disabled"
       @card-click="emit('select', card.id)"
     >
       <template

--- a/shell/edit/provisioning.cattle.io.cluster/ingress/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/ingress/index.vue
@@ -15,6 +15,7 @@ import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 import { set, get, mergeWithReplace } from '@shell/utils/object';
 import { saferDump } from '@shell/utils/create-yaml';
 import RichTranslation from '@shell/components/RichTranslation.vue';
+import { getVersionData } from '@shell/config/version';
 
 interface Props {
   mode?: string;
@@ -26,6 +27,7 @@ interface Props {
   userChartValues: any;
   versionInfo: any;
   originalIngressController?: string | string[];
+  kubernetesVersion?: string;
 }
 const {
   mode = _CREATE,
@@ -36,7 +38,8 @@ const {
   traefikSupported,
   userChartValues,
   versionInfo,
-  originalIngressController = INGRESS_NONE
+  originalIngressController = INGRESS_NONE,
+  kubernetesVersion
 } = defineProps<Props>();
 
 const emit = defineEmits(['update:value', 'error', 'config-validation-changed', 'yaml-validation-changed', 'update-values']);
@@ -48,10 +51,14 @@ const traefikYaml = useTemplateRef('traefik-yaml');
 const showAdvanced = ref<Boolean>(false);
 const isView = computed(() => mode === _VIEW);
 const isEdit = computed(() => mode === _EDIT);
+const isCreate = computed(() => mode === _CREATE);
 const showTraefikBanner = ref<Boolean>(false);
 const traefikMerged = ref(initYamlEditor(traefikChart));
 const nginxMerged = ref(initYamlEditor(nginxChart));
 const showConfig = computed(() => !!versionInfo[traefikChart] || !!versionInfo[nginxChart]);
+const isPrime = ref( getVersionData().RancherPrime === 'true');
+const isIngressDisableVersion = computed(() => isCreate.value && !!kubernetesVersion && semver.gte(kubernetesVersion, 'v1.37.0'));
+const showTransitioningBanner = computed(() => traefikSupported && (!isIngressDisableVersion.value || !!isPrime.value));
 
 // in traefik v40 the nginx key changed from kubernetesIngressNginx to kubernetesIngressNGINX
 const traefikNginxKey = computed(() => {
@@ -114,9 +121,14 @@ const ingressOptions = computed(() => {
 
     return true;
   }).map((option) => {
+    const primeOnlyDisabled = !isPrime.value && !!option.prime && isIngressDisableVersion.value;
+
     return {
       ...option,
-      selected: option.id === ingressSelection.value
+      content:  primeOnlyDisabled && option.newContent ? option.newContent : (option.oldContent || option.content),
+      doc:      primeOnlyDisabled && option.newDoc ? option.newDoc : (option.oldDoc || option.doc),
+      selected: option.id === ingressSelection.value,
+      disabled: mode === _VIEW || primeOnlyDisabled
     };
   });
 });
@@ -257,14 +269,15 @@ function updateYaml(component: any, value: any) {
   </div>
   <div v-else>
     <Banner
-      v-if="traefikSupported"
+      v-if="showTransitioningBanner"
       color="info"
       label-key="cluster.ingress.banners.transitioning.label"
     />
     <IngressCards
       :options="ingressOptions"
       :mode="mode"
-      :class="!traefikSupported ? 'mt-10' : ''"
+      :class="!showTransitioningBanner ? 'mt-10' : ''"
+      :is-prime="isPrime"
       @select="selectIngress"
     />
     <Banner

--- a/shell/edit/provisioning.cattle.io.cluster/shared.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/shared.ts
@@ -19,12 +19,15 @@ export const INGRESS_OPTIONS = [
     doc:       { url: 'https://docs.rke2.io/networking/networking_services?_highlight=ingress#ingress-controller' }
   },
   {
-    id:        INGRESS_NGINX,
-    image:     { src: requireAsset('@shell/assets/images/providers/kubernetes.svg'), alt: 'NGINX' },
-    header:    { title: { key: 'cluster.ingress.nginx.header' } },
-    subHeader: { label: { key: 'cluster.ingress.legacy' } },
-    content:   { key: 'cluster.ingress.nginx.content' },
-    doc:       { url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' }
+    id:         INGRESS_NGINX,
+    image:      { src: requireAsset('@shell/assets/images/providers/kubernetes.svg'), alt: 'NGINX' },
+    header:     { title: { key: 'cluster.ingress.nginx.header' } },
+    subHeader:  { label: { key: 'cluster.ingress.legacy' } },
+    newContent: { key: 'cluster.ingress.nginx.contentCommunity' },
+    oldContent: { key: 'cluster.ingress.nginx.content' },
+    newDoc:     { url: 'https://www.suse.com/c/trade-the-ingress-nginx-retirement-for-up-to-2-years-of-rke2-support-stability/' },
+    oldDoc:     { url: 'https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/' },
+    prime:      true
   },
   {
     id:        INGRESS_DUAL,

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -8,7 +8,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import YamlEditor from '@shell/components/YamlEditor';
 import semver from 'semver';
-import Ingress from '@shell/edit/provisioning.cattle.io.cluster/tabs/Ingress';
+import Ingress from '@shell/edit/provisioning.cattle.io.cluster/ingress/index';
 import {
   HARVESTER, RKE2_INGRESS_NGINX, RKE2_TRAEFIK, INGRESS_CONTROLLER, INGRESS_NGINX, INGRESS_NONE
 } from '@shell/edit/provisioning.cattle.io.cluster/shared';
@@ -642,6 +642,7 @@ export default {
       :user-chart-values="userChartValues"
       :version-info="versionInfo"
       :original-ingress-controller="originalIngressController"
+      :kubernetes-version="value.spec.kubernetesVersion"
       @update-values="(name, val) => $emit('update-values', name, val)"
       @error="$emit('error', $event)"
       @yaml-validation-changed="e => $emit('yaml-validation-changed', e)"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17340 
<!-- Define findings related to the feature or bug issue. -->
Disabled the ingress card when provisioning new clusters with k8s 1.37+ on community Rancher.
 
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Updated the text and the doc link for Ingress nginx , removed the 'Rancher is transitioning to Traefik as the default provider. While Ingress-NGINX remains available for migration purposes, we recommend moving workloads to Traefik to ensure long-term compatibility and support.' banner for Community Rancher when provisioning clusters with k8s 1.37+

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
On community:
1. When provisioning a new RKE2 cluster with k8s version 1.36 and below, there should be no changes
2. When provisioning a new RKE2 cluster with k8s version 1.37 and above, NGINX card should be disabled, text and doc link should be updated. 'Rancher is transitioning to Traefik as the default provider. While Ingress-NGINX remains available for migration purposes, we recommend moving workloads to Traefik to ensure long-term compatibility and support.' banner should be removed
3. There should be no changes tot he editing behavior
On prime:
Validate that provisioning and editing behavior hasn't changed

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
This is very self contained and other areas should not be affected. prime installations could be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1829" height="767" alt="Screenshot 2026-09-10 at 3 50 48 PM" src="https://github.com/user-attachments/assets/769cc13c-b58a-44eb-bdb2-e30cdeb8aeba" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
