### PR TITLE
Show why Create is disabled on duplicate node group names

### DIFF
--- a/pkg/aks/types/index.ts
+++ b/pkg/aks/types/index.ts
@@ -28,6 +28,7 @@ export interface AKSNodePool {
   _id?: string
   _validation: {
     _validName?: boolean
+    _validUnique?: boolean
     _validSize?: boolean
     _validAZ?: boolean
     _validCount?: boolean

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -153,6 +153,16 @@ describe('fx: nodePoolNamesUnique', () => {
     expect(ctx.nodePools.map((pool) => pool?._validation?._validUnique)).toStrictEqual([false, false, true]);
   });
 
+  it('does not treat pools that have no name as duplicates of each other', () => {
+    const ctx = {
+      ...mockCtx,
+      nodePools: [{ name: '', _validation: {} }, { name: '', _validation: {} }, { name: 'abc', _validation: {} }] as unknown as AKSNodePool[]
+    };
+
+    expect(validators.nodePoolNamesUnique(ctx)()).toBeUndefined();
+    expect(ctx.nodePools.map((pool) => pool?._validation?._validUnique)).toStrictEqual([true, true, true]);
+  });
+
   it('clears the flag once a duplicate name is corrected', () => {
     const ctx = {
       ...mockCtx,

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -142,6 +142,31 @@ describe('fx: nodePoolNames', () => {
   });
 });
 
+describe('fx: nodePoolNamesUnique', () => {
+  it('returns an error and flags only the pools sharing a name', () => {
+    const ctx = {
+      ...mockCtx,
+      nodePools: [{ name: 'abc', _validation: {} }, { name: 'abc', _validation: {} }, { name: 'def', _validation: {} }] as unknown as AKSNodePool[]
+    };
+
+    expect(validators.nodePoolNamesUnique(ctx)()).toStrictEqual(MOCK_TRANSLATION);
+    expect(ctx.nodePools.map((pool) => pool?._validation?._validUnique)).toStrictEqual([false, false, true]);
+  });
+
+  it('clears the flag once a duplicate name is corrected', () => {
+    const ctx = {
+      ...mockCtx,
+      nodePools: [{ name: 'abc', _validation: {} }, { name: 'abc', _validation: {} }] as unknown as AKSNodePool[]
+    };
+
+    validators.nodePoolNamesUnique(ctx)();
+    ctx.nodePools[1].name = 'def';
+
+    expect(validators.nodePoolNamesUnique(ctx)()).toBeUndefined();
+    expect(ctx.nodePools.map((pool) => pool?._validation?._validUnique)).toStrictEqual([true, true]);
+  });
+});
+
 describe('fx: nodePoolCount', () => {
   // AksNodePool unit tests check that the second arg is passed in as expected
   it('validates that count is at least 1 and at most 1000 when second arg is false', () => {

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -175,7 +175,7 @@ export const nodePoolNamesUnique = (ctx: any) => {
     let hasDuplicates = false;
 
     pools.forEach((pool: AKSNodePool) => {
-      const isUnique = poolNames.filter((name: string) => name === pool.name).length === 1;
+      const isUnique = !pool.name || poolNames.filter((name: string) => name === pool.name).length === 1;
 
       set(pool._validation, '_validUnique', isUnique);
       hasDuplicates = hasDuplicates || !isUnique;

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -168,10 +168,18 @@ export const nodePoolNames = (ctx: any) => {
 };
 
 export const nodePoolNamesUnique = (ctx: any) => {
+  // Flags each colliding pool the way nodePoolNames does, so its tab shows an error icon.
   return () :string | undefined => {
-    const poolNames = (ctx.nodePools || []).map((pool: AKSNodePool) => pool.name);
+    const pools = ctx.nodePools || [];
+    const poolNames = pools.map((pool: AKSNodePool) => pool.name);
+    let hasDuplicates = false;
 
-    const hasDuplicates = poolNames.some((name: string, idx: number) => poolNames.indexOf(name) !== idx);
+    pools.forEach((pool: AKSNodePool) => {
+      const isUnique = poolNames.filter((name: string) => name === pool.name).length === 1;
+
+      set(pool._validation, '_validUnique', isUnique);
+      hasDuplicates = hasDuplicates || !isUnique;
+    });
 
     if (hasDuplicates) {
       return ctx.t('aks.errors.poolNamesUnique');

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -238,8 +238,11 @@ export default defineComponent({
       },
       {
         path:  'nodegroupNames',
-        rules: ['nodeGroupNamesRequired', 'nodeGroupNamesUnique']
-
+        rules: ['nodeGroupNamesRequired']
+      },
+      {
+        path:  'nodeGroupNamesUnique',
+        rules: ['nodeGroupNamesUnique']
       },
       {
         path:  'maxSize',
@@ -757,6 +760,7 @@ export default defineComponent({
             :weight="-1 * i"
             :label="node.nodegroupName || t('eks.nodeGroups.unnamed')"
             :name="`${node.nodegroupName} ${i}`"
+            :error="node.__nameUnique === false"
           >
             <NodeGroup
               v-model:node-role="node.nodeRole"

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -760,7 +760,7 @@ export default defineComponent({
             :weight="-1 * i"
             :label="node.nodegroupName || t('eks.nodeGroups.unnamed')"
             :name="`${node.nodegroupName} ${i}`"
-            :error="node.__nameUnique === false"
+            :error="node.__nameUnique === false || node.__nameRequired === false"
           >
             <NodeGroup
               v-model:node-role="node.nodeRole"

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -57,6 +57,16 @@ const requiredSetup = (versionSetting = { value: '<=1.27.x' }) => {
   };
 };
 
+// Tabbed is stubbed by shallow mounting and a stub renders no default slot, so read the Tabs it
+// was given out of its slot vnodes; the first slot entry is the node group v-for fragment
+const nodeGroupTabErrors = (wrapper: VueWrapper<any>) => {
+  const tabbed = wrapper.findComponent({ name: 'Tabbed' });
+
+  const [nodeGroupTabs] = tabbed.vm.$slots.default();
+
+  return nodeGroupTabs.children.map((tab: any) => tab.props.error);
+};
+
 const setCredential = async(wrapper: VueWrapper<any>, config = {} as EKSConfig) => {
   wrapper.setData({ config });
   wrapper.vm.updateCredential('foo');
@@ -211,6 +221,29 @@ describe('eKS provisioning form', () => {
 
     expect(wrapper.vm.fvFormIsValid).toBe(false);
     expect(wrapper.vm.fvUnreportedValidationErrors).toStrictEqual(['eks.errors.nodeGroupsRequired']);
+  });
+
+  it('should show a form-level error and mark the offending tabs when two node groups share a name', async() => {
+    const wrapper = mount(CruEKS, {
+      props:   { value: {}, mode: 'create' },
+      ...requiredSetup(),
+      shallow: true,
+    });
+
+    // see above - DEFAULT_EKS_CONFIG does not satisfy EKSConfig
+    await setCredential(wrapper, { ...DEFAULT_EKS_CONFIG } as unknown as EKSConfig);
+    wrapper.setData({ nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }] });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.fvUnreportedValidationErrors).toContain('eks.errors.nodeGroups.nameUnique');
+    expect(wrapper.vm.fvFormIsValid).toBe(false);
+    expect(nodeGroupTabErrors(wrapper)).toStrictEqual([true, true, false]);
+
+    wrapper.vm.nodeGroups[1].nodegroupName = 'ghi';
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.fvUnreportedValidationErrors).not.toContain('eks.errors.nodeGroups.nameUnique');
+    expect(nodeGroupTabErrors(wrapper)).toStrictEqual([false, false, false]);
   });
 
   it('should NOT show an error nor prevent saving if no node groups are defined in an IMPORTED cluster', async() => {

--- a/pkg/eks/types/index.d.ts
+++ b/pkg/eks/types/index.d.ts
@@ -36,6 +36,7 @@ export interface EKSNodeGroup {
   version?: string
   arm?: boolean
   __nameUnique?: boolean
+  __nameRequired?: boolean
   _isNew?: boolean,
   _isUpgrading?: boolean
 }

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -68,34 +68,47 @@ describe('validate EKS node group names', () => {
     [{
       nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
       t:          mockTranslation,
-    } as any as CruEKSContext, 'abc', null],
-    [{
-      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:          mockTranslation,
-    } as any as CruEKSContext, 'abc', 'eks.errors.nodeGroups.nameUnique'],
-    [{
-      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:          mockTranslation,
-    } as any as CruEKSContext, 'def', null],
-  ])('should return an error if the node group name passed in is not unique within ctx', (ctx, nodeGroupName, expected) => {
-    const res = EKSValidators.nodeGroupNamesUnique(ctx)(nodeGroupName);
-
-    expect(res).toBe(expected);
-  });
-
-  it.each([
-    [{
-      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:          mockTranslation,
     } as any as CruEKSContext, null],
     [{
       nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
       t:          mockTranslation,
-    } as any as CruEKSContext, 'eks.errors.nodeGroups.nameUnique']
-  ])('should return an error if any node group within ctx has non-unique name, if not passed a name', (ctx, expected) => {
-    const res = EKSValidators.nodeGroupNamesUnique(ctx)(undefined);
+    } as any as CruEKSContext, 'eks.errors.nodeGroups.nameUnique'],
+    [{
+      nodeGroups: [{ nodegroupName: '' }, { nodegroupName: '' }],
+      t:          mockTranslation,
+    } as any as CruEKSContext, null],
+    [{
+      nodeGroups: [],
+      t:          mockTranslation,
+    } as any as CruEKSContext, null]
+  ])('should return an error if any node group within ctx has a non-unique name, ignoring unnamed groups', (ctx, expected) => {
+    const res = EKSValidators.nodeGroupNamesUnique(ctx)();
 
     expect(res).toBe(expected);
+  });
+
+  it('should flag only the node groups sharing a name', () => {
+    const ctx = {
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
+    } as any as CruEKSContext;
+
+    EKSValidators.nodeGroupNamesUnique(ctx)();
+
+    expect(ctx.nodeGroups.map((group) => group.__nameUnique)).toStrictEqual([false, false, undefined]);
+  });
+
+  it('should clear the flag once a duplicate name is corrected', () => {
+    const ctx = {
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }],
+      t:          mockTranslation,
+    } as any as CruEKSContext;
+
+    EKSValidators.nodeGroupNamesUnique(ctx)();
+    ctx.nodeGroups[1].nodegroupName = 'def';
+
+    expect(EKSValidators.nodeGroupNamesUnique(ctx)()).toBeNull();
+    expect(ctx.nodeGroups.every((group) => group.__nameUnique === undefined)).toBe(true);
   });
 });
 

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -49,6 +49,30 @@ describe('validate EKS node group names', () => {
     expect(res).toBeDefined();
   });
 
+  it('should flag only the node groups that have no name', () => {
+    const ctx = {
+      nodeGroups: [{ nodegroupName: '' }, { nodegroupName: 'abc' }],
+      t:          mockTranslation,
+    } as any as CruEKSContext;
+
+    EKSValidators.nodeGroupNamesRequired(ctx)(undefined);
+
+    expect(ctx.nodeGroups.map((group) => group.__nameRequired)).toStrictEqual([false, undefined]);
+  });
+
+  it('should clear the flag once a node group is named', () => {
+    const ctx = {
+      nodeGroups: [{ nodegroupName: '' }],
+      t:          mockTranslation,
+    } as any as CruEKSContext;
+
+    EKSValidators.nodeGroupNamesRequired(ctx)(undefined);
+    ctx.nodeGroups[0].nodegroupName = 'abc';
+
+    expect(EKSValidators.nodeGroupNamesRequired(ctx)(undefined)).toBeNull();
+    expect(ctx.nodeGroups[0].__nameRequired).toBeUndefined();
+  });
+
   it.each([
     [{
       nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -1,4 +1,3 @@
-import { set } from '@shell/utils/object';
 import { EKSConfig, EKSNodeGroup, NormanCluster } from '@pkg/eks/types';
 
 export interface CruEKSContext {
@@ -30,25 +29,27 @@ const nodeGroupNamesRequired = (ctx: CruEKSContext) => {
   };
 };
 
+/**
+ * Compares node groups against each other rather than validating one field, so it is not passed to
+ * fvGetAndReportPathRules and its message appears as a banner at the top of the form instead.
+ * Unnamed node groups are left to nodeGroupNamesRequired. Colliding node groups are marked with
+ * `__nameUnique` so the tab component can flag them; the mark is removed rather than set true,
+ * because node groups are sent to the API as they are.
+ */
 const nodeGroupNamesUnique = (ctx: CruEKSContext) => {
-  return (nodeName: string | undefined): null | string => {
+  return (): null | string => {
     let out = null as null|string;
 
-    const names = ctx.nodeGroups.map((node) => node.nodegroupName);
+    const names = ctx.nodeGroups.map((node) => node.nodegroupName).filter((name) => !!name);
 
-    if (nodeName !== undefined) {
-      const matchingNames = names.filter((n) => n === nodeName);
-
-      return matchingNames.length > 1 ? ctx.t('eks.errors.nodeGroups.nameUnique') : null;
-    }
     ctx.nodeGroups.forEach((group) => {
-      const name = group.nodegroupName;
-
-      if (names.filter((n) => n === name).length > 1) {
-        set(group, '__nameUnique', false);
+      if (names.filter((name) => name === group.nodegroupName).length > 1) {
+        group.__nameUnique = false;
         if (!out) {
           out = ctx.t('eks.errors.nodeGroups.nameUnique');
         }
+      } else {
+        delete group.__nameUnique;
       }
     });
 

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -19,13 +19,31 @@ const clusterNameRequired = (ctx: CruEKSContext) => {
   };
 };
 
+/**
+ * Validates one name when given it, and every node group when not. The message stays on the name
+ * input either way; the context-wide arm marks unnamed node groups with `__nameRequired` so their
+ * tab is flagged, which is the only sign an unnamed node group gives on a tab the user is not on.
+ */
 const nodeGroupNamesRequired = (ctx: CruEKSContext) => {
   return (nodeName: string | undefined): null | string => {
+    const msg = ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') });
+
     if (nodeName !== undefined) {
-      return nodeName === '' ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') }) : null;
+      return nodeName === '' ? msg : null;
     }
 
-    return !!ctx.nodeGroups.find((group) => !group.nodegroupName) ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') }) : null;
+    let out = null as null|string;
+
+    ctx.nodeGroups.forEach((group) => {
+      if (group.nodegroupName) {
+        delete group.__nameRequired;
+      } else {
+        group.__nameRequired = false;
+        out = msg;
+      }
+    });
+
+    return out;
   };
 };
 


### PR DESCRIPTION
### Summary
Fixes #11208

### Occurred changes and/or fixed issues
- EKS reports duplicate node group names in the error banner.
- EKS and AKS mark the tabs of the groups that collide, and EKS marks a group left unnamed.
- Correcting a name now clears the mark.
- Unnamed groups and pools are no longer reported as duplicates of each other.

### Technical notes summary
- Bound to the name input, the message was filtered out of the banner yet still disabled Create. An unreported path is GKE's documented fix.
- EKS deletes the mark rather than setting true, leaving the save payload unchanged.
- Unnamed groups are excluded on EKS and AKS; GKE still pairs both.
- The required message stays inline; no provider banners it. Only its tab marker is new.

### Areas or cases that should be tested
Needs an AWS cloud credential. Every EKS result below was verified with one. There was no Azure credential, so AKS is covered by unit tests only.

```
Cluster Management > Clusters > Create > Amazon EKS
Pick a cloud credential, name the cluster
Node Groups > "+" to add a second group > open its tab
Rename it to group1, the name the first group already has
```

Correct: a red banner reads "Node group names must be unique within a cluster.", the other tab shows an error icon, and Create is disabled. Clearing that name removes the banner but still marks its tab. A unique name clears it all and enables Create.

### Areas which could experience regressions
- On AKS, `_validUnique` joins the `_validation` bag `poolIsValid` reads.
- Registering an existing EKS cluster has no node groups, so it is untouched.

### Screenshot/Video

**Before** - two groups named group1, Create disabled, nothing says why:

https://github.com/user-attachments/assets/c9ae5087-d6c0-4fa7-a765-b8cc1fab3f27

**After** - the same walk, then clearing the name to show an unnamed group's marked tab:

https://github.com/user-attachments/assets/4c1aab93-0bd0-45fb-bb4f-6867a27169e9

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`


