### PR TITLE
Automation: Account for Rancher build type and improve AI analysis

### DIFF
--- a/.github/workflows/ci-failure-inspection.yaml
+++ b/.github/workflows/ci-failure-inspection.yaml
@@ -70,6 +70,7 @@ jobs:
           GITHUB_ISSUE_LABELS: area/automation-test-ui,kind/flaky-test
           STATUS_FIELD_ID: ${{ secrets.INSPECTOR_STATUS_FIELD_ID }}
           BACKLOG_OPTION_ID: ${{ secrets.INSPECTOR_BACKLOG_OPTION_ID }}
+          REOPENED_OPTION_ID: ${{ secrets.INSPECTOR_REOPENED_OPTION_ID }}
           INSPECTOR_BUILD_WINDOW: ${{ vars.INSPECTOR_BUILD_WINDOW }}
           INSPECTOR_ANCHOR_DESCRIPTION: ${{ vars.INSPECTOR_ANCHOR_DESCRIPTION }}
           INSPECTOR_VERSION_FILTER: ${{ inputs.version_filter }}

--- a/cypress/jenkins/inspector/README.md
+++ b/cypress/jenkins/inspector/README.md
@@ -29,7 +29,8 @@ Runs automatically **Tue–Sat at 4:00 AM PST** (11:00 UTC) via GitHub Actions, 
 | `JENKINS_BASE_URL` | Repo secret | Jenkins instance base URL |
 | `INSPECTOR_JENKINS_JOB_PATH` | Repo secret | Job path |
 | `INSPECTOR_STATUS_FIELD_ID` | Repo secret | ProjectV2 Status field node ID |
-| `INSPECTOR_BACKLOG_OPTION_ID` | Repo secret | Status option ID for Backlog column |
+| `INSPECTOR_BACKLOG_OPTION_ID` | Repo secret | Status option ID for Backlog column — where newly created issues land |
+| `INSPECTOR_REOPENED_OPTION_ID` | Repo secret | Status option ID for the Reopened column — where regressions land. Falls back to the Backlog column if unset |
 | `UI_QA_SLACK_BOT_TOKEN` | Repo secret | Slack bot token for high-failure alerts |
 | `UI_QA_SLACK_CHANNEL` | Repo secret | Slack channel ID for alerts (e.g. `#team-rancher-ui-qa-jenkins-test-results`) |
 | `UI_QA_SLACK_GROUP_ID` | Repo secret | Slack user group ID for `@ui-qa` mentions (e.g. `S01234ABC`) |

--- a/cypress/jenkins/inspector/src/ai-client.js
+++ b/cypress/jenkins/inspector/src/ai-client.js
@@ -20,13 +20,28 @@ const MODEL = process.env.COPILOT_MODEL || 'gpt-5.6-luna';
 // Truncate stacktrace to first N lines — the LLM only needs root cause frames
 const STACKTRACE_LINES = 20;
 
