### PR TITLE
Remove SIGINT handler for the dev server

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -620,7 +620,7 @@ module.exports = function(dir, appConfig = {}) {
       config.plugins.push(createEnvVariablesPlugin(routerBasePath, rancherEnv));
       config.plugins.push(new NodePolyfillPlugin({ additionalAliases: ['process'] })); // required from Webpack 5 to polyfill node modules
 
-     // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
+      // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
       config.plugins.push(new CopyWebpackPlugin({ patterns: [{ from: path.join(SHELL_ABS, 'static'), to: '.' }] }));
 
       config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /\/__tests__\// }));

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -298,12 +298,12 @@ const getDevServerConfig = (proxy) => {
 
       const app = devServer.app;
 
-      // Close down quickly in response to CTRL + C
-      process.once('SIGINT', () => {
-        devServer.close();
-        console.log('\n'); // eslint-disable-line no-console
-        process.exit(1);
-      });
+      // CTRL + C is handled by webpack-dev-server itself: its `setupExitSignals`
+      // option (on by default) listens for SIGINT/SIGTERM, shuts the server and
+      // compiler down gracefully, and force-exits on a second CTRL + C. We used
+      // to install our own SIGINT handler here calling `devServer.close()`, but
+      // v5 removed `close()` (and `listen()`) in favour of `stop()`/
+      // `stopCallback()`, so that handler threw a TypeError on exit.
 
       app.use(serverMiddlewares);
 
@@ -620,7 +620,7 @@ module.exports = function(dir, appConfig = {}) {
       config.plugins.push(createEnvVariablesPlugin(routerBasePath, rancherEnv));
       config.plugins.push(new NodePolyfillPlugin({ additionalAliases: ['process'] })); // required from Webpack 5 to polyfill node modules
 
-      // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
+     // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
       config.plugins.push(new CopyWebpackPlugin({ patterns: [{ from: path.join(SHELL_ABS, 'static'), to: '.' }] }));
 
       config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /\/__tests__\// }));


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes issue where if you `CTRL+C` from `yarn dev`, you see:

```
^C/<HOME>/dashboard/shell/vue.config.js:303
        devServer.close();
                  ^

TypeError: devServer.close is not a function
    at process.<anonymous> (/Users/NMACDOUGALL/dev/dev-server-error/shell/vue.config.js:303:19)
    at Object.onceWrapper (node:events:623:26)
    at process.emit (node:events:520:35)
```

This was introduced by a change to the `webpack-dev-server` dependency.

We are now using v5 and not v4.

v5 does provide a `stop` method, but it also takes care of this for us, so we don't need to call it ourselves.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`