### PR TITLE
fix ext compat tests failure around tabs due to change from PR 18859

### DIFF
--- a/cypress/e2e/tests/pages/extensions/extension-compatibility.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extension-compatibility.spec.ts
@@ -249,7 +249,8 @@ describe('Extension Compatibility', { tags: ['@extensionsCompatibility', '@admin
       .should('exist')
       .scrollIntoView()
       .click({ force: true });
-    cy.get(`[data-testid="tab-panel-${ tabName }"]`, MEDIUM_TIMEOUT_OPT).should('be.visible').and('contain', 'THIS IS A DEMO TAB');
+    // New dashboard: tab panels carry data-testid="tab-panel-<name>"; old dashboard: <section id="<name>">.
+    cy.get(`[data-testid="tab-panel-${ tabName }"], section#${ tabName }`, MEDIUM_TIMEOUT_OPT).should('be.visible').and('contain', 'THIS IS A DEMO TAB');
   };
 
   /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes a regression introduced by #18859 that broke the nightly Extension Compatibility Test for Rancher versions 2.10–2.15.

### Occurred changes and/or fixed issues
- Fix `clickDemoTabAndAssert` in `extension-compatibility.spec.ts` so it works against both old and new dashboard versions. The selector now accepts either `[data-testid="tab-panel-<name>"]` (new dashboard, post-#18859) or `section#<name>` (old dashboard, pre-#18859 — still shipped inside Rancher 2.10 through 2.15 release images).

### Technical notes summary
PR #18859 added `data-testid="tab-panel-${name}"` to the `Tab` component's `<section>` panel and updated test selectors to use it. The extension compatibility test (`extension-compatibility.spec.ts`) was updated the same way, but that test runs the current master Cypress code against the **stock dashboards bundled inside older Rancher release images** (2.10–2.15). Those older dashboards still render `<section id="${name}">` without the `data-testid` attribute, so the new selector failed for every version except "Rancher latest" (which uses the nightly Rancher head build, already carrying the updated dashboard).

The fix is a single combined CSS selector: `[data-testid="tab-panel-${tabName}"], section#${tabName}`. Cypress resolves it to whichever element exists in the current page, making the assertion pass on both old and new dashboard versions.

### Areas or cases that should be tested
The nightly Extension Compatibility Test workflow (`Extension Compatibility Test (Cypress)`) is the only meaningful way to verify this — it runs the spec against real Rancher installs at every supported version. A green run across all matrix rows (2.10, 2.11, 2.12, 2.13, 2.14, 2.15, latest) confirms the fix.

Locally you can verify no regression on the current dashboard by running:
```
yarn cy:run --spec cypress/e2e/tests/pages/extensions/extension-compatibility.spec.ts
```

### Areas which could experience regressions
- None. The change is additive — the combined selector is a strict superset of the old one. Any environment where `section#${tabName}` previously matched will still match; environments with the new dashboard will now match on the `data-testid` alternative.

### Screenshot/Video
N/A — the regression was only visible in the nightly CI run, not in the UI itself.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`