+// Split across lines for reviewability — sent as one system message.
+const SYSTEM_PROMPT = [
+  'You are a CI failure analyst for a Cypress end-to-end test suite that runs against Rancher.',
+  'Each environment is listed as "<image tag> (<build type>)", where the build type is the Rancher edition: `community` (Docker Hub images) or `prime` (SUSE registry images).',
+  'These editions can differ in bundled chart versions, registry availability, feature gating and branding, so a failure confined to one edition points at a different root cause than one seen on both.',
+  'A failing test does not mean the test is wrong. It may have correctly caught a real defect in the Rancher product or UI.',
+  'Do not assume the test is at fault, and do not propose a change that would make a failing assertion pass if the product behaviour it asserts is genuinely broken.',
+  'Respond with:',
+  '1) A verdict — classify the failure as PRODUCT BUG (Rancher behaves incorrectly), TEST ISSUE (the test is wrong, brittle or outdated), or ENVIRONMENT/INFRASTRUCTURE (setup, registry, network or timing outside the product and the test) — state your confidence and say if the evidence is insufficient to tell.',
+  '2) A brief explanation of why the test failed.',
+  '3) 2-4 likely root causes as bullet points, covering product-side causes as well as test-side ones.',
+  '4) A concrete next step: for a product bug, what to verify and where in the product to look, plus what a bug report should record; for a test or environment issue, a code or config snippet showing the fix where applicable.',
+  'Be specific to the error shown — avoid generic advice.',
+].join(' ');
+
 export class AIClient {
   constructor(token) {
     this.token = token;
   }
 
   async generateFixSuggestions({
-    testTitle, suite, errorSummary, stacktrace
+    testTitle, suite, errorSummary, stacktrace, environments
   }) {
     if (!this.token) {
       console.warn('  Warning: COPILOT_TOKEN not set — skipping AI fix suggestions');
@@ -35,10 +50,12 @@ export class AIClient {
     }
 
     const truncatedStack = stacktrace ? stacktrace.split('\n').slice(0, STACKTRACE_LINES).join('\n') : null;
+    const failedOn = [...new Set((environments || []).map((e) => `${ e.version } (${ e.env })`))].join(', ');
 
     const userPrompt = [
       `Test: ${ testTitle }`,
       `Suite: ${ suite }`,
+      failedOn ? `Failed on: ${ failedOn }` : '',
       ``,
       `Error:`,
       sanitizeText((errorSummary || '').slice(0, 500)),
@@ -58,7 +75,7 @@ export class AIClient {
           input: [
             {
               role:    'system',
-              content: 'You are a CI failure analyst for a Cypress end-to-end test suite. Given a failing test and its error output, provide: 1) A brief explanation of why the test failed. 2) 2-4 likely root causes as bullet points. 3) A concrete code snippet showing a suggested fix where applicable. Be specific to the error shown — avoid generic advice.',
+              content: SYSTEM_PROMPT,
             },
             {
               role:    'user',

--- a/cypress/jenkins/inspector/src/github-client.js
+++ b/cypress/jenkins/inspector/src/github-client.js
@@ -23,6 +23,8 @@ class GitHubClient {
       .split(',').map((l) => l.trim()).filter(Boolean);
     this.statusFieldId = process.env.STATUS_FIELD_ID;
     this.backlogOptionId = process.env.BACKLOG_OPTION_ID;
+    // Optional — reopened regressions land in Backlog alongside new issues until set.
+    this.reopenedOptionId = process.env.REOPENED_OPTION_ID || process.env.BACKLOG_OPTION_ID;
     this.headers = {
       Authorization:  `token ${ token }`,
       Accept:         'application/vnd.github.v3+json',
@@ -178,15 +180,17 @@ class GitHubClient {
   }
 
   _renderEnvironmentsTable(environments) {
-    // Renders a markdown table listing each environment the test failed in
+    // Renders a markdown table listing each environment the test failed in.
+    // `env` is the Rancher build type (community/prime) and `user` the Cypress
+    // tag expression — both come from the Jenkins build description.
     if (!environments?.length) return '';
     const rows = environments.map((e) => {
-      const user = e.user ? `\`${ e.user }\`` : '—';
+      const tags = e.user ? `\`${ e.user }\`` : '—';
 
-      return `| ${ e.version || '—' } | ${ e.env || '—' } | ${ user } |`;
+      return `| ${ e.version || '—' } | ${ e.env || '—' } | ${ tags } |`;
     }).join('\n');
 
-    return `### Failing Environments\n| Version | Environment | User |\n|---------|-------------|------|\n${ rows }`;
+    return `### Failing Environments\n| Version | Build Type | Cypress Tags |\n|---------|------------|--------------|\n${ rows }`;
   }
 
   async reopenIssue(issueNumber, environments = [], failure = {}, aiSuggestions = null) {
@@ -343,10 +347,10 @@ ${ aiSection }
     return nodeIds;
   }
 
-  async addToProject(issueNodeId) {
+  async addToProject(issueNodeId, statusOptionId = this.backlogOptionId) {
     try {
       const projectId = await this._getProjectId();
-      const canSetStatus = !!this.statusFieldId && !!this.backlogOptionId;
+      const canSetStatus = !!this.statusFieldId && !!statusOptionId;
 
       // addProjectV2ItemById is idempotent — if already on board it returns the existing item
       const addRes = await this._projectRequest('POST', '/graphql', {
@@ -365,12 +369,12 @@ ${ aiSection }
       const itemId = addRes.data.addProjectV2ItemById.item.id;
 
       if (!canSetStatus) {
-        console.warn('STATUS_FIELD_ID or BACKLOG_OPTION_ID not set — skipping status assignment');
+        console.warn('STATUS_FIELD_ID or the target status option ID not set — skipping status assignment');
 
         return { projectItemId: itemId };
       }
 
-      // Set status to Backlog
+      // Move the item into its target column
       const updateRes = await this._projectRequest('POST', '/graphql', {
         query: `
           mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
@@ -386,7 +390,7 @@ ${ aiSection }
           projectId,
           itemId,
           fieldId:  this.statusFieldId,
-          optionId: this.backlogOptionId
+          optionId: statusOptionId
         }
       });
 

--- a/cypress/jenkins/inspector/src/inspect.js
+++ b/cypress/jenkins/inspector/src/inspect.js
@@ -104,14 +104,14 @@ async function groupAndCreateIssues(failures, existingIssues) {
         continue;
       }
       if (existing?.state === 'closed') {
-        // Test was fixed but is failing again — reopen and move back to Backlog.
+        // Test was fixed but is failing again — reopen and move to the Reopened column.
         // Always call addToProject on reopen: addProjectV2ItemById is idempotent so it's safe
-        // even if the issue is already on the board, and it ensures the status resets to Backlog.
+        // even if the issue is already on the board, and it ensures the status is reset for triage.
         const aiSuggestions = await aiClient.generateFixSuggestions(failure);
 
         await githubClient.reopenIssue(existing.id, failure.environments, failure, aiSuggestions);
         try {
-          await githubClient.addToProject(existing.nodeId);
+          await githubClient.addToProject(existing.nodeId, githubClient.reopenedOptionId);
         } catch (e) {
           console.error(`  Warning: could not add #${ existing.id } to project: ${ e.message }`);
           boardAssignmentFailures.push({ id: existing.id, url: existing.url });

--- a/cypress/jenkins/inspector/src/jenkins-client.js
+++ b/cypress/jenkins/inspector/src/jenkins-client.js
@@ -150,6 +150,8 @@ export class JenkinsClient {
       const raw = await this.getFailingTests(build);
       const desc = build.description || '';
       const parts = desc.split(' · ').map((p) => p.trim());
+      // "<image tag> · <build type> · <cypress tags>". `env` is the Rancher build
+      // type and `user` the Cypress tag expression, not a user.
       const environment = {
         version: parts[0] || 'unknown',
         env:     parts[1] || 'unknown',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2542

- AI prompt now classifies each failure as PRODUCT BUG / TEST ISSUE / ENVIRONMENT with confidence, rather than assuming the test is at fault, and won't suggest changes that make a failing assertion pass when the product behaviour it asserts is broken.
- Reopened regressions move to the new Reopened column instead of Backlog, via a new `INSPECTOR_REOPENED_OPTION_ID` secret. Falls back to Backlog if unset, so it's backwards compatible.
- The build type each test failed on is now passed to the AI (`Failed on: head (community), v2.13-head (prime)`), which previously never received it.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